### PR TITLE
refactor(field): merge extension field type list into field type list

### DIFF
--- a/zk_dtypes/_src/dtypes.cc
+++ b/zk_dtypes/_src/dtypes.cc
@@ -576,15 +576,8 @@ bool Initialize() {
   if (!RegisterFieldDtype<ActualType>(numpy.get())) { \
     return false;                                     \
   }
-  ZK_DTYPES_PUBLIC_PRIME_FIELD_TYPE_LIST(REGISTER_FIELD_DTYPES)
+  ZK_DTYPES_PUBLIC_FIELD_TYPE_LIST(REGISTER_FIELD_DTYPES)
 #undef REGISTER_FIELD_DTYPES
-
-#define REGISTER_EXT_FIELD_DTYPES(ActualType, ...)    \
-  if (!RegisterFieldDtype<ActualType>(numpy.get())) { \
-    return false;                                     \
-  }
-  ZK_DTYPES_PUBLIC_EXT_FIELD_TYPE_LIST(REGISTER_EXT_FIELD_DTYPES)
-#undef REGISTER_EXT_FIELD_DTYPES
 
 #define REGISTER_EC_POINT_DTYPES(ActualType, ...)       \
   if (!RegisterEcPointDtype<ActualType>(numpy.get())) { \
@@ -664,7 +657,6 @@ extern "C" EXPORT_SYMBOL PyObject* PyInit__zk_dtypes_ext() {
     return nullptr;                                                          \
   }
   ZK_DTYPES_PUBLIC_TYPE_LIST(INIT_MODULE_TYPE)
-  ZK_DTYPES_PUBLIC_EXT_FIELD_TYPE_LIST(INIT_MODULE_TYPE)
 #undef INIT_MODULE_TYPE
 
 #ifdef Py_GIL_DISABLED

--- a/zk_dtypes/include/all_types.h
+++ b/zk_dtypes/include/all_types.h
@@ -49,12 +49,13 @@ WITH_STD(V, ::zk_dtypes::bn254::Fq2, Bn254Bf2, BN254_BF2, bn254_bf2)
 // Field Types
 //===----------------------------------------------------------------------===//
 
-// TODO(chokobole): Add `ZK_DTYPES_PUBLIC_EXT_FIELD_TYPE_LIST()`
 #define ZK_DTYPES_PUBLIC_FIELD_TYPE_LIST(V) \
-ZK_DTYPES_PUBLIC_PRIME_FIELD_TYPE_LIST(V)
+ZK_DTYPES_PUBLIC_PRIME_FIELD_TYPE_LIST(V)   \
+ZK_DTYPES_PUBLIC_EXT_FIELD_TYPE_LIST(V)
 
 #define ZK_DTYPES_ALL_FIELD_TYPE_LIST(V) \
-ZK_DTYPES_PUBLIC_FIELD_TYPE_LIST(V)
+ZK_DTYPES_ALL_PRIME_FIELD_TYPE_LIST(V)   \
+ZK_DTYPES_ALL_EXT_FIELD_TYPE_LIST(V)
 
 //===----------------------------------------------------------------------===//
 // ScalarField Types
@@ -163,14 +164,12 @@ ZK_DTYPES_PUBLIC_EC_POINT_TYPE_LIST(V)
 // All Types
 //===----------------------------------------------------------------------===//
 
-// TODO(chokobole): Change `ZK_DTYPES_PUBLIC_PRIME_FIELD_TYPE_LIST()` to `ZK_DTYPES_PUBLIC_FIELD_TYPE_LIST()`
-#define ZK_DTYPES_PUBLIC_TYPE_LIST(V)     \
-ZK_DTYPES_PUBLIC_PRIME_FIELD_TYPE_LIST(V) \
+#define ZK_DTYPES_PUBLIC_TYPE_LIST(V) \
+ZK_DTYPES_PUBLIC_FIELD_TYPE_LIST(V)   \
 ZK_DTYPES_PUBLIC_EC_POINT_TYPE_LIST(V)
 
-// TODO(chokobole): Change `ZK_DTYPES_ALL_PRIME_FIELD_TYPE_LIST()` to `ZK_DTYPES_ALL_FIELD_TYPE_LIST()`
-#define ZK_DTYPES_ALL_TYPE_LIST(V)     \
-ZK_DTYPES_ALL_PRIME_FIELD_TYPE_LIST(V) \
+#define ZK_DTYPES_ALL_TYPE_LIST(V) \
+ZK_DTYPES_ALL_FIELD_TYPE_LIST(V)   \
 ZK_DTYPES_ALL_EC_POINT_TYPE_LIST(V)
 // clang-format on
 


### PR DESCRIPTION
## Description

Merge extension field type lists into the main field type lists to simplify macro usage.

- Merge `ZK_DTYPES_PUBLIC_EXT_FIELD_TYPE_LIST` into `ZK_DTYPES_PUBLIC_FIELD_TYPE_LIST`
- Merge `ZK_DTYPES_ALL_EXT_FIELD_TYPE_LIST` into `ZK_DTYPES_ALL_FIELD_TYPE_LIST`
- Update `ZK_DTYPES_PUBLIC_TYPE_LIST` and `ZK_DTYPES_ALL_TYPE_LIST` to use the merged field type lists
- Remove redundant `ZK_DTYPES_PUBLIC_EXT_FIELD_TYPE_LIST` calls in `dtypes.cc`
- Resolve 3 TODOs in `all_types.h`

## Related Issues/PRs

- https://github.com/fractalyze/zkx/pull/157

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline