### PR TITLE
fix: fix conditions for sqrt algorithm9

### DIFF
--- a/zk_dtypes/include/field/finite_field.h
+++ b/zk_dtypes/include/field/finite_field.h
@@ -40,6 +40,9 @@ class FiniteField {
   constexpr absl::StatusOr<F> SquareRoot() const {
     using BasePrimeField = typename FiniteFieldTraits<F>::BasePrimeField;
 
+    // See
+    // https://fractalyze.gitbook.io/intro/primitives/modular-arithmetic/modular-square-root
+    // for more details.
     constexpr uint64_t p =
         static_cast<uint64_t>(BasePrimeField::Config::kModulus);
     if constexpr (F::ExtensionDegree() % 2 == 1) {

--- a/zk_dtypes/include/field/square_root_algorithms/shanks.h
+++ b/zk_dtypes/include/field/square_root_algorithms/shanks.h
@@ -33,6 +33,9 @@ constexpr absl::StatusOr<F> ComputeShanksSquareRoot(const F& a) {
   //    = b^(p+1) (since b^(p-1) = 1, See https://en.wikipedia.org/wiki/Fermat%27s_little_theorem)
   // a  = b^((p + 1) / 4)
   // clang-format on
+  // See
+  // https://fractalyze.gitbook.io/intro/primitives/modular-arithmetic/modular-square-root/shanks-algorithm
+  // for more details.
   using BasePrimeField = typename FiniteFieldTraits<F>::BasePrimeField;
   static_assert(static_cast<uint64_t>(BasePrimeField::Config::kModulus) % 4 ==
                 3);

--- a/zk_dtypes/include/field/square_root_algorithms/square_root_algorithm9.h
+++ b/zk_dtypes/include/field/square_root_algorithms/square_root_algorithm9.h
@@ -29,6 +29,9 @@ absl::StatusOr<F> ComputeAlgorithm9SquareRoot(const F& a) {
   // Finds x such that x² = a.
   // Assumes the modulus p satisfies p ≡ 3 (mod 4).
   // See: https://eprint.iacr.org/2012/685.pdf (Algorithm 9, page 17)
+  // See
+  // https://fractalyze.gitbook.io/intro/primitives/modular-arithmetic/modular-square-root/generalized-shanks-algorithm-for-quadratic-extension-field
+  // for more details.
   using BasePrimeField = typename FiniteFieldTraits<F>::BasePrimeField;
   static_assert(static_cast<uint64_t>(BasePrimeField::Config::kModulus) % 4 ==
                 3);

--- a/zk_dtypes/include/field/square_root_algorithms/tonelli_shanks.h
+++ b/zk_dtypes/include/field/square_root_algorithms/tonelli_shanks.h
@@ -28,6 +28,9 @@ constexpr absl::StatusOr<F> ComputeTonelliShanksSquareRoot(const F& a) {
   // The modulus p is assumed to have the form p = 2ˢ * T + 1,
   // where s is the 2-adicity and T is the "trace".
   // See: https://eprint.iacr.org/2012/685.pdf (Algorithm 5, page 12)
+  // See
+  // https://fractalyze.gitbook.io/intro/primitives/modular-arithmetic/modular-square-root/tonelli-shanks-algorithm
+  // for more details.
   using BasePrimeField = typename FiniteFieldTraits<F>::BasePrimeField;
   static_assert(BasePrimeField::Config::kHasTwoAdicRootOfUnity);
 


### PR DESCRIPTION
## Description

This corrects the conditional logic for selecting `ComputeAlgorithm9SquareRoot` within `FiniteField::SquareRoot()`.
    
The algorithm is specifically designed for quadratic extension fields (where the extension degree $m=2$) over a base prime field where the prime $p$ satisfies $p \equiv 3 \pmod 4$.
    
If you see the figure 1 in the [reference](https://eprint.iacr.org/2012/685.pdf), it looks like algorithm 9 supports more generalized versions, but it seems not.

## Related Issues/PRs

N/A

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
