### PR TITLE
feat(field): add quartic extension field with Toom-Cook4

### DIFF
--- a/zk_dtypes/BUILD.bazel
+++ b/zk_dtypes/BUILD.bazel
@@ -29,6 +29,7 @@ cc_library(
     hdrs = ["include/all_types.h"],
     deps = [
         ":babybear",
+        ":babybear4",
         ":bn254_fq",
         ":bn254_fq2",
         ":bn254_fr",
@@ -37,6 +38,7 @@ cc_library(
         ":goldilocks",
         ":goldilocks3",
         ":koalabear",
+        ":koalabear4",
         ":mersenne31",
     ],
 )
@@ -187,6 +189,15 @@ cc_library(
 )
 
 cc_library(
+    name = "babybear4",
+    hdrs = ["include/field/babybear/babybear4.h"],
+    deps = [
+        ":babybear",
+        ":extension_field",
+    ],
+)
+
+cc_library(
     name = "big_prime_field",
     hdrs = ["include/field/big_prime_field.h"],
     deps = [
@@ -223,6 +234,7 @@ cc_library(
         "include/field/extension_field_operation.h",
         "include/field/frobenius.h",
         "include/field/quadratic_extension_field_operation.h",
+        "include/field/quartic_extension_field_operation.h",
     ],
     # NOTE(chokobole): The dependency "@com_google_absl//absl/status:statusor" is deliberately omitted.
     # This prevents ZKIR (which uses this library for code generation) from incurring an unwanted
@@ -281,6 +293,15 @@ cc_library(
     name = "koalabear",
     hdrs = ["include/field/koalabear/koalabear.h"],
     deps = [":small_prime_field"],
+)
+
+cc_library(
+    name = "koalabear4",
+    hdrs = ["include/field/koalabear/koalabear4.h"],
+    deps = [
+        ":extension_field",
+        ":koalabear",
+    ],
 )
 
 cc_library(

--- a/zk_dtypes/include/all_types.h
+++ b/zk_dtypes/include/all_types.h
@@ -5,9 +5,11 @@
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/g1.h"
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/g2.h"
 #include "zk_dtypes/include/field/babybear/babybear.h"
+#include "zk_dtypes/include/field/babybear/babybear4.h"
 #include "zk_dtypes/include/field/goldilocks/goldilocks.h"
 #include "zk_dtypes/include/field/goldilocks/goldilocks3.h"
 #include "zk_dtypes/include/field/koalabear/koalabear.h"
+#include "zk_dtypes/include/field/koalabear/koalabear4.h"
 #include "zk_dtypes/include/field/mersenne31/mersenne31.h"
 
 // clang-format off
@@ -34,7 +36,9 @@ WITH_STD(V, ::zk_dtypes::bn254::Fq, Bn254Bf, BN254_BF, bn254_bf)
 // ExtendedField Types
 //===----------------------------------------------------------------------===//
 
-#define ZK_DTYPES_PUBLIC_EXT_FIELD_TYPE_LIST(V) \
+#define ZK_DTYPES_PUBLIC_EXT_FIELD_TYPE_LIST(V)                              \
+WITH_STD(V, ::zk_dtypes::Babybear4, Babybear4, BABYBEAR4, babybear4)         \
+WITH_STD(V, ::zk_dtypes::Koalabear4, Koalabear4, KOALABEAR4, koalabear4)     \
 WITH_STD(V, ::zk_dtypes::Goldilocks3, Goldilocks3, GOLDILLOCKS3, goldilocks3)
 
 #define ZK_DTYPES_ALL_EXT_FIELD_TYPE_LIST(V) \

--- a/zk_dtypes/include/field/babybear/babybear4.h
+++ b/zk_dtypes/include/field/babybear/babybear4.h
@@ -1,0 +1,60 @@
+/* Copyright 2025 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_FIELD_BABYBEAR_BABYBEAR4_H_
+#define ZK_DTYPES_INCLUDE_FIELD_BABYBEAR_BABYBEAR4_H_
+
+#include <stdint.h>
+
+#include "zk_dtypes/include/field/babybear/babybear.h"
+#include "zk_dtypes/include/field/extension_field.h"
+
+namespace zk_dtypes {
+
+// Quartic extension field over Babybear: Babybear⁴ = Babybear[u] / (u⁴ - 11)
+// W = 11 is a quartic non-residue in Babybear field.
+template <typename BaseField>
+class Babybear4BaseConfig {
+ public:
+  constexpr static uint32_t kDegreeOverBaseField = 4;
+  constexpr static BaseField kNonResidue = 11;
+};
+
+class Babybear4StdConfig : public Babybear4BaseConfig<BabybearStd> {
+ public:
+  constexpr static bool kUseMontgomery = false;
+
+  using StdConfig = Babybear4StdConfig;
+
+  using BaseField = BabybearStd;
+  using BasePrimeField = BabybearStd;
+};
+
+class Babybear4Config : public Babybear4BaseConfig<Babybear> {
+ public:
+  constexpr static bool kUseMontgomery = true;
+
+  using StdConfig = Babybear4StdConfig;
+
+  using BaseField = Babybear;
+  using BasePrimeField = Babybear;
+};
+
+using Babybear4 = ExtensionField<Babybear4Config>;
+using Babybear4Std = ExtensionField<Babybear4StdConfig>;
+
+}  // namespace zk_dtypes
+
+#endif  // ZK_DTYPES_INCLUDE_FIELD_BABYBEAR_BABYBEAR4_H_

--- a/zk_dtypes/include/field/extension_field.h
+++ b/zk_dtypes/include/field/extension_field.h
@@ -32,6 +32,7 @@ limitations under the License.
 #include "zk_dtypes/include/field/cubic_extension_field_operation.h"
 #include "zk_dtypes/include/field/finite_field.h"
 #include "zk_dtypes/include/field/quadratic_extension_field_operation.h"
+#include "zk_dtypes/include/field/quartic_extension_field_operation.h"
 #include "zk_dtypes/include/pow.h"
 #include "zk_dtypes/include/str_join.h"
 
@@ -44,8 +45,9 @@ class ExtensionField;
 // Selects the appropriate extension field operation based on degree.
 template <typename Config, size_t Degree>
 struct ExtensionFieldOperationSelector {
-  static_assert(AlwaysFalse<Config>,
-                "Unsupported extension degree. Only 2 and 3 are supported.");
+  static_assert(
+      AlwaysFalse<Config>,
+      "Unsupported extension degree. Only 2, 3, and 4 are supported.");
 };
 
 template <typename Config>
@@ -56,6 +58,11 @@ struct ExtensionFieldOperationSelector<Config, 2> {
 template <typename Config>
 struct ExtensionFieldOperationSelector<Config, 3> {
   using Type = CubicExtensionFieldOperation<ExtensionField<Config>>;
+};
+
+template <typename Config>
+struct ExtensionFieldOperationSelector<Config, 4> {
+  using Type = QuarticExtensionFieldOperation<ExtensionField<Config>>;
 };
 
 template <typename _Config>

--- a/zk_dtypes/include/field/koalabear/koalabear4.h
+++ b/zk_dtypes/include/field/koalabear/koalabear4.h
@@ -1,0 +1,60 @@
+/* Copyright 2025 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_FIELD_KOALABEAR_KOALABEAR4_H_
+#define ZK_DTYPES_INCLUDE_FIELD_KOALABEAR_KOALABEAR4_H_
+
+#include <stdint.h>
+
+#include "zk_dtypes/include/field/extension_field.h"
+#include "zk_dtypes/include/field/koalabear/koalabear.h"
+
+namespace zk_dtypes {
+
+// Quartic extension field over Koalabear: Koalabear⁴ = Koalabear[u] / (u⁴ - 3)
+// W = 3 is a quartic non-residue in Koalabear field.
+template <typename BaseField>
+class Koalabear4BaseConfig {
+ public:
+  constexpr static uint32_t kDegreeOverBaseField = 4;
+  constexpr static BaseField kNonResidue = 3;
+};
+
+class Koalabear4StdConfig : public Koalabear4BaseConfig<KoalabearStd> {
+ public:
+  constexpr static bool kUseMontgomery = false;
+
+  using StdConfig = Koalabear4StdConfig;
+
+  using BaseField = KoalabearStd;
+  using BasePrimeField = KoalabearStd;
+};
+
+class Koalabear4Config : public Koalabear4BaseConfig<Koalabear> {
+ public:
+  constexpr static bool kUseMontgomery = true;
+
+  using StdConfig = Koalabear4StdConfig;
+
+  using BaseField = Koalabear;
+  using BasePrimeField = Koalabear;
+};
+
+using Koalabear4 = ExtensionField<Koalabear4Config>;
+using Koalabear4Std = ExtensionField<Koalabear4StdConfig>;
+
+}  // namespace zk_dtypes
+
+#endif  // ZK_DTYPES_INCLUDE_FIELD_KOALABEAR_KOALABEAR4_H_

--- a/zk_dtypes/include/field/quartic_extension_field_operation.h
+++ b/zk_dtypes/include/field/quartic_extension_field_operation.h
@@ -1,0 +1,208 @@
+/* Copyright 2025 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_FIELD_QUARTIC_EXTENSION_FIELD_OPERATION_H_
+#define ZK_DTYPES_INCLUDE_FIELD_QUARTIC_EXTENSION_FIELD_OPERATION_H_
+
+#include <array>
+
+#include "zk_dtypes/include/field/extension_field_operation.h"
+
+namespace zk_dtypes {
+
+// Quartic extension field operations using Toom-Cook4 algorithm.
+//
+// See https://eprint.iacr.org/2006/471.pdf
+// Devegili OhEig Scott Dahab --- Multiplication and Squaring on
+// Pairing-Friendly Fields.
+//
+// For Fp4 = Fp[u] / (u⁴ - ξ), where x = x₀ + x₁u + x₂u² + x₃u³.
+template <typename Derived>
+class QuarticExtensionFieldOperation : public ExtensionFieldOperation<Derived> {
+ public:
+  using BaseField = typename ExtensionFieldOperationTraits<Derived>::BaseField;
+
+  // Returns the 7x7 inverse Vandermonde matrix V⁻¹ for Toom-Cook4
+  // interpolation.
+  //
+  // For evaluation points t = {0, 1, -1, 2, -2, 3, ∞}, V⁻¹ satisfies c = V⁻¹ *
+  // v where:
+  //   v = {v₀, v₁, v₂, v₃, v₄, v₅, v₆} are evaluation results
+  //   c = {c₀, c₁, c₂, c₃, c₄, c₅, c₆} are polynomial coefficients
+  const std::array<std::array<BaseField, 7>, 7>& GetVandermondeInverseMatrix()
+      const {
+    static const auto matrix = ComputeVandermondeInverseMatrix();
+    return matrix;
+  }
+
+  // Multiplication in Fp4 using Toom-Cook4.
+  //
+  // For x = x₀ + x₁u + x₂u² + x₃u³ and y = y₀ + y₁u + y₂u² + y₃u³:
+  //
+  // Evaluation phase (7 points):
+  //   v₀ = x₀ · y₀
+  //   v₁ = (x₀ + x₁ + x₂ + x₃) · (y₀ + y₁ + y₂ + y₃)
+  //   v₂ = (x₀ - x₁ + x₂ - x₃) · (y₀ - y₁ + y₂ - y₃)
+  //   v₃ = (x₀ + 2x₁ + 4x₂ + 8x₃) · (y₀ + 2y₁ + 4y₂ + 8y₃)
+  //   v₄ = (x₀ - 2x₁ + 4x₂ - 8x₃) · (y₀ - 2y₁ + 4y₂ - 8y₃)
+  //   v₅ = (x₀ + 3x₁ + 9x₂ + 27x₃) · (y₀ + 3y₁ + 9y₂ + 27y₃)
+  //   v₆ = x₃ · y₃
+  //
+  // Then interpolate using Interpolate and reduce using Reduce.
+  Derived operator*(const Derived& other) const {
+    std::array<BaseField, 4> x =
+        static_cast<const Derived&>(*this).ToBaseField();
+    std::array<BaseField, 4> y =
+        static_cast<const Derived&>(other).ToBaseField();
+
+    // Precompute powers of coefficients for evaluation
+    // x[i] * n using Double/Add operations for ZKIR compatibility
+    BaseField x1_2 = x[1].Double();
+    BaseField x1_3 = x1_2 + x[1];
+    BaseField x2_4 = x[2].Double().Double();
+    BaseField x2_9 = x2_4.Double() + x[2];
+    BaseField x3_2 = x[3].Double();
+    BaseField x3_3 = x3_2 + x[3];
+    BaseField x3_8 = x3_2.Double().Double();
+    BaseField x3_27 = x3_8.Double() + x3_8 + x3_3;
+
+    BaseField y1_2 = y[1].Double();
+    BaseField y1_3 = y1_2 + y[1];
+    BaseField y2_4 = y[2].Double().Double();
+    BaseField y2_9 = y2_4.Double() + y[2];
+    BaseField y3_2 = y[3].Double();
+    BaseField y3_3 = y3_2 + y[3];
+    BaseField y3_8 = y3_2.Double().Double();
+    BaseField y3_27 = y3_8.Double() + y3_8 + y3_3;
+
+    // Evaluation phase
+    // v₀ = x₀ · y₀
+    BaseField v0 = x[0] * y[0];
+
+    // v₁ = (x₀ + x₁ + x₂ + x₃) · (y₀ + y₁ + y₂ + y₃)
+    BaseField v1 = (x[0] + x[1] + x[2] + x[3]) * (y[0] + y[1] + y[2] + y[3]);
+
+    // v₂ = (x₀ - x₁ + x₂ - x₃) · (y₀ - y₁ + y₂ - y₃)
+    BaseField v2 = (x[0] - x[1] + x[2] - x[3]) * (y[0] - y[1] + y[2] - y[3]);
+
+    // v₃ = (x₀ + 2x₁ + 4x₂ + 8x₃) · (y₀ + 2y₁ + 4y₂ + 8y₃)
+    BaseField v3 = (x[0] + x1_2 + x2_4 + x3_8) * (y[0] + y1_2 + y2_4 + y3_8);
+
+    // v₄ = (x₀ - 2x₁ + 4x₂ - 8x₃) · (y₀ - 2y₁ + 4y₂ - 8y₃)
+    BaseField v4 = (x[0] - x1_2 + x2_4 - x3_8) * (y[0] - y1_2 + y2_4 - y3_8);
+
+    // v₅ = (x₀ + 3x₁ + 9x₂ + 27x₃) · (y₀ + 3y₁ + 9y₂ + 27y₃)
+    BaseField v5 = (x[0] + x1_3 + x2_9 + x3_27) * (y[0] + y1_3 + y2_9 + y3_27);
+
+    // v₆ = x₃ · y₃
+    BaseField v6 = x[3] * y[3];
+
+    // Interpolation and reduction
+    return this->Reduce(this->Interpolate(
+        std::array<BaseField, 7>{v0, v1, v2, v3, v4, v5, v6}));
+  }
+
+  // Square in Fp4 using Toom-Cook4.
+  //
+  // For x = x₀ + x₁u + x₂u² + x₃u³:
+  //
+  // Evaluation phase (7 points):
+  //   v₀ = x₀²
+  //   v₁ = (x₀ + x₁ + x₂ + x₃)²
+  //   v₂ = (x₀ - x₁ + x₂ - x₃)²
+  //   v₃ = (x₀ + 2x₁ + 4x₂ + 8x₃)²
+  //   v₄ = (x₀ - 2x₁ + 4x₂ - 8x₃)²
+  //   v₅ = (x₀ + 3x₁ + 9x₂ + 27x₃)²
+  //   v₆ = x₃²
+  //
+  // Then interpolate using Interpolate and reduce using Reduce.
+  Derived Square() const {
+    std::array<BaseField, 4> x =
+        static_cast<const Derived&>(*this).ToBaseField();
+
+    // Precompute powers of coefficients for evaluation
+    // x[i] * n using Double/Add operations for ZKIR compatibility
+    BaseField x1_2 = x[1].Double();
+    BaseField x1_3 = x1_2 + x[1];
+    BaseField x2_4 = x[2].Double().Double();
+    BaseField x2_9 = x2_4.Double() + x[2];
+    BaseField x3_2 = x[3].Double();
+    BaseField x3_3 = x3_2 + x[3];
+    BaseField x3_8 = x3_2.Double().Double();
+    BaseField x3_27 = x3_8.Double() + x3_8 + x3_3;
+
+    // Evaluation phase
+    // v₀ = x₀²
+    BaseField v0 = x[0].Square();
+
+    // v₁ = (x₀ + x₁ + x₂ + x₃)²
+    BaseField v1 = (x[0] + x[1] + x[2] + x[3]).Square();
+
+    // v₂ = (x₀ - x₁ + x₂ - x₃)²
+    BaseField v2 = (x[0] - x[1] + x[2] - x[3]).Square();
+
+    // v₃ = (x₀ + 2x₁ + 4x₂ + 8x₃)²
+    BaseField v3 = (x[0] + x1_2 + x2_4 + x3_8).Square();
+
+    // v₄ = (x₀ - 2x₁ + 4x₂ - 8x₃)²
+    BaseField v4 = (x[0] - x1_2 + x2_4 - x3_8).Square();
+
+    // v₅ = (x₀ + 3x₁ + 9x₂ + 27x₃)²
+    BaseField v5 = (x[0] + x1_3 + x2_9 + x3_27).Square();
+
+    // v₆ = x₃²
+    BaseField v6 = x[3].Square();
+
+    // Interpolation and reduction
+    return this->Reduce(this->Interpolate(
+        std::array<BaseField, 7>{v0, v1, v2, v3, v4, v5, v6}));
+  }
+
+ private:
+  // Computes the 7x7 inverse Vandermonde matrix for Toom-Cook4 interpolation.
+  static std::array<std::array<BaseField, 7>, 7>
+  ComputeVandermondeInverseMatrix() {
+#define C(x) BaseField(x)
+#define C2(x, y) (*(BaseField(x) / BaseField(y)))
+
+    // clang-format off
+    // V⁻¹ matrix for Toom-Cook4 interpolation
+    // Row i gives coefficients for cᵢ in terms of v₀...v₆
+    return {{  // NOLINT(readability/braces)
+      // c₀ = 1*v₀ + 0*v₁ + 0*v₂ + 0*v₃ + 0*v₄ + 0*v₅ + 0*v₆
+      {C(1), C(0), C(0), C(0), C(0), C(0), C(0)},
+      // c₁ = -(1/3)v₀ + 1*v₁ - (1/2)v₂ - (1/4)v₃ + (1/20)v₄ + (1/30)v₅ - 12*v₆
+      {C2(-1, 3), C(1), C2(-1, 2), C2(-1, 4), C2(1, 20), C2(1, 30), C(-12)},
+      // c₂ = -(5/4)v₀ + (2/3)v₁ + (2/3)v₂ - (1/24)v₃ - (1/24)v₄ + 0*v₅ + 4*v₆
+      {C2(-5, 4), C2(2, 3), C2(2, 3), C2(-1, 24), C2(-1, 24), C(0), C(4)},
+      // c₃ = (5/12)v₀ - (7/12)v₁ - (1/24)v₂ + (7/24)v₃ - (1/24)v₄ - (1/24)v₅ + 15*v₆
+      {C2(5, 12), C2(-7, 12), C2(-1, 24), C2(7, 24), C2(-1, 24), C2(-1, 24), C(15)},
+      // c₄ = (1/4)v₀ - (1/6)v₁ - (1/6)v₂ + (1/24)v₃ + (1/24)v₄ + 0*v₅ - 5*v₆
+      {C2(1, 4), C2(-1, 6), C2(-1, 6), C2(1, 24), C2(1, 24), C(0), C(-5)},
+      // c₅ = -(1/12)v₀ + (1/12)v₁ + (1/24)v₂ - (1/24)v₃ - (1/120)v₄ + (1/120)v₅ - 3*v₆
+      {C2(-1, 12), C2(1, 12), C2(1, 24), C2(-1, 24), C2(-1, 120), C2(1, 120), C(-3)},
+      // c₆ = 0*v₀ + 0*v₁ + 0*v₂ + 0*v₃ + 0*v₄ + 0*v₅ + 1*v₆
+      {C(0), C(0), C(0), C(0), C(0), C(0), C(1)},
+    }};
+    // clang-format on
+
+#undef C
+#undef C2
+  }
+};
+
+}  // namespace zk_dtypes
+
+#endif  // ZK_DTYPES_INCLUDE_FIELD_QUARTIC_EXTENSION_FIELD_OPERATION_H_

--- a/zk_dtypes/tests/field/extension_field_unittest.cc
+++ b/zk_dtypes/tests/field/extension_field_unittest.cc
@@ -124,16 +124,24 @@ TYPED_TEST(ExtensionFieldTypedTest, Mul) {
 
 TYPED_TEST(ExtensionFieldTypedTest, SquareRoot) {
   using ExtF = TypeParam;
-  if constexpr (std::is_same_v<ExtF, Goldilocks3> ||
-                std::is_same_v<ExtF, Goldilocks3Std>) {
-    GTEST_SKIP() << "Skipping test because Goldilocks3 has large trace value.";
+  // clang-format off
+  if constexpr (std::is_same_v<ExtF, Babybear4> ||
+                std::is_same_v<ExtF, Babybear4Std> ||
+                std::is_same_v<ExtF, Koalabear4> ||
+                std::is_same_v<ExtF, Koalabear4Std>) {
+    GTEST_SKIP() << "SquareRoot is not implemented for quartic extension "
+                    "fields.";
+  } else if constexpr (std::is_same_v<ExtF, Goldilocks3> ||  // NOLINT(readability/braces)
+                       std::is_same_v<ExtF, Goldilocks3Std>) {
+    GTEST_SKIP() << "Skipping because Goldilocks3 has large trace value.";
+  } else {  // NOLINT(readability/braces)
+    // clang-format on
+    ExtF a = ExtF::Random();
+    ExtF a2 = a.Square();
+    absl::StatusOr<ExtF> sqrt = a2.SquareRoot();
+    ASSERT_TRUE(sqrt.ok());
+    EXPECT_TRUE(a == (*sqrt) || a == -(*sqrt));
   }
-
-  ExtF a = ExtF::Random();
-  ExtF a2 = a.Square();
-  absl::StatusOr<ExtF> sqrt = a2.SquareRoot();
-  ASSERT_TRUE(sqrt.ok());
-  EXPECT_TRUE(a == (*sqrt) || a == -(*sqrt));
 }
 
 TYPED_TEST(ExtensionFieldTypedTest, Inverse) {


### PR DESCRIPTION
## Description

Add Fp4 = Fp[u] / (u⁴ - ξ) support using Toom-Cook4 algorithm for efficient multiplication and squaring operations.

- Add `QuarticExtensionFieldOperation` class with Toom-Cook4 multiplication/squaring
- Add `Interpolate` and `Reduce` template functions to `ExtensionFieldOperation`
- Add Babybear4, Koalabear4 extension field configurations

## Related Issues/PRs

N/A

## Checklist

- [x] Branch name follows the [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow the [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] PR conforms to the [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)