### PR TITLE
refactor(field): extract VandermondeMatrix and FrobeniusCoeffs as mixin classes

### DIFF
--- a/zk_dtypes/BUILD.bazel
+++ b/zk_dtypes/BUILD.bazel
@@ -220,12 +220,22 @@ cc_library(
         ":always_false",
         ":extension_field_operations",
         ":finite_field",
+        ":frobenius_coeffs",
         ":pow",
         ":str_join",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:span",
+    ],
+)
+
+cc_library(
+    name = "frobenius_coeffs",
+    hdrs = ["include/field/frobenius_coeffs.h"],
+    deps = [
+        ":big_int",
+        ":pow",
     ],
 )
 
@@ -242,8 +252,14 @@ cc_library(
         ":frobenius_operation",
         ":karatsuba_operation",
         ":toom_cook_operation",
+        ":vandermonde_matrix",
         "@com_google_absl//absl/status:statusor",
     ],
+)
+
+cc_library(
+    name = "vandermonde_matrix",
+    hdrs = ["include/field/vandermonde_matrix.h"],
 )
 
 cc_library(

--- a/zk_dtypes/include/field/frobenius_coeffs.h
+++ b/zk_dtypes/include/field/frobenius_coeffs.h
@@ -1,0 +1,79 @@
+/* Copyright 2025 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_FIELD_FROBENIUS_COEFFS_H_
+#define ZK_DTYPES_INCLUDE_FIELD_FROBENIUS_COEFFS_H_
+
+#include <array>
+#include <cstddef>
+
+#include "zk_dtypes/include/big_int.h"
+#include "zk_dtypes/include/pow.h"
+
+namespace zk_dtypes {
+
+// Mixin providing precomputed Frobenius coefficients for extension fields.
+//
+// Returns precomputed Frobenius coefficients for all φᴱ (E = 1, ..., N - 1):
+// coeffs[E - 1][i - 1] = ξ^(i * (pᴱ - 1) / n) for i = 1, ..., N - 1.
+//
+// For Fp3: a = (a₁, a₂, a₃, a₄) where
+//   a₁ = ξ^((p - 1) / 3), a₂ = ξ^(2(p - 1) / 3)
+//   a₃ = ξ^((p² - 1) / 3), a₄ = ξ^(2(p² - 1) / 3)
+// - φ¹(x) = (x₀, x₁ * a₁, x₂ * a₂)
+// - φ²(x) = (x₀, x₁ * a₃, x₂ * a₄)
+//
+// See:
+// https://fractalyze.gitbook.io/intro/primitives/abstract-algebra/extension-field/inversion#id-2.2.-optimized-computation-when
+//
+template <typename Config>
+class FrobeniusCoeffs {
+ public:
+  using BaseField = typename Config::BaseField;
+  using BasePrimeField = typename Config::BasePrimeField;
+  constexpr static size_t N = Config::kDegreeOverBaseField;
+
+  static const std::array<std::array<BaseField, N - 1>, N - 1>&
+  GetFrobeniusCoeffs() {
+    static const auto coeffs = []() {
+      // Use larger BigInt to avoid overflow when computing pᵉ.
+      constexpr size_t kLimbNums = BasePrimeField::kLimbNums * N;
+      BigInt<kLimbNums> p(BasePrimeField::Config::kModulus);
+      BaseField nr = Config::kNonResidue;
+
+      std::array<std::array<BaseField, N - 1>, N - 1> result{};
+      // p_e = pᵉ, computed iteratively
+      BigInt<kLimbNums> p_e = p;
+      BigInt<kLimbNums> n_big(N);
+      for (size_t e = 1; e < N; ++e) {
+        // qₑ = (pᵉ - 1) / n
+        auto q_e = ((p_e - 1) / n_big).value();
+        BaseField nr_q_e = zk_dtypes::Pow(nr, q_e);
+
+        result[e - 1][0] = nr_q_e;
+        for (size_t i = 1; i < N - 1; ++i) {
+          result[e - 1][i] = result[e - 1][i - 1] * nr_q_e;
+        }
+        p_e = p_e * p;
+      }
+      return result;
+    }();
+    return coeffs;
+  }
+};
+
+}  // namespace zk_dtypes
+
+#endif  // ZK_DTYPES_INCLUDE_FIELD_FROBENIUS_COEFFS_H_

--- a/zk_dtypes/include/field/vandermonde_matrix.h
+++ b/zk_dtypes/include/field/vandermonde_matrix.h
@@ -1,0 +1,78 @@
+/* Copyright 2025 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_FIELD_VANDERMONDE_MATRIX_H_
+#define ZK_DTYPES_INCLUDE_FIELD_VANDERMONDE_MATRIX_H_
+
+#include <array>
+#include <cstddef>
+#include <type_traits>
+
+namespace zk_dtypes {
+
+// Mixin providing Vandermonde inverse matrix for Toom-Cook multiplication.
+//
+// Template parameter N is the extension degree (e.g., N=4 for Toom-Cook4).
+// Returns the (2N - 1) x (2N - 1) inverse Vandermonde matrix V⁻¹.
+//
+// For N=4, evaluation points t = {0, 1, -1, 2, -2, 3, ∞}, V⁻¹ satisfies
+// c = V⁻¹ * v where:
+//   v = {v₀, v₁, v₂, v₃, v₄, v₅, v₆} are evaluation results
+//   c = {c₀, c₁, c₂, c₃, c₄, c₅, c₆} are polynomial coefficients
+//
+// TODO(junbeomlee): Share this matrix with zkir by adding CreateConstant() and
+// CreateRationalConstant() methods to the Derived class interface.
+template <typename F, size_t N>
+class VandermondeMatrix {
+ public:
+  static constexpr size_t kNumEvaluation = 2 * N - 1;
+
+  template <size_t N2 = N, std::enable_if_t<N2 == 4>* = nullptr>
+  const std::array<std::array<F, kNumEvaluation>, kNumEvaluation>&
+  GetVandermondeInverseMatrix() const {
+    static const auto matrix = []() {
+#define C(x) F(x)
+#define C2(x, y) (*(F(x) / F(y)))
+      // clang-format off
+      // V⁻¹ matrix for Toom-Cook4 interpolation
+      // Row i gives coefficients for cᵢ in terms of v₀...v₆
+      return std::array<std::array<F, kNumEvaluation>, kNumEvaluation>{{  // NOLINT(readability/braces)
+        // c₀ = 1*v₀ + 0*v₁ + 0*v₂ + 0*v₃ + 0*v₄ + 0*v₅ + 0*v₆
+        {C(1), C(0), C(0), C(0), C(0), C(0), C(0)},
+        // c₁ = -(1/3)v₀ + 1*v₁ - (1/2)v₂ - (1/4)v₃ + (1/20)v₄ + (1/30)v₅ - 12*v₆
+        {C2(-1, 3), C(1), C2(-1, 2), C2(-1, 4), C2(1, 20), C2(1, 30), C(-12)},
+        // c₂ = -(5/4)v₀ + (2/3)v₁ + (2/3)v₂ - (1/24)v₃ - (1/24)v₄ + 0*v₅ + 4*v₆
+        {C2(-5, 4), C2(2, 3), C2(2, 3), C2(-1, 24), C2(-1, 24), C(0), C(4)},
+        // c₃ = (5/12)v₀ - (7/12)v₁ - (1/24)v₂ + (7/24)v₃ - (1/24)v₄ - (1/24)v₅ + 15*v₆
+        {C2(5, 12), C2(-7, 12), C2(-1, 24), C2(7, 24), C2(-1, 24), C2(-1, 24), C(15)},
+        // c₄ = (1/4)v₀ - (1/6)v₁ - (1/6)v₂ + (1/24)v₃ + (1/24)v₄ + 0*v₅ - 5*v₆
+        {C2(1, 4), C2(-1, 6), C2(-1, 6), C2(1, 24), C2(1, 24), C(0), C(-5)},
+        // c₅ = -(1/12)v₀ + (1/12)v₁ + (1/24)v₂ - (1/24)v₃ - (1/120)v₄ + (1/120)v₅ - 3*v₆
+        {C2(-1, 12), C2(1, 12), C2(1, 24), C2(-1, 24), C2(-1, 120), C2(1, 120), C(-3)},
+        // c₆ = 0*v₀ + 0*v₁ + 0*v₂ + 0*v₃ + 0*v₄ + 0*v₅ + 1*v₆
+        {C(0), C(0), C(0), C(0), C(0), C(0), C(1)},
+      }};
+      // clang-format on
+
+#undef C
+#undef C2
+    }();
+    return matrix;
+  }
+};
+
+}  // namespace zk_dtypes
+
+#endif  // ZK_DTYPES_INCLUDE_FIELD_VANDERMONDE_MATRIX_H_


### PR DESCRIPTION
## Description

Extract `GetVandermondeInverseMatrix` and `GetFrobeniusCoeffs` into separate mixin classes to resolve name hiding issues in zkir's `ExtensionFieldCodeGen`.

### Changes

- Add `VandermondeMatrix<F, N>` mixin for Toom-Cook interpolation matrix
- Add `FrobeniusCoeffs<Config>` mixin for Frobenius coefficients
- `ExtensionField` inherits `FrobeniusCoeffs`
- `QuarticExtensionFieldOperation` inherits `VandermondeMatrix<BaseField, 4>`

## Related Issues/PRs

- Related to zkir TODO: Remove `using` declarations in `ExtensionFieldCodeGen.h`

## Checklist

- [x] Branch name follows conventions
- [x] Commit messages follow conventions
- [x] Reviewed PR guidelines