### PR TITLE
build: add Bazel infrastructure for Python wheel packaging

### DIFF
--- a/third_party/py/manylinux_compliance_test.py
+++ b/third_party/py/manylinux_compliance_test.py
@@ -1,0 +1,128 @@
+# Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2025 The zk_dtypes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import argparse
+import contextlib
+import io
+import pathlib
+import platform
+import re
+from auditwheel import main_show
+
+
+def parse_args():
+  """Arguments parser."""
+  parser = argparse.ArgumentParser(
+      description="Helper for manylinux compliance verification",
+      fromfile_prefix_chars="@",
+  )
+  parser.add_argument(
+      "--wheel-path", required=True, help="Path of the wheel, mandatory"
+  )
+  parser.add_argument(
+      "--aarch64-compliance-tag",
+      required=True,
+      help="ManyLinux compliance tag for aarch64",
+  )
+  parser.add_argument(
+      "--x86_64-compliance-tag",
+      required=True,
+      help="ManyLinux compliance tag for x86_64",
+  )
+  parser.add_argument(
+      "--ppc64le-compliance-tag",
+      required=True,
+      help="ManyLinux compliance tag for ppc64le",
+  )
+  return parser.parse_args()
+
+
+def get_auditwheel_output(wheel_path: str) -> str:
+  """Run "auditwheel show" on the wheel and return the output.
+
+  Args:
+    wheel_path: path of the wheel file
+
+  Returns:
+    "auditwheel show" output
+  """
+  stringio = io.StringIO()
+  with contextlib.redirect_stdout(stringio):
+    auditwheel_parser = argparse.ArgumentParser(
+        description="Cross-distro Python wheels."
+    )
+    sub_parsers = auditwheel_parser.add_subparsers(metavar="command", dest="cmd")
+    main_show.configure_parser(sub_parsers)
+    auditwheel_args = argparse.Namespace(
+        WHEEL_FILE=pathlib.Path(wheel_path),
+        DISABLE_ISA_EXT_CHECK=True,
+        verbose=1,
+    )
+
+    main_show.execute(auditwheel_args, auditwheel_parser)
+
+  return stringio.getvalue()
+
+
+def verify_manylinux_compliance(
+    auditwheel_log: str,
+    compliance_tag: str,
+) -> None:
+  """Verify manylinux compliance.
+
+  Args:
+    auditwheel_log: "auditwheel show" execution results
+    compliance_tag: manyLinux compliance tag
+
+  Raises:
+    RuntimeError: if the wheel is not manyLinux compliant.
+  """
+  regex = 'following platform tag:\s+"{}"'.format(compliance_tag)
+  alt_regex = regex.replace("2014", "_2_17")
+  if not (
+      re.search(regex, auditwheel_log) or re.search(alt_regex, auditwheel_log)
+  ):
+    raise RuntimeError(
+        ("The wheel is not compliant with the tag {tag}.\n{result}").format(
+            tag=compliance_tag, result=auditwheel_log
+        )
+    )
+
+
+def test_manylinux_compliance(args):
+  machine_type = platform.uname().machine
+  supported_machine_types = ["x86_64", "aarch64", "ppc64le"]
+  if machine_type not in supported_machine_types:
+    raise RuntimeError(
+        "Unsupported machine type {machine_type}. The supported are:"
+        " {supported_types}".format(
+            machine_type=machine_type, supported_types=supported_machine_types
+        )
+    )
+  compliance_tag = {
+      "x86_64": args.x86_64_compliance_tag,
+      "aarch64": args.aarch64_compliance_tag,
+      "ppc64le": args.ppc64le_compliance_tag,
+  }[machine_type]
+  auditwheel_output = get_auditwheel_output(args.wheel_path)
+  verify_manylinux_compliance(
+      auditwheel_output,
+      compliance_tag,
+  )
+
+
+if __name__ == "__main__":
+  test_manylinux_compliance(parse_args())

