### PR TITLE
refactor: remove `ZK_DTYPES_USE_ABSL` macro

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ else:
   PLATFORM_ARGS = ["-std:c++17", "-fvisibility=hidden"]
   DEFINE_PREFIX = "-D"
 
-DEFINES = ["EIGEN_MPL2_ONLY", "ZK_DTYPES_USE_ABSL"]
+DEFINES = ["EIGEN_MPL2_ONLY"]
 COMPILE_ARGS = PLATFORM_ARGS + [f"{DEFINE_PREFIX}{d}" for d in DEFINES]
 
 

--- a/zk_dtypes/BUILD.bazel
+++ b/zk_dtypes/BUILD.bazel
@@ -204,7 +204,6 @@ cc_library(
 cc_library(
     name = "extension_field",
     hdrs = ["include/field/extension_field.h"],
-    defines = ["ZK_DTYPES_USE_ABSL"],
     deps = [
         ":always_false",
         ":extension_field_operations",
@@ -224,10 +223,10 @@ cc_library(
         "include/field/frobenius.h",
         "include/field/quadratic_extension_field_operation.h",
     ],
-    # NOTE(chokobole): The dependency "@com_google_absl//absl/status:statusor" is deliberately omitted.
-    # This prevents ZKIR (which uses this library for code generation) from incurring an unwanted
-    # dependency on Abseil.
-    deps = [":extension_field_operation_traits_forward"],
+    deps = [
+        ":extension_field_operation_traits_forward",
+        "@com_google_absl//absl/status:statusor",
+    ],
 )
 
 cc_library(

--- a/zk_dtypes/include/field/extension_field_operation.h
+++ b/zk_dtypes/include/field/extension_field_operation.h
@@ -20,9 +20,8 @@ limitations under the License.
 #include <cstddef>
 #include <utility>
 
-#if defined(ZK_DTYPES_USE_ABSL)
 #include "absl/status/statusor.h"
-#endif
+
 #include "zk_dtypes/include/field/extension_field_operation_traits_forward.h"
 #include "zk_dtypes/include/field/frobenius.h"
 
@@ -90,12 +89,7 @@ class ExtensionFieldOperation {
   // Since Norm(x) ∈ Fp, we only need Fp inverse (cheaper than Fpⁿ inverse).
   //
   // Note: Child classes may override this with more efficient algorithms.
-#if defined(ZK_DTYPES_USE_ABSL)
-  absl::StatusOr<Derived>
-#else
-  Derived
-#endif
-  Inverse() const {
+  absl::StatusOr<Derived> Inverse() const {
     const Derived& self = static_cast<const Derived&>(*this);
 
     // Compute φ¹(x) · φ²(x) · ... · φⁿ⁻¹(x) using precomputed coefficients.
@@ -112,16 +106,11 @@ class ExtensionFieldOperation {
     Derived norm_ext = self * frob_product;
     BaseField norm = norm_ext.ToBaseField()[0];
 
-#if defined(ZK_DTYPES_USE_ABSL)
     // BaseField inverse (cheaper than extension field inverse)
     absl::StatusOr<BaseField> norm_inv = norm.Inverse();
     if (!norm_inv.ok()) return norm_inv.status();
     // x⁻¹ = φ(x) · ... · φⁿ⁻¹(x) · norm⁻¹
     return frob_product * (*norm_inv);
-#else
-    BaseField norm_inv = norm.Inverse();
-    return frob_product * norm_inv;
-#endif
   }
 
  private:
@@ -134,17 +123,11 @@ class ExtensionFieldOperation {
   }
 
  public:
-#if defined(ZK_DTYPES_USE_ABSL)
   absl::StatusOr<Derived> operator/(const Derived& other) const {
     absl::StatusOr<Derived> inv = other.Inverse();
     if (!inv.ok()) return inv.status();
     return static_cast<const Derived&>(*this) * inv.value();
   }
-#else
-  Derived operator/(const Derived& other) const {
-    return static_cast<const Derived&>(*this) * other.Inverse();
-  }
-#endif
 };
 
 }  // namespace zk_dtypes

--- a/zk_dtypes/include/field/quadratic_extension_field_operation.h
+++ b/zk_dtypes/include/field/quadratic_extension_field_operation.h
@@ -18,9 +18,8 @@ limitations under the License.
 
 #include <array>
 
-#if defined(ZK_DTYPES_USE_ABSL)
 #include "absl/status/statusor.h"
-#endif
+
 #include "zk_dtypes/include/field/extension_field_operation.h"
 
 namespace zk_dtypes {
@@ -95,12 +94,7 @@ class QuadraticExtensionFieldOperation
     return static_cast<const Derived&>(*this).FromBaseFields({y0, y1});
   }
 
-#if defined(ZK_DTYPES_USE_ABSL)
-  absl::StatusOr<Derived>
-#else
-  Derived
-#endif
-  Inverse() const {
+  absl::StatusOr<Derived> Inverse() const {
     std::array<BaseField, 2> x =
         static_cast<const Derived&>(*this).ToBaseField();
     BaseField non_residue = static_cast<const Derived&>(*this).NonResidue();
@@ -112,14 +106,9 @@ class QuadraticExtensionFieldOperation
     // v0 = x[0]² - q * v1
     BaseField v0 = x[0].Square() - v1 * non_residue;
 
-#if defined(ZK_DTYPES_USE_ABSL)
     absl::StatusOr<BaseField> v0_inv = v0.Inverse();
     if (!v0_inv.ok()) return v0_inv.status();
     std::array<BaseField, 2> y{x[0] * (*v0_inv), -x[1] * (*v0_inv)};
-#else
-    BaseField v0_inv = v0.Inverse();
-    std::array<BaseField, 2> y{x[0] * v0_inv, -x[1] * v0_inv};
-#endif
     return static_cast<const Derived&>(*this).FromBaseFields(y);
   }
 };


### PR DESCRIPTION
## Description

Removes the `ZK_DTYPES_USE_ABSL` macro, which was originally introduced to prevent the ZKIR project from introducing an explicit dependency on `abseil-cpp`.

After recent change(#17) allowing ZKIR to depend on the `all_types` target (which transitively pulls in `abseil-cpp`), this macro is no longer necessary and has been removed for cleanup.

## Related Issues/PRs

#17 

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
