### PR TITLE
feat(field): enable `ExtensionField` construction from `BasePrimeField`

### DIFF
--- a/zk_dtypes/include/field/extension_field.h
+++ b/zk_dtypes/include/field/extension_field.h
@@ -146,6 +146,14 @@ class ExtensionField : public FiniteField<ExtensionField<_Config>>,
 
   constexpr ExtensionField(const BaseField& value) { values_[0] = value; }
 
+  template <typename Config2 = Config,
+            std::enable_if_t<
+                !std::is_same_v<typename Config2::kBaseField,
+                                typename Config2::kBasePrimeField>>* = nullptr>
+  constexpr ExtensionField(const BasePrimeField& value) {
+    AsBasePrimeFields()[0] = value;
+  }
+
   constexpr ExtensionField(std::initializer_list<BaseField> values) {
     DCHECK_LE(values.size(), N);
     auto it = values.begin();

--- a/zk_dtypes/tests/field/extension_field_unittest.cc
+++ b/zk_dtypes/tests/field/extension_field_unittest.cc
@@ -80,6 +80,37 @@ TYPED_TEST(ExtensionFieldTypedTest, ConstructFromUnsignedInteger) {
   }
 }
 
+TYPED_TEST(ExtensionFieldTypedTest, ConstructFromBaseField) {
+  using ExtF = TypeParam;
+  using BaseField = typename ExtF::BaseField;
+  constexpr size_t kDegree = ExtF::Config::kDegreeOverBaseField;
+
+  ExtF a(BaseField(3));
+  EXPECT_EQ(a[0], BaseField(3));
+  for (size_t i = 1; i < kDegree; ++i) {
+    EXPECT_TRUE(a[i].IsZero());
+  }
+}
+
+TYPED_TEST(ExtensionFieldTypedTest, ConstructFromBasePrimeField) {
+  using ExtF = TypeParam;
+  using BaseField = typename ExtF::BaseField;
+  using BasePrimeField = typename ExtF::BasePrimeField;
+
+  if constexpr (std::is_same_v<BaseField, BasePrimeField>) {
+    GTEST_SKIP()
+        << "Skipping test because BaseField and BasePrimeField are the same.";
+  } else {
+    ExtF a(BasePrimeField(3));
+    EXPECT_EQ(a[0], BaseField(3));
+    absl::Span<const BasePrimeField> base_prime_fields = a.AsBasePrimeFields();
+    EXPECT_EQ(base_prime_fields[0], BasePrimeField(3));
+    for (size_t i = 1; i < ExtF::ExtensionDegree(); ++i) {
+      EXPECT_TRUE(base_prime_fields[i].IsZero());
+    }
+  }
+}
+
 TYPED_TEST(ExtensionFieldTypedTest, Add) {
   using ExtF = TypeParam;
   constexpr size_t kDegree = ExtF::Config::kDegreeOverBaseField;


### PR DESCRIPTION
## Description

This allows direct initialization of an extension field element using its underlying prime field type, facilitating easier type promotion in tower extensions.

## Related Issues/PRs

https://github.com/fractalyze/zkx/pull/157#discussion_r2652026672

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
