### PR TITLE
chore: exclude ipynb from clang-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,7 @@ repos:
     hooks:
       - id: clang-format
         args: ["--style=file"]
+        exclude: '\.ipynb$'
 
   # Starlark
   - repo: https://github.com/keith/pre-commit-buildifier


### PR DESCRIPTION
## Description

Exclude `.ipynb` files from `clang-format` hook to prevent formatting issues with Jupyter notebooks.

## Related Issues/PRs

- #40

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)