### PR TITLE
feat(field): add extension field Python bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ used in Zero Knowledge libraries inspired by
   - `mersenne31`
   - `mersenne31_std`
 
+- Extension Field:
+
+  - `babybear4`
+  - `babybear4_std`
+  - `goldilocks3`
+  - `goldilocks3_std`
+  - `koalabear4`
+  - `koalabear4_std`
+
 - Elliptic curve:
 
   - `bn254_sf`

--- a/zk_dtypes/BUILD.bazel
+++ b/zk_dtypes/BUILD.bazel
@@ -633,3 +633,15 @@ py_test(
         "@pypi//numpy",
     ],
 )
+
+py_test(
+    name = "extension_field_test",
+    srcs = ["tests/extension_field_test.py"],
+    main = "tests/extension_field_test.py",
+    deps = [
+        ":test_utils",
+        ":zk_dtypes_py",
+        "@pypi//absl_py",
+        "@pypi//numpy",
+    ],
+)

--- a/zk_dtypes/__init__.py
+++ b/zk_dtypes/__init__.py
@@ -35,6 +35,13 @@ __all__ = [
     # Big prime field types
     "bn254_sf",
     "bn254_sf_std",
+    # Extension field types
+    "babybear4",
+    "babybear4_std",
+    "koalabear4",
+    "koalabear4_std",
+    "goldilocks3",
+    "goldilocks3_std",
     # Elliptic curve types
     "bn254_g1_affine",
     "bn254_g1_affine_std",
@@ -68,6 +75,12 @@ from zk_dtypes._zk_dtypes_ext import mersenne31
 from zk_dtypes._zk_dtypes_ext import mersenne31_std
 from zk_dtypes._zk_dtypes_ext import bn254_sf
 from zk_dtypes._zk_dtypes_ext import bn254_sf_std
+from zk_dtypes._zk_dtypes_ext import babybear4
+from zk_dtypes._zk_dtypes_ext import babybear4_std
+from zk_dtypes._zk_dtypes_ext import koalabear4
+from zk_dtypes._zk_dtypes_ext import koalabear4_std
+from zk_dtypes._zk_dtypes_ext import goldilocks3
+from zk_dtypes._zk_dtypes_ext import goldilocks3_std
 from zk_dtypes._zk_dtypes_ext import bn254_g1_affine
 from zk_dtypes._zk_dtypes_ext import bn254_g1_affine_std
 from zk_dtypes._zk_dtypes_ext import bn254_g1_jacobian
@@ -97,6 +110,12 @@ mersenne31: Type[np.generic]
 mersenne31_std: Type[np.generic]
 bn254_sf: Type[np.generic]
 bn254_sf_std: Type[np.generic]
+babybear4: Type[np.generic]
+babybear4_std: Type[np.generic]
+koalabear4: Type[np.generic]
+koalabear4_std: Type[np.generic]
+goldilocks3: Type[np.generic]
+goldilocks3_std: Type[np.generic]
 bn254_g1_affine: Type[np.generic]
 bn254_g1_affine_std: Type[np.generic]
 bn254_g1_jacobian: Type[np.generic]

--- a/zk_dtypes/_src/dtypes.cc
+++ b/zk_dtypes/_src/dtypes.cc
@@ -236,6 +236,90 @@ struct TypeDescriptor<bn254::FrStd> : FieldTypeDescriptor<bn254::FrStd> {
 };
 
 template <>
+struct TypeDescriptor<Babybear4> : FieldTypeDescriptor<Babybear4> {
+  typedef Babybear4 T;
+  static constexpr bool is_floating = false;
+  static constexpr bool is_integral = false;
+  static constexpr const char* kTypeName = "babybear4";
+  static constexpr const char* kQualifiedTypeName = "zk_dtypes.babybear4";
+  static constexpr const char* kTpDoc =
+      "babybear quartic extension field values on montgomery domain";
+  static constexpr char kNpyDescrKind = 'V';
+  static constexpr char kNpyDescrType = 'd';
+  static constexpr char kNpyDescrByteorder = '=';
+};
+
+template <>
+struct TypeDescriptor<Babybear4Std> : FieldTypeDescriptor<Babybear4Std> {
+  typedef Babybear4Std T;
+  static constexpr bool is_floating = false;
+  static constexpr bool is_integral = false;
+  static constexpr const char* kTypeName = "babybear4_std";
+  static constexpr const char* kQualifiedTypeName = "zk_dtypes.babybear4_std";
+  static constexpr const char* kTpDoc =
+      "babybear quartic extension field values on standard domain";
+  static constexpr char kNpyDescrKind = 'V';
+  static constexpr char kNpyDescrType = 'D';
+  static constexpr char kNpyDescrByteorder = '=';
+};
+
+template <>
+struct TypeDescriptor<Koalabear4> : FieldTypeDescriptor<Koalabear4> {
+  typedef Koalabear4 T;
+  static constexpr bool is_floating = false;
+  static constexpr bool is_integral = false;
+  static constexpr const char* kTypeName = "koalabear4";
+  static constexpr const char* kQualifiedTypeName = "zk_dtypes.koalabear4";
+  static constexpr const char* kTpDoc =
+      "koalabear quartic extension field values on montgomery domain";
+  static constexpr char kNpyDescrKind = 'V';
+  static constexpr char kNpyDescrType = 'e';
+  static constexpr char kNpyDescrByteorder = '=';
+};
+
+template <>
+struct TypeDescriptor<Koalabear4Std> : FieldTypeDescriptor<Koalabear4Std> {
+  typedef Koalabear4Std T;
+  static constexpr bool is_floating = false;
+  static constexpr bool is_integral = false;
+  static constexpr const char* kTypeName = "koalabear4_std";
+  static constexpr const char* kQualifiedTypeName = "zk_dtypes.koalabear4_std";
+  static constexpr const char* kTpDoc =
+      "koalabear quartic extension field values on standard domain";
+  static constexpr char kNpyDescrKind = 'V';
+  static constexpr char kNpyDescrType = 'E';
+  static constexpr char kNpyDescrByteorder = '=';
+};
+
+template <>
+struct TypeDescriptor<Goldilocks3> : FieldTypeDescriptor<Goldilocks3> {
+  typedef Goldilocks3 T;
+  static constexpr bool is_floating = false;
+  static constexpr bool is_integral = false;
+  static constexpr const char* kTypeName = "goldilocks3";
+  static constexpr const char* kQualifiedTypeName = "zk_dtypes.goldilocks3";
+  static constexpr const char* kTpDoc =
+      "goldilocks cubic extension field values on montgomery domain";
+  static constexpr char kNpyDescrKind = 'V';
+  static constexpr char kNpyDescrType = 't';
+  static constexpr char kNpyDescrByteorder = '=';
+};
+
+template <>
+struct TypeDescriptor<Goldilocks3Std> : FieldTypeDescriptor<Goldilocks3Std> {
+  typedef Goldilocks3Std T;
+  static constexpr bool is_floating = false;
+  static constexpr bool is_integral = false;
+  static constexpr const char* kTypeName = "goldilocks3_std";
+  static constexpr const char* kQualifiedTypeName = "zk_dtypes.goldilocks3_std";
+  static constexpr const char* kTpDoc =
+      "goldilocks cubic extension field values on standard domain";
+  static constexpr char kNpyDescrKind = 'V';
+  static constexpr char kNpyDescrType = 'T';
+  static constexpr char kNpyDescrByteorder = '=';
+};
+
+template <>
 struct TypeDescriptor<bn254::G1AffinePoint>
     : EcPointTypeDescriptor<bn254::G1AffinePoint> {
   typedef bn254::G1AffinePoint T;
@@ -495,6 +579,13 @@ bool Initialize() {
   ZK_DTYPES_PUBLIC_PRIME_FIELD_TYPE_LIST(REGISTER_FIELD_DTYPES)
 #undef REGISTER_FIELD_DTYPES
 
+#define REGISTER_EXT_FIELD_DTYPES(ActualType, ...)    \
+  if (!RegisterFieldDtype<ActualType>(numpy.get())) { \
+    return false;                                     \
+  }
+  ZK_DTYPES_PUBLIC_EXT_FIELD_TYPE_LIST(REGISTER_EXT_FIELD_DTYPES)
+#undef REGISTER_EXT_FIELD_DTYPES
+
 #define REGISTER_EC_POINT_DTYPES(ActualType, ...)       \
   if (!RegisterEcPointDtype<ActualType>(numpy.get())) { \
     return false;                                       \
@@ -573,6 +664,7 @@ extern "C" EXPORT_SYMBOL PyObject* PyInit__zk_dtypes_ext() {
     return nullptr;                                                          \
   }
   ZK_DTYPES_PUBLIC_TYPE_LIST(INIT_MODULE_TYPE)
+  ZK_DTYPES_PUBLIC_EXT_FIELD_TYPE_LIST(INIT_MODULE_TYPE)
 #undef INIT_MODULE_TYPE
 
 #ifdef Py_GIL_DISABLED

--- a/zk_dtypes/tests/extension_field_test.py
+++ b/zk_dtypes/tests/extension_field_test.py
@@ -1,0 +1,288 @@
+# Copyright 2025 The zk_dtypes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Test cases for extension field types."""
+
+import copy
+import operator
+import pickle
+import random
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import zk_dtypes
+from multi_thread_utils import multi_threaded
+import numpy as np
+
+babybear4 = zk_dtypes.babybear4
+babybear4_std = zk_dtypes.babybear4_std
+koalabear4 = zk_dtypes.koalabear4
+koalabear4_std = zk_dtypes.koalabear4_std
+goldilocks3 = zk_dtypes.goldilocks3
+goldilocks3_std = zk_dtypes.goldilocks3_std
+
+EXT_FIELD_TYPES = [
+    babybear4,
+    babybear4_std,
+    koalabear4,
+    koalabear4_std,
+    goldilocks3,
+    goldilocks3_std,
+]
+
+
+def make_values(degree):
+  """Create 4 random extension field elements as tuples."""
+  return [tuple(random.sample(range(-100, 100), degree)) for _ in range(4)]
+
+
+VALUES = {
+    babybear4: make_values(4),
+    babybear4_std: make_values(4),
+    koalabear4: make_values(4),
+    koalabear4_std: make_values(4),
+    goldilocks3: make_values(3),
+    goldilocks3_std: make_values(3),
+}
+
+
+def make_array(scalar_type):
+  """Create a numpy array from VALUES by first converting to scalars."""
+  return np.array([scalar_type(v) for v in VALUES[scalar_type]])
+
+
+@multi_threaded(num_workers=3)
+class ExtensionFieldScalarTest(parameterized.TestCase):
+
+  @parameterized.product(scalar_type=EXT_FIELD_TYPES)
+  def testModuleName(self, scalar_type):
+    self.assertEqual(scalar_type.__module__, "zk_dtypes")
+
+  @parameterized.product(scalar_type=EXT_FIELD_TYPES)
+  def testFromTuple(self, scalar_type):
+    for v in VALUES[scalar_type]:
+      x = scalar_type(v)
+      self.assertIsInstance(x, scalar_type)
+
+  @parameterized.product(scalar_type=EXT_FIELD_TYPES)
+  def testFromInt(self, scalar_type):
+    # Integer creates extension field with base field embedding
+    x = scalar_type(42)
+    self.assertIsInstance(x, scalar_type)
+
+  @parameterized.product(scalar_type=EXT_FIELD_TYPES)
+  def testWrongLengthRaisesError(self, scalar_type):
+    for v in VALUES[scalar_type]:
+      wrong_elem = v + (99,)  # one extra element
+      with self.assertRaises(TypeError):
+        scalar_type(wrong_elem)
+
+  @parameterized.product(scalar_type=EXT_FIELD_TYPES)
+  def testStr(self, scalar_type):
+    for v in VALUES[scalar_type]:
+      x = scalar_type(v)
+      s = str(x)
+      self.assertIsInstance(s, str)
+
+  @parameterized.product(scalar_type=EXT_FIELD_TYPES)
+  def testRepr(self, scalar_type):
+    for v in VALUES[scalar_type]:
+      x = scalar_type(v)
+      r = repr(x)
+      self.assertIsInstance(r, str)
+
+  @parameterized.product(scalar_type=EXT_FIELD_TYPES)
+  def testItem(self, scalar_type):
+    for v in VALUES[scalar_type]:
+      x = scalar_type(v)
+      self.assertIsInstance(x.item(), scalar_type)
+
+  @parameterized.product(scalar_type=EXT_FIELD_TYPES)
+  def testIntConversionRaisesError(self, scalar_type):
+    for v in VALUES[scalar_type]:
+      x = scalar_type(v)
+      with self.assertRaises(TypeError):
+        int(x)
+
+  @parameterized.product(
+      scalar_type=EXT_FIELD_TYPES,
+      op=[operator.eq, operator.ne],
+  )
+  def testComparison(self, scalar_type, op):
+    for v in VALUES[scalar_type]:
+      for w in VALUES[scalar_type]:
+        result = op(scalar_type(v), scalar_type(w))
+        self.assertIsInstance(result, np.bool_)
+
+  @parameterized.product(
+      scalar_type=EXT_FIELD_TYPES,
+      op=[operator.lt, operator.le, operator.gt, operator.ge],
+  )
+  def testOrderingRaisesError(self, scalar_type, op):
+    for v in VALUES[scalar_type]:
+      for w in VALUES[scalar_type]:
+        with self.assertRaises(TypeError):
+          op(scalar_type(v), scalar_type(w))
+
+  @parameterized.product(
+      scalar_type=EXT_FIELD_TYPES,
+      op=[operator.neg],
+  )
+  def testUnop(self, scalar_type, op):
+    for v in VALUES[scalar_type]:
+      out = op(scalar_type(v))
+      self.assertIsInstance(out, scalar_type)
+
+  @parameterized.product(
+      scalar_type=EXT_FIELD_TYPES,
+      op=[operator.add, operator.sub, operator.mul],
+  )
+  def testBinop(self, scalar_type, op):
+    for v in VALUES[scalar_type]:
+      for w in VALUES[scalar_type]:
+        out = op(scalar_type(v), scalar_type(w))
+        self.assertIsInstance(out, scalar_type)
+
+  @parameterized.product(scalar_type=EXT_FIELD_TYPES)
+  def testDivop(self, scalar_type):
+    for v in VALUES[scalar_type]:
+      for w in VALUES[scalar_type]:
+        out = scalar_type(v) / scalar_type(w)
+        self.assertIsInstance(out, scalar_type)
+        # (v / w) * w == v
+        self.assertEqual(out * scalar_type(w), scalar_type(v))
+
+  @parameterized.product(scalar_type=EXT_FIELD_TYPES)
+  def testDivByZeroRaisesError(self, scalar_type):
+    for v in VALUES[scalar_type]:
+      with self.assertRaises(ZeroDivisionError):
+        _ = scalar_type(v) / scalar_type(0)
+
+  @parameterized.product(scalar_type=EXT_FIELD_TYPES)
+  def testPowerOp(self, scalar_type):
+    for v in VALUES[scalar_type]:
+      out = scalar_type(v) ** 5
+      self.assertIsInstance(out, scalar_type)
+
+  @parameterized.product(scalar_type=EXT_FIELD_TYPES)
+  def testCastToDtype(self, scalar_type):
+    name = scalar_type.__name__
+    dt = np.dtype(scalar_type)
+    self.assertIs(dt.type, scalar_type)
+    self.assertEqual(dt.name, name)
+    self.assertEqual(repr(dt), f"dtype({name})")
+
+
+@multi_threaded(num_workers=3)
+class ExtensionFieldArrayTest(parameterized.TestCase):
+
+  @parameterized.product(scalar_type=EXT_FIELD_TYPES)
+  def testDtype(self, scalar_type):
+    self.assertEqual(scalar_type, np.dtype(scalar_type))
+
+  @parameterized.product(scalar_type=EXT_FIELD_TYPES)
+  def testHash(self, scalar_type):
+    h = hash(np.dtype(scalar_type))
+    self.assertEqual(h, hash(np.dtype(scalar_type.dtype)))
+    self.assertEqual(h, hash(np.dtype(scalar_type.__name__)))
+
+  @parameterized.product(scalar_type=EXT_FIELD_TYPES)
+  def testDeepCopyDoesNotAlterHash(self, scalar_type):
+    dtype = np.dtype(scalar_type)
+    h = hash(dtype)
+    _ = copy.deepcopy(dtype)
+    self.assertEqual(h, hash(dtype))
+
+  @parameterized.product(scalar_type=EXT_FIELD_TYPES)
+  def testArray(self, scalar_type):
+    x = make_array(scalar_type)
+    self.assertEqual(scalar_type, x.dtype)
+    self.assertEqual(x.shape, (4,))
+    self.assertTrue((x == x).all())  # pylint: disable=comparison-with-itself
+
+  @parameterized.product(scalar_type=EXT_FIELD_TYPES)
+  def test2DArray(self, scalar_type):
+    row = make_array(scalar_type)
+    x = np.array([row, row])
+    self.assertEqual(scalar_type, x.dtype)
+    self.assertEqual(x.shape, (2, 4))
+
+  @parameterized.product(scalar_type=EXT_FIELD_TYPES)
+  def testPickleable(self, scalar_type):
+    x = make_array(scalar_type)
+    serialized = pickle.dumps(x)
+    x_out = pickle.loads(serialized)
+    self.assertEqual(x_out.dtype, x.dtype)
+    self.assertTrue((x_out == x).all())
+
+  @parameterized.product(scalar_type=EXT_FIELD_TYPES)
+  def testIssubdtype(self, scalar_type):
+    self.assertTrue(np.issubdtype(scalar_type, np.generic))
+    self.assertTrue(np.issubdtype(np.dtype(scalar_type), np.generic))
+
+  @parameterized.product(scalar_type=EXT_FIELD_TYPES)
+  def testNonzeroUfunc(self, scalar_type):
+    x = make_array(scalar_type)
+    result = np.nonzero(x)
+    self.assertIsInstance(result, tuple)
+
+  @parameterized.product(
+      scalar_type=EXT_FIELD_TYPES,
+      ufunc=[np.equal, np.not_equal],
+  )
+  def testPredicateUfuncs(self, scalar_type, ufunc):
+    x = make_array(scalar_type)
+    y = make_array(scalar_type)
+    result = ufunc(x, y)
+    self.assertEqual(result.dtype, np.bool_)
+
+  @parameterized.product(
+      scalar_type=EXT_FIELD_TYPES,
+      ufunc=[np.less, np.less_equal, np.greater, np.greater_equal],
+  )
+  def testOrderingUfuncsRaiseError(self, scalar_type, ufunc):
+    x = make_array(scalar_type)
+    y = make_array(scalar_type)
+    with self.assertRaises(TypeError):
+      ufunc(x, y)
+
+  @parameterized.product(
+      scalar_type=EXT_FIELD_TYPES,
+      ufunc=[np.negative],
+  )
+  def testUnaryUfuncs(self, scalar_type, ufunc):
+    x = make_array(scalar_type)
+    result = ufunc(x)
+    self.assertEqual(scalar_type, result.dtype)
+
+  @parameterized.product(
+      scalar_type=EXT_FIELD_TYPES,
+      ufunc=[np.add, np.subtract, np.multiply, np.divide],
+  )
+  def testBinaryUfuncs(self, scalar_type, ufunc):
+    x = make_array(scalar_type)
+    y = make_array(scalar_type)
+    z = ufunc(x, y)
+    self.assertEqual(scalar_type, z.dtype)
+
+  @parameterized.product(scalar_type=EXT_FIELD_TYPES)
+  def testPowerUfunc(self, scalar_type):
+    x = make_array(scalar_type)
+    z = x**5
+    self.assertEqual(scalar_type, z.dtype)
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
## Description

Add NumPy dtype support for extension fields:
- Goldilocks3 / Goldilocks3Std (cubic extension)
- Babybear4 / Babybear4Std (quartic extension)
- Koalabear4 / Koalabear4Std (quartic extension)

Includes:
- Scalar type creation from list/tuple of coefficients
- Arithmetic operations (+, -, *, /, **)
- Equality comparison (==, !=)
- NumPy array support with ufuncs

## Related Issues/PRs

None

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)