### PR TITLE
build: support fast installation using pre-built Bazel outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,38 @@ pip install absl-py pytest
 pytest zk_dtypes/tests
 ```
 
-To build from source, clone the repository and run:
+### Installation from source
+
+To build and install the package from source, run:
 
 ```shell
 pip install .
 ```
+
+#### Installation from prebuilt binary
+
+Use `USE_BAZEL_OUTPUT=1` for a faster installation that uses pre-built Bazel
+artifacts. This is the recommended path for development.
+
+- **On Linux / macOS**
+
+  ```shell
+  # Build the shared library (.so)
+  bazel build //zk_dtypes:_zk_dtypes_ext.so
+
+  # Install using the Bazel output
+  USE_BAZEL_OUTPUT=1 pip install .
+  ```
+
+- **On Windows**
+
+  ```powershell
+  # Build the Python extension (.pyd)
+  bazel build //zk_dtypes:_zk_dtypes_ext.pyd
+
+  # Install using the Bazel output (PowerShell syntax)
+  $env:USE_BAZEL_OUTPUT=1; pip install .
+  ```
 
 ## Example Usage
 


### PR DESCRIPTION
## Description

This PR introduces an alternative installation path for the Python package that bypasses the slow `setuptools.Extension` build process by utilizing existing Bazel build artifacts.

## Related Issues/PRs

N/A

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
