### PR TITLE
feat(field): add IsExtensionField type trait

### DIFF
--- a/zk_dtypes/include/field/extension_field.h
+++ b/zk_dtypes/include/field/extension_field.h
@@ -313,6 +313,19 @@ std::ostream& operator<<(std::ostream& os, const ExtensionField<Config>& ef) {
   return os << ef.ToString();
 }
 
+template <typename T>
+struct IsExtensionFieldImpl {
+  static constexpr bool value = false;
+};
+
+template <typename Config>
+struct IsExtensionFieldImpl<ExtensionField<Config>> {
+  static constexpr bool value = true;
+};
+
+template <typename T>
+constexpr bool IsExtensionField = IsExtensionFieldImpl<T>::value;
+
 }  // namespace zk_dtypes
 
 #endif  // ZK_DTYPES_INCLUDE_FIELD_EXTENSION_FIELD_H_


### PR DESCRIPTION
## Description

Add `IsExtensionField<T>` constexpr bool to detect extension field types at compile time. This is useful for SFINAE and `if constexpr` patterns when handling extension fields differently from prime fields.

## Related Issues/PRs

None

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)