### PR TITLE
fix(field): use BaseField instead of BigInt in unsigned constructor

### DIFF
--- a/zk_dtypes/include/field/extension_field.h
+++ b/zk_dtypes/include/field/extension_field.h
@@ -142,7 +142,7 @@ class ExtensionField : public FiniteField<ExtensionField<_Config>>,
   }
 
   template <typename T, std::enable_if_t<std::is_unsigned_v<T>>* = nullptr>
-  constexpr ExtensionField(T value) : ExtensionField({BigInt<N>(value)}) {}
+  constexpr ExtensionField(T value) : ExtensionField({BaseField(value)}) {}
 
   constexpr ExtensionField(const BaseField& value) { values_[0] = value; }
 

--- a/zk_dtypes/tests/field/extension_field_unittest.cc
+++ b/zk_dtypes/tests/field/extension_field_unittest.cc
@@ -66,6 +66,20 @@ TYPED_TEST(ExtensionFieldTypedTest, One) {
   EXPECT_FALSE(ExtF::Zero().IsOne());
 }
 
+TYPED_TEST(ExtensionFieldTypedTest, ConstructFromUnsignedInteger) {
+  using ExtF = TypeParam;
+  using BaseField = typename ExtF::BaseField;
+  constexpr size_t kDegree = ExtF::Config::kDegreeOverBaseField;
+
+  ExtF a(uint32_t{3});
+
+  // The first coefficient should be the value, others should be zero.
+  EXPECT_EQ(a[0], BaseField(3));
+  for (size_t i = 1; i < kDegree; ++i) {
+    EXPECT_TRUE(a[i].IsZero());
+  }
+}
+
 TYPED_TEST(ExtensionFieldTypedTest, Add) {
   using ExtF = TypeParam;
   constexpr size_t kDegree = ExtF::Config::kDegreeOverBaseField;


### PR DESCRIPTION
## Description

Fix ExtensionField unsigned constructor to use `BaseField(value)` instead of `BigInt<N>(value)`.

This constructor was never instantiated before because all existing tests used signed integers (e.g., `ExtF(0)`, `ExtF(1)`), which go through the signed constructor. The bug was only discovered when zkx tried to use unsigned integers with extension fields.

The fix aligns with the constructor below it:

```cpp
// Unsigned constructor (this PR)
constexpr ExtensionField(T value) : ExtensionField({BaseField(value)}) {}

// BaseField constructor (existing) - should have same behavior
constexpr ExtensionField(const BaseField& value) { values_[0] = value; }
```

Both should put the scalar value in the first coefficient.

## Related Issues/PRs

- https://github.com/fractalyze/zkx/pull/157

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline