### PR TITLE
docs(harness): add CLAUDE.md and .claude/ harness configuration

### DIFF
--- a/.claude/knowledge/architecture.md
+++ b/.claude/knowledge/architecture.md
@@ -1,0 +1,34 @@
+# zk_dtypes Architecture
+
+## Type Hierarchy
+
+```
+NumPy dtype extensions
+├── Narrow Integers: int2, int4, uint2, uint4, int128, uint128, int256, uint256
+├── Prime Fields
+│   ├── BabyBear (p=2013265921)
+│   ├── Goldilocks (p=2^64-2^32+1)
+│   ├── KoalaBear (p=2^31-2^24+1=2130706433)
+│   ├── Mersenne31 (p=2^31-1)
+│   ├── BN254 scalar field: bn254_sf, bn254_sf_mont
+│   ├── BN254 Fq: bn254_fq, bn254_fq_mont
+│   └── BN254 Fr: bn254_fr, bn254_fr_mont
+├── Extension Fields
+│   ├── BabyBearx4 (degree-4 extension)
+│   ├── Goldilocksx3 (degree-3 extension)
+│   └── KoalaBearx4
+├── Binary Fields: binary_field_t0..t7
+└── Elliptic Curves
+    ├── BN254 G1: bn254_g1_affine, bn254_g1_jacobian, bn254_g1_xyzz (+ _mont variants)
+    └── BN254 G2: bn254_g2_affine, bn254_g2_jacobian, bn254_g2_xyzz (+ _mont variants)
+```
+
+## Implementation Layers
+1. **C/C++ core**: Field arithmetic implementations, NumPy dtype registration
+2. **Python bindings**: NumPy-compatible interface, operator overloading
+3. **Testing**: Property-based tests verifying field axioms
+
+## Key Design Decisions
+- Each dtype has both standard and Montgomery form (`_mont` suffix)
+- All field ops must satisfy: associativity, commutativity, distributivity
+- Extension field degree is encoded in the type name

--- a/.claude/knowledge/solutions.md
+++ b/.claude/knowledge/solutions.md
@@ -1,0 +1,16 @@
+# Past Bugs & Resolution Patterns
+
+Record non-obvious bugs here as they are discovered. Format:
+- **Problem**: what went wrong
+- **Cause**: root cause
+- **Fix**: how it was resolved
+- **Prevention**: how to avoid recurrence
+
+## Template
+<!-- Copy this when adding a new entry:
+### [Date] — [Short description]
+- **Problem**: 
+- **Cause**: 
+- **Fix**: 
+- **Prevention**: 
+-->

--- a/.claude/knowledge/testing-guide.md
+++ b/.claude/knowledge/testing-guide.md
@@ -1,0 +1,17 @@
+# zk_dtypes Testing Guide
+
+## Running Tests
+```
+bazel test //...
+```
+
+## Property-Based Testing
+New field types MUST verify:
+- Addition: associativity, commutativity, identity (0), inverse
+- Multiplication: associativity, commutativity, identity (1), inverse (non-zero)
+- Distributivity: a * (b + c) == a*b + a*c
+- Montgomery conversion: from_mont(to_mont(x)) == x
+
+## Test Naming
+- Test files: `*_test.py`
+- Test functions: `test_<field_type>_<property>`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,38 @@
+# CLAUDE.md
+
+## Project Overview
+zk_dtypes is a NumPy dtype extension library for zero-knowledge cryptography.
+Provides prime fields, extension fields, binary fields, elliptic curve types,
+and narrow integers — all registered as first-class NumPy dtypes.
+
+## Current Focus
+Q2: E2E proving p99 ≤ 7s on 16 GPUs (excluding verification).
+Sprint: E2E correctness — 5 test blocks Phase 1-3 bug-free.
+Out of scope: Multi-zkVM 2nd backend, community building, internal tooling, external talks.
+
+## Commands
+- Build: `bazel build //...`
+- Test: `bazel test //...`
+
+## Why Decisions
+- NumPy extension over standalone lib: seamless JAX/NumPy interop without conversion overhead at every call boundary.
+- C extensions for field arithmetic: Python-only implementation would be 100x slower for core field operations.
+- Montgomery form as default: eliminates repeated conversion in proving pipelines that chain multiple field operations.
+
+## Rules
+- New field types MUST include property-based tests verifying all field axioms.
+- Do NOT add dtypes without registering them in NumPy's type system.
+- Do NOT break field axiom properties (associativity, commutativity, distributivity, identity, inverse).
+- Montgomery `_mont` suffix and extension `x{degree}` suffix are mandatory naming conventions.
+- Always run `bazel test //...` before committing.
+
+## Invisible Traps
+- `bn254_sf`/`bn254_sf_mont` are prime field (scalar field) types, NOT elliptic curve types. EC types are `bn254_g1_affine`, `bn254_g2_affine`, etc. Confusing them compiles but produces nonsense.
+- Montgomery conversion test direction: `from_mont(to_mont(x)) == x` (start from standard element). C++ API uses `MontReduce()`.
+- Narrow integers include int128/uint128/int256/uint256 — easily missed when enumerating types.
+
+## Knowledge Files
+Read ONLY when relevant to your current task:
+@.claude/knowledge/architecture.md — Type hierarchy, C/Python binding layers
+@.claude/knowledge/testing-guide.md — Property-based testing for field axioms
+@.claude/knowledge/solutions.md — Past bug resolution patterns


### PR DESCRIPTION
## Description
Add project-specific AI harness configuration following the Harness Engineering decision tree.

## Checklist
- [x] CLAUDE.md with Q2 context and AI safety zones
- [x] .claude/knowledge/architecture.md
- [x] .claude/knowledge/testing-guide.md
- [x] .claude/knowledge/solutions.md (starter template)