--- a/third_party/py/py_import.bzl
+++ b/third_party/py/py_import.bzl
@@ -1,0 +1,93 @@
+# Copyright The OpenXLA Authors.
+# Copyright 2025 The zk_dtypes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+""" Macros to unpack a wheel and use its content as a py_library. """
+
+load("@rules_python//python:defs.bzl", "py_library")
+
+def _unpacked_wheel_impl(ctx):
+    output_dir = ctx.actions.declare_directory(ctx.label.name)
+    wheel = ctx.file.wheel
+    args = ctx.actions.args()
+    args.add("--wheel=%s" % wheel.path)
+    args.add("--output_dir=%s" % output_dir.path)
+    srcs = [wheel]
+    for d in ctx.attr.wheel_deps:
+        for f in d[DefaultInfo].default_runfiles.files.to_list():
+            srcs.append(f)
+            args.add("--wheel_files=%s" % (f.path))
+    for z in ctx.files.zip_deps:
+        srcs.append(z)
+        args.add("--zip_files=%s" % (z.path))
+    args.set_param_file_format("flag_per_line")
+    args.use_param_file("@%s", use_always = False)
+    ctx.actions.run(
+        arguments = [args],
+        inputs = srcs,
+        outputs = [output_dir],
+        executable = ctx.executable.unpack_wheel_and_unzip_archive_files,
+        mnemonic = "UnpackWheelAndUnzipArchiveFiles",
+    )
+
+    return [
+        DefaultInfo(files = depset([output_dir])),
+    ]
+
+_unpacked_wheel = rule(
+    implementation = _unpacked_wheel_impl,
+    attrs = {
+        "wheel": attr.label(mandatory = True, allow_single_file = True),
+        "unpack_wheel_and_unzip_archive_files": attr.label(
+            default = Label("//third_party/py:unpack_wheel_and_unzip_archive_files"),
+            executable = True,
+            cfg = "exec",
+        ),
+        "wheel_deps": attr.label_list(allow_files = True),
+        "zip_deps": attr.label_list(allow_files = True),
+    },
+)
+
+def py_import(
+        name,
+        wheel,
+        deps = [],
+        wheel_deps = [],
+        zip_deps = []):
+    """Unpacks the wheel and uses its content as a py_library.
+
+    Args:
+        name: name of the py_library.
+        wheel: wheel file to unpack.
+        deps: dependencies of the py_library.
+        wheel_deps: additional wheels to unpack. These wheels will be unpacked in the
+                    same folder as the wheel.
+        zip_deps: additional zip files to unpack. These files will be extracted
+                    in the same folder as the wheel.
+    """
+    unpacked_wheel_name = name + "_unpacked_wheel"
+    _unpacked_wheel(
+        name = unpacked_wheel_name,
+        wheel = wheel,
+        wheel_deps = wheel_deps,
+        zip_deps = zip_deps,
+    )
+    py_library(
+        name = name,
+        data = [":" + unpacked_wheel_name],
+        imports = [unpacked_wheel_name],
+        deps = deps,
+        visibility = ["//visibility:public"],
+    )

--- a/third_party/py/py_manylinux_compliance_test.bzl
+++ b/third_party/py/py_manylinux_compliance_test.bzl
@@ -1,0 +1,43 @@
+# Copyright The OpenXLA Authors.
+# Copyright 2025 The zk_dtypes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+""" Macros for manylinux compliance verification test. """
+
+load("@rules_python//python:py_test.bzl", "py_test")
+
+def verify_manylinux_compliance_test(
+        name,
+        wheel,
+        aarch64_compliance_tag,
+        x86_64_compliance_tag,
+        ppc64le_compliance_tag,
+        test_tags = []):
+    py_test(
+        name = name,
+        srcs = [Label("//third_party/py:manylinux_compliance_test.py")],
+        data = [
+            wheel,
+        ],
+        deps = ["@pypi_auditwheel//:pkg"],
+        args = [
+            "--wheel-path=$(location {})".format(wheel),
+            "--aarch64-compliance-tag={}".format(aarch64_compliance_tag),
+            "--x86_64-compliance-tag={}".format(x86_64_compliance_tag),
+            "--ppc64le-compliance-tag={}".format(ppc64le_compliance_tag),
+        ],
+        main = "manylinux_compliance_test.py",
+        tags = ["manual"] + test_tags,
+    )

