### PR TITLE
refactor: introduce `kStorageBits` to distinguish from `kModulusBits`

### DIFF
--- a/zk_dtypes/include/elliptic_curve/bn/bn254/fq.h
+++ b/zk_dtypes/include/elliptic_curve/bn/bn254/fq.h
@@ -21,6 +21,7 @@ limitations under the License.
 namespace zk_dtypes::bn254 {
 
 struct FqBaseConfig {
+  constexpr static size_t kStorageBits = 256;
   constexpr static size_t kModulusBits = 254;
   constexpr static BigInt<4> kModulus = {
       UINT64_C(4332616871279656263),

--- a/zk_dtypes/include/elliptic_curve/bn/bn254/fr.h
+++ b/zk_dtypes/include/elliptic_curve/bn/bn254/fr.h
@@ -21,6 +21,7 @@ limitations under the License.
 namespace zk_dtypes::bn254 {
 
 struct FrBaseConfig {
+  constexpr static size_t kStorageBits = 256;
   constexpr static size_t kModulusBits = 254;
   constexpr static BigInt<4> kModulus = {
       UINT64_C(4891460686036598785),

--- a/zk_dtypes/include/elliptic_curve/short_weierstrass/test/sw_curve_config.h
+++ b/zk_dtypes/include/elliptic_curve/short_weierstrass/test/sw_curve_config.h
@@ -27,6 +27,7 @@ namespace zk_dtypes::test {
 
 struct PrimeFieldBaseConfig {
  public:
+  constexpr static size_t kStorageBits = 8;
   constexpr static size_t kModulusBits = 4;
   constexpr static uint8_t kModulus = 7;
 

--- a/zk_dtypes/include/field/babybear/babybear.h
+++ b/zk_dtypes/include/field/babybear/babybear.h
@@ -23,6 +23,7 @@ limitations under the License.
 namespace zk_dtypes {
 
 struct BabybearBaseConfig {
+  constexpr static size_t kStorageBits = 32;
   constexpr static size_t kModulusBits = 31;
   constexpr static uint32_t kModulus = 2013265921;
 

--- a/zk_dtypes/include/field/big_prime_field.h
+++ b/zk_dtypes/include/field/big_prime_field.h
@@ -38,15 +38,18 @@ namespace zk_dtypes {
 // If Config::kUseMontgomery is true, the operations are performed on montgomery
 // domain. Otherwise, the operations are performed on standard domain.
 template <typename _Config>
-class PrimeField<_Config, std::enable_if_t<(_Config::kModulusBits > 64)>>
+class PrimeField<_Config, std::enable_if_t<(_Config::kStorageBits > 64)>>
     : public FiniteField<PrimeField<_Config>> {
  public:
   constexpr static bool kUseMontgomery = _Config::kUseMontgomery;
-  constexpr static size_t kModulusBits = _Config::kModulusBits;
-  constexpr static size_t kLimbNums = (kModulusBits + 63) / 64;
+  constexpr static size_t kStorageBits = _Config::kStorageBits;
+  constexpr static size_t kLimbNums = (kStorageBits + 63) / 64;
   constexpr static size_t N = kLimbNums;
   constexpr static size_t kBitWidth = BigInt<N>::kBitWidth;
   constexpr static size_t kByteWidth = BigInt<N>::kByteWidth;
+
+  static_assert(kStorageBits == kBitWidth,
+                "kStorageBits must be equal to kBitWidth");
 
   using Config = _Config;
   using StdType = PrimeField<typename Config::StdConfig>;

--- a/zk_dtypes/include/field/goldilocks/goldilocks.h
+++ b/zk_dtypes/include/field/goldilocks/goldilocks.h
@@ -23,6 +23,7 @@ limitations under the License.
 namespace zk_dtypes {
 
 struct GoldilocksBaseConfig {
+  constexpr static size_t kStorageBits = 64;
   constexpr static size_t kModulusBits = 64;
   constexpr static uint64_t kModulus = UINT64_C(18446744069414584321);
 

--- a/zk_dtypes/include/field/koalabear/koalabear.h
+++ b/zk_dtypes/include/field/koalabear/koalabear.h
@@ -23,6 +23,7 @@ limitations under the License.
 namespace zk_dtypes {
 
 struct KoalabearBaseConfig {
+  constexpr static size_t kStorageBits = 32;
   constexpr static size_t kModulusBits = 31;
   constexpr static uint32_t kModulus = 2130706433;
 

--- a/zk_dtypes/include/field/mersenne31/mersenne31.h
+++ b/zk_dtypes/include/field/mersenne31/mersenne31.h
@@ -23,6 +23,7 @@ limitations under the License.
 namespace zk_dtypes {
 
 struct Mersenne31BaseConfig {
+  constexpr static size_t kStorageBits = 32;
   constexpr static size_t kModulusBits = 31;
   constexpr static uint32_t kModulus = 2147483647;
 

--- a/zk_dtypes/include/field/small_prime_field.h
+++ b/zk_dtypes/include/field/small_prime_field.h
@@ -41,23 +41,26 @@ namespace zk_dtypes {
 // If Config::kUseMontgomery is true, the operations are performed on montgomery
 // domain. Otherwise, the operations are performed on standard domain.
 template <typename _Config>
-class PrimeField<_Config, std::enable_if_t<(_Config::kModulusBits <= 64)>>
+class PrimeField<_Config, std::enable_if_t<(_Config::kStorageBits <= 64)>>
     : public FiniteField<PrimeField<_Config>> {
  public:
   using UnderlyingType = std::conditional_t<
-      _Config::kModulusBits <= 32,
+      _Config::kStorageBits <= 32,
       std::conditional_t<
-          _Config::kModulusBits <= 16,
-          std::conditional_t<_Config::kModulusBits <= 8, uint8_t, uint16_t>,
+          _Config::kStorageBits <= 16,
+          std::conditional_t<_Config::kStorageBits <= 8, uint8_t, uint16_t>,
           uint32_t>,
       uint64_t>;
 
   constexpr static bool kUseMontgomery = _Config::kUseMontgomery;
-  constexpr static size_t kModulusBits = _Config::kModulusBits;
+  constexpr static size_t kStorageBits = _Config::kStorageBits;
   constexpr static size_t kLimbNums = 1;
   constexpr static size_t N = kLimbNums;
   constexpr static size_t kBitWidth = 8 * sizeof(UnderlyingType);
   constexpr static size_t kByteWidth = sizeof(UnderlyingType);
+
+  static_assert(kStorageBits == kBitWidth,
+                "kStorageBits must be equal to kBitWidth");
 
   using Config = _Config;
   using StdType = PrimeField<typename Config::StdConfig>;

--- a/zk_dtypes/tests/field/prime_field_unittest.cc
+++ b/zk_dtypes/tests/field/prime_field_unittest.cc
@@ -64,7 +64,7 @@ TYPED_TEST(PrimeFieldTypedTest, Operations) {
   using UnderlyingType = typename F::UnderlyingType;
 
   UnderlyingType a_value, b_value;
-  if constexpr (F::Config::kModulusBits <= 64) {
+  if constexpr (F::Config::kStorageBits <= 64) {
     a_value = Uniform(UnderlyingType{0}, F::Config::kModulus);
     b_value = Uniform(UnderlyingType{0}, F::Config::kModulus);
   } else {
@@ -79,7 +79,7 @@ TYPED_TEST(PrimeFieldTypedTest, Operations) {
   EXPECT_EQ(a < b, a_value < b_value);
   EXPECT_EQ(a == b, a_value == b_value);
   if constexpr (F::HasSpareBit()) {
-    if constexpr (F::Config::kModulusBits <= 64) {
+    if constexpr (F::Config::kStorageBits <= 64) {
       EXPECT_EQ(a + b, F((a_value + b_value) % F::Config::kModulus));
       EXPECT_EQ(a.Double(), F((a_value + a_value) % F::Config::kModulus));
       if (a >= b) {


### PR DESCRIPTION
## Description

Initially, this task was conceived as a simple renaming of `kModulusBits` to `kStorageBits` (as reflected in the branch name `refactor/rename-modulus-bits-to-storage-bits`). However, during implementation, it became clear that these two constants serve distinct purposes and should coexist to support more complex field types, such as **Binary Fields**.

This PR introduces **`kStorageBits`** to explicitly define the physical memory footprint, while preserving **`kModulusBits`** to represent the mathematical bit length required for identity and alias matching.

* **`kModulusBits` (Retained)**: Strictly represents the bit length of the prime modulus. This is essential for ZKIR's `KnownModulus` utility to correctly identify fields and match them with specific aliases.
* **`kStorageBits` (New)**: Defines the actual storage requirement (e.g., 8, 16, 32, 64, or 256 bits). This ensures that limb calculations and memory alignments are consistent, even if the modulus doesn't perfectly align with standard storage boundaries (common in binary fields).

### 💡 Note to Reviewers

While the branch name suggests a "rename," the scope has evolved into an **architectural refinement**. This separation provides the necessary flexibility for upcoming features, such as binary field support, where the modulus bit length and storage alignment often diverge.

## Related Issues/PRs

N/A

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
