### PR TITLE
fix(build): fix C++17 flag typo for Unix platforms

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,13 +22,15 @@ import subprocess
 from setuptools import Extension
 from setuptools import setup
 
+CPP_STANDARD = "c++17"
+
 if platform.system() == "Windows":
   FILE = "_zk_dtypes_ext.pyd"
-  PLATFORM_ARGS = ["/std:c++17", "/EHsc", "/bigobj"]
+  PLATFORM_ARGS = [f"/std:{CPP_STANDARD}", "/EHsc", "/bigobj"]
   DEFINE_PREFIX = "/D"
 else:
   FILE = "_zk_dtypes_ext.so"
-  PLATFORM_ARGS = ["-std:c++17", "-fvisibility=hidden"]
+  PLATFORM_ARGS = [f"-std={CPP_STANDARD}", "-fvisibility=hidden"]
   DEFINE_PREFIX = "-D"
 
 DEFINES = ["EIGEN_MPL2_ONLY"]


### PR DESCRIPTION
## Description

Fix C++17 compiler flag for Unix platforms: `-std:c++17` → `-std=c++17`

The colon syntax is for Windows MSVC, Unix compilers use equals sign.

## Related Issues/PRs

None

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)