### PR TITLE
build: use '@zk_dtypes' for external repository paths

### DIFF
--- a/bazel/zk_dtypes_deps.bzl
+++ b/bazel/zk_dtypes_deps.bzl
@@ -27,7 +27,7 @@ def zk_dtypes_deps():
         sha256 = "9b2b72d4e8367c0b843fa2bcfa2b08debbe3cee34f7aaa27de55a6cbb3e843db",
         strip_prefix = "abseil-cpp-20250814.0",
         urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20250814.0.tar.gz"],
-        patches = ["//third_party/absl:endian.patch"],
+        patches = ["@zk_dtypes//third_party/absl:endian.patch"],
         patch_args = ["-p1"],
         repo_mapping = {
             "@googletest": "@com_google_googletest",
@@ -51,7 +51,7 @@ def zk_dtypes_deps():
     EIGEN_COMMIT = "4c38131a16803130b66266a912029504f2cf23cd"
     http_archive(
         name = "eigen_archive",
-        build_file = "//third_party/eigen3:eigen_archive.BUILD",
+        build_file = "@zk_dtypes//third_party/eigen3:eigen_archive.BUILD",
         sha256 = "1a432ccbd597ea7b9faa1557b1752328d6adc1a3db8969f6fe793ff704be3bf0",
         strip_prefix = "eigen-{commit}".format(commit = EIGEN_COMMIT),
         urls = ["https://gitlab.com/libeigen/eigen/-/archive/{commit}/eigen-{commit}.tar.gz".format(commit = EIGEN_COMMIT)],


### PR DESCRIPTION
## Description

Adds the **`@zk_dtypes`** repository prefix to the patch path within the Bazel `http_archive` definition. This prefix is necessary for correctly resolving paths (e.g., `endian.patch`) when referencing dependencies from an external repository (e.g., `@com_google_absl`).

## Related Issues/PRs

N/A

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