--- a/third_party/py/python_wheel.bzl
+++ b/third_party/py/python_wheel.bzl
@@ -1,0 +1,292 @@
+# Copyright The OpenXLA Authors.
+# Copyright 2025 The zk_dtypes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+load("@rules_python//python:py_info.bzl", "PyInfo")
+
+""" Repository and build rules for Python wheels packaging utilities. """
+
+def _get_host_environ(repository_ctx, name, default_value = None):
+    """Returns the value of an environment variable on the host platform.
+
+    The host platform is the machine that Bazel runs on.
+
+    Args:
+      repository_ctx: the repository_ctx
+      name: the name of environment variable
+      default_value: the value to return if the environment variable is not set
+
+    Returns:
+      The value of the environment variable 'name' on the host platform.
+    """
+    if name in repository_ctx.os.environ:
+        return repository_ctx.os.environ.get(name).strip()
+
+    if hasattr(repository_ctx.attr, "environ") and name in repository_ctx.attr.environ:
+        return repository_ctx.attr.environ.get(name).strip()
+
+    return default_value
+
+def _python_wheel_version_suffix_repository_impl(repository_ctx):
+    """ Repository rule for storing Python wheel filename version suffix.
+
+    The calculated wheel version suffix depends on the wheel type:
+    - nightly: .dev{build_date}
+    - release: ({custom_version_suffix})?
+    - custom: .dev{build_date}(+{git_hash})?({custom_version_suffix})?
+    - snapshot (default): .dev0+selfbuilt
+
+    The following environment variables can be set:
+    {wheel_type}: ML_WHEEL_TYPE
+    {build_date}: ML_WHEEL_BUILD_DATE (should be YYYYMMDD or YYYY-MM-DD)
+    {git_hash}: ML_WHEEL_GIT_HASH
+    {custom_version_suffix}: ML_WHEEL_VERSION_SUFFIX
+
+    Examples:
+    1. nightly wheel version: 2.19.0.dev20250107
+    Env vars passed to Bazel command: --repo_env=ML_WHEEL_TYPE=nightly
+                                        --repo_env=ML_WHEEL_BUILD_DATE=20250107
+    2. release wheel version: 2.19.0
+    Env vars passed to Bazel command: --repo_env=ML_WHEEL_TYPE=release
+    3. release candidate wheel version: 2.19.0rc1
+    Env vars passed to Bazel command: --repo_env=ML_WHEEL_TYPE=release
+                                        --repo_env=ML_WHEEL_VERSION_SUFFIX=rc1
+    4. custom wheel version: 2.19.0.dev20250107+cbe478fc5custom
+    Env vars passed to Bazel command: --repo_env=ML_WHEEL_TYPE=custom
+                                        --repo_env=ML_WHEEL_BUILD_DATE=$(git show -s --format=%as HEAD)
+                                        --repo_env=ML_WHEEL_GIT_HASH=$(git rev-parse HEAD)
+                                        --repo_env=ML_WHEEL_VERSION_SUFFIX=custom
+    5. snapshot wheel version: 2.19.0.dev0+selfbuilt
+    Env vars passed to Bazel command: --repo_env=ML_WHEEL_TYPE=snapshot
+    """
+    wheel_type = _get_host_environ(
+        repository_ctx,
+        _ML_WHEEL_WHEEL_TYPE,
+        "snapshot",
+    )
+    build_date = _get_host_environ(repository_ctx, _ML_WHEEL_BUILD_DATE)
+    git_hash = _get_host_environ(repository_ctx, _ML_WHEEL_GIT_HASH)
+    custom_version_suffix = _get_host_environ(
+        repository_ctx,
+        _ML_WHEEL_VERSION_SUFFIX,
+    )
+
+    if wheel_type not in ["release", "nightly", "snapshot", "custom"]:
+        fail("Environment variable ML_WHEEL_TYPE should have values \"release\", \"nightly\", \"custom\" or \"snapshot\"")
+
+    wheel_version_suffix = ""
+    semantic_wheel_version_suffix = ""
+    if wheel_type == "nightly":
+        if not build_date:
+            fail("Environment variable ML_WHEEL_BUILD_DATE is required for nightly builds!")
+        formatted_date = build_date.replace("-", "")
+        wheel_version_suffix = ".dev{}".format(formatted_date)
+        semantic_wheel_version_suffix = "-dev{}".format(formatted_date)
+    elif wheel_type == "release":
+        if custom_version_suffix:
+            wheel_version_suffix = custom_version_suffix.replace("-", "")
+            semantic_wheel_version_suffix = custom_version_suffix
+    elif wheel_type == "custom":
+        if build_date:
+            formatted_date = build_date.replace("-", "")
+            wheel_version_suffix += ".dev{}".format(formatted_date)
+            semantic_wheel_version_suffix = "-dev{}".format(formatted_date)
+        if git_hash:
+            # This processing is necessary to align with Python packaging standards
+            # (PEP 440), particularly how setuptools normalizes version strings.
+            # See PEP 440 for local version identifiers:
+            # https://peps.python.org/pep-0440/#local-version-identifiers
+            formatted_hash = git_hash[:9]
+
+            wheel_version_suffix += "+{}".format(formatted_hash)
+            semantic_wheel_version_suffix += "+{}".format(formatted_hash)
+        if custom_version_suffix:
+            wheel_version_suffix += custom_version_suffix.replace("-", "")
+            semantic_wheel_version_suffix += custom_version_suffix
+    else:
+        wheel_version_suffix = ".dev0+selfbuilt"
+        semantic_wheel_version_suffix = "-dev0+selfbuilt"
+
+    version_suffix_bzl_content = """WHEEL_VERSION_SUFFIX = '{wheel_version_suffix}'
+SEMANTIC_WHEEL_VERSION_SUFFIX = '{semantic_wheel_version_suffix}'""".format(
+        wheel_version_suffix = wheel_version_suffix,
+        semantic_wheel_version_suffix = semantic_wheel_version_suffix,
+    )
+
+    repository_ctx.file(
+        "wheel_version_suffix.bzl",
+        version_suffix_bzl_content,
+    )
+    repository_ctx.file("BUILD", "")
+
+_ML_WHEEL_WHEEL_TYPE = "ML_WHEEL_TYPE"
+_ML_WHEEL_BUILD_DATE = "ML_WHEEL_BUILD_DATE"
+_ML_WHEEL_GIT_HASH = "ML_WHEEL_GIT_HASH"
+_ML_WHEEL_VERSION_SUFFIX = "ML_WHEEL_VERSION_SUFFIX"
+
+_ENVIRONS = [
+    _ML_WHEEL_WHEEL_TYPE,
+    _ML_WHEEL_BUILD_DATE,
+    _ML_WHEEL_GIT_HASH,
+    _ML_WHEEL_VERSION_SUFFIX,
+]
+
+python_wheel_version_suffix_repository = repository_rule(
+    implementation = _python_wheel_version_suffix_repository_impl,
+    environ = _ENVIRONS,
+)
+
+def _transitive_py_deps_impl(ctx):
+    outputs = depset(
+        [],
+        transitive = [dep[PyInfo].transitive_sources for dep in ctx.attr.deps],
+    )
+
+    return DefaultInfo(files = outputs)
+
+_transitive_py_deps = rule(
+    attrs = {
+        "deps": attr.label_list(
+            allow_files = True,
+            providers = [PyInfo],
+        ),
+    },
+    implementation = _transitive_py_deps_impl,
+)
+
+def transitive_py_deps(name, deps = []):
+    """Collects python files that a target depends on.
+
+    It traverses dependencies of provided targets, collect their direct and
+    transitive python deps and then return a list of paths to files.
+    """
+    _transitive_py_deps(name = name + "_gather", deps = deps)
+    native.filegroup(name = name, srcs = [":" + name + "_gather"])
+
+FilePathInfo = provider(
+    "Returns path of selected files.",
+    fields = {
+        "files": "requested files from data attribute",
+    },
+)
+
+def _collect_data_aspect_impl(_, ctx):
+    files = {}
+    extensions = ctx.attr._extensions
+    if hasattr(ctx.rule.attr, "data"):
+        for data in ctx.rule.attr.data:
+            for f in data.files.to_list():
+                if not f.owner.package:
+                    continue
+                for ext in extensions:
+                    if f.extension == ext:
+                        files[f] = True
+                        break
+
+    transitive_deps = []
+    if hasattr(ctx.rule.attr, "deps"):
+        for dep in ctx.rule.attr.deps:
+            if FilePathInfo in dep:
+                transitive_deps.append(dep[FilePathInfo].files)
+    return [FilePathInfo(files = depset(direct = files.keys(), transitive = transitive_deps))]
+
+collect_data_aspect = aspect(
+    implementation = _collect_data_aspect_impl,
+    attr_aspects = ["deps"],
+    attrs = {
+        "_extensions": attr.string_list(
+            default = ["so", "pyd", "pyi", "dll", "dylib", "lib", "pd"],
+        ),
+    },
+)
+
+def _collect_symlink_data_aspect_impl(_, ctx):
+    files = {}
+    symlink_extensions = ctx.attr._symlink_extensions
+    if not hasattr(ctx.rule.attr, "symlink_deps"):
+        return [FilePathInfo(files = depset(files.keys()))]
+    for dep in ctx.rule.attr.symlink_deps:
+        if not (dep[DefaultInfo].default_runfiles and
+                dep[DefaultInfo].default_runfiles.files):
+            continue
+        for file in dep[DefaultInfo].default_runfiles.files.to_list():
+            if not file.owner.package:
+                continue
+            for ext in symlink_extensions:
+                if file.extension == ext:
+                    files[file] = True
+                    break
+
+    return [FilePathInfo(files = depset(files.keys()))]
+
+collect_symlink_data_aspect = aspect(
+    implementation = _collect_symlink_data_aspect_impl,
+    attr_aspects = ["symlink_deps"],
+    attrs = {
+        "_symlink_extensions": attr.string_list(
+            default = ["pyi", "lib", "pd"],
+        ),
+    },
+)
+
+def _collect_data_files_impl(ctx):
+    """Rule to collect data files.
+
+    It recursively traverses `deps` attribute of the target and collects paths to
+    files that are in `data` attribute. Then it filters all files that do not match
+    the provided extensions.
+    """
+    files = {}
+    for dep in ctx.attr.deps:
+        for f in dep[FilePathInfo].files.to_list():
+            files[f] = True
+    for symlink_dep in ctx.attr.symlink_deps:
+        for f in symlink_dep[FilePathInfo].files.to_list():
+            files[f] = True
+    return [DefaultInfo(files = depset(
+        files.keys(),
+    ))]
+
+collect_data_files = rule(
+    implementation = _collect_data_files_impl,
+    attrs = {
+        "deps": attr.label_list(
+            aspects = [collect_data_aspect],
+        ),
+        "symlink_deps": attr.label_list(
+            aspects = [collect_symlink_data_aspect],
+        ),
+    },
+)
+
+def _nvidia_wheel_versions_repository_impl(repository_ctx):
+    """Repository rule for storing NVIDIA wheel versions."""
+    versions_source = repository_ctx.attr.versions_source
+
+    versions_file_content = repository_ctx.read(
+        repository_ctx.path(versions_source),
+    )
+    repository_ctx.file(
+        "versions.bzl",
+        "NVIDIA_WHEEL_VERSIONS = '''%s'''" % versions_file_content,
+    )
+    repository_ctx.file("BUILD", "")
+
+nvidia_wheel_versions_repository = repository_rule(
+    implementation = _nvidia_wheel_versions_repository_impl,
+    attrs = {
+        "versions_source": attr.label(mandatory = True, allow_single_file = True),
+    },
+)


### PR DESCRIPTION
## Description

Introduces a comprehensive suite of Bazel macros and scripts to support Python package builds, specifically designed for downstream projects like Zorch that depend on `zk_dtypes`.

**Key Changes:**
1. **Compliance Testing**: Added `manylinux_compliance_test.py` and its corresponding Bazel macro to verify wheels against ManyLinux standards using `auditwheel`.
2. **Packaging Macros**:
   - `py_import.bzl`: Macros to unpack wheels and use them as `py_library`.
   - `python_wheel.bzl`: Comprehensive rules for version suffixing (nightly, release, custom), dependency collection, and data file management.
3. **Version Management**: Implemented a repository rule to dynamically calculate wheel version suffixes based on environment variables like `ML_WHEEL_TYPE` and `ML_WHEEL_GIT_HASH`.
4. **Dependency Collection**: Added aspects to recursively gather transitive Python sources and shared library data files (`.so`, `.pyd`, etc.) for inclusion in the final package.

**Motivation:**
Since other repositories already depend on `zk_dtypes` as a base, centralizing the Python build configuration here simplifies the release process for all dependent projects.

## Related Issues/PRs

N/A

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
