### PR TITLE
feat(field): add AsBasePrimeFields() to ExtensionField

### DIFF
--- a/zk_dtypes/BUILD.bazel
+++ b/zk_dtypes/BUILD.bazel
@@ -223,6 +223,7 @@ cc_library(
         ":str_join",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/types:span",
     ],
 )
 

--- a/zk_dtypes/include/field/extension_field.h
+++ b/zk_dtypes/include/field/extension_field.h
@@ -27,6 +27,7 @@ limitations under the License.
 
 #include "absl/log/check.h"
 #include "absl/strings/substitute.h"
+#include "absl/types/span.h"
 
 #include "zk_dtypes/include/always_false.h"
 #include "zk_dtypes/include/big_int.h"
@@ -176,6 +177,17 @@ class ExtensionField : public FiniteField<ExtensionField<_Config>>,
 
   constexpr const std::array<BaseField, N>& values() const { return values_; }
   constexpr std::array<BaseField, N>& values() { return values_; }
+
+  constexpr absl::Span<const BasePrimeField> AsBasePrimeFields() const {
+    return absl::Span<const BasePrimeField>(
+        reinterpret_cast<const BasePrimeField*>(values_.data()),
+        ExtensionDegree());
+  }
+
+  constexpr absl::Span<BasePrimeField> AsBasePrimeFields() {
+    return absl::Span<BasePrimeField>(
+        reinterpret_cast<BasePrimeField*>(values_.data()), ExtensionDegree());
+  }
 
   constexpr bool IsZero() const {
     for (size_t i = 0; i < std::size(values_); ++i) {

--- a/zk_dtypes/tests/field/extension_field_unittest.cc
+++ b/zk_dtypes/tests/field/extension_field_unittest.cc
@@ -229,5 +229,25 @@ TYPED_TEST(ExtensionFieldTypedTest, MontReduce) {
   }
 }
 
+TYPED_TEST(ExtensionFieldTypedTest, AsBasePrimeFields) {
+  using ExtF = TypeParam;
+  using BasePrimeField = typename ExtF::BasePrimeField;
+
+  ExtF a = ExtF::Random();
+  absl::Span<const BasePrimeField> span = a.AsBasePrimeFields();
+
+  // Test that AsBasePrimeFields() returns the correct size.
+  EXPECT_EQ(span.size(), ExtF::ExtensionDegree());
+
+  // Test that span points to actual internal data.
+  size_t idx = 0;
+  for (const auto& base_field : a.values()) {
+    if constexpr (std::is_same_v<typename ExtF::BaseField, BasePrimeField>) {
+      EXPECT_EQ(span[idx], base_field);
+      ++idx;
+    }
+  }
+}
+
 }  // namespace
 }  // namespace zk_dtypes


### PR DESCRIPTION
## Description

Add `AsBasePrimeFields()` method to ExtensionField class that returns `absl::Span<BasePrimeField>` for iterating over base prime field elements. This is useful for operations that need to work with individual prime field components.

## Related Issues/PRs

- fractalyze/zkx#157

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)