### PR TITLE
ci: strip .so files in wheels and reduce artifact retention

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           name: wheels-linux-x86_64
           path: wheelhouse/*.whl
+          retention-days: 3
 
   build-linux-aarch64:
     name: Build / Linux aarch64
@@ -55,6 +56,7 @@ jobs:
         with:
           name: wheels-linux-aarch64
           path: wheelhouse/*.whl
+          retention-days: 3
 
   build-macos-arm64:
     name: Build / macOS arm64
@@ -70,6 +72,7 @@ jobs:
         with:
           name: wheels-macos-arm64
           path: wheelhouse/*.whl
+          retention-days: 3
 
   publish:
     name: Publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,22 @@ before-all = """
     chmod +x bazelisk
     mv bazelisk /usr/local/bin/bazel
 """
+repair-wheel-command = """
+    python -m wheel unpack {wheel} -d /tmp/whl-unpack && \
+    find /tmp/whl-unpack -name '*.so' -exec strip -s {} + && \
+    python -m wheel pack /tmp/whl-unpack/* -d /tmp/whl-stripped && \
+    auditwheel repair -w {dest_dir} /tmp/whl-stripped/*.whl && \
+    rm -rf /tmp/whl-unpack /tmp/whl-stripped
+"""
 
 [tool.cibuildwheel.macos]
 archs = ["arm64"]
 before-all = "brew install bazelisk"
 environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
+repair-wheel-command = """
+    python -m wheel unpack {wheel} -d /tmp/whl-unpack && \
+    find /tmp/whl-unpack -name '*.so' -exec strip -x {} + && \
+    python -m wheel pack /tmp/whl-unpack/* -d /tmp/whl-stripped && \
+    delocate-wheel --require-archs {delocate_archs} -w {dest_dir} /tmp/whl-stripped/*.whl && \
+    rm -rf /tmp/whl-unpack /tmp/whl-stripped
+"""


### PR DESCRIPTION
## Description

Strip debug symbols from .so files during wheel repair to reduce wheel size by ~30-50%.
Also reduce artifact retention to 3 days since final wheels are uploaded to GitHub release
assets (which don't count toward Actions storage).

- Linux: `strip -s` (remove all symbols) via `repair-wheel-command`
- macOS: `strip -x` (remove local symbols, keep exported for dyld) via `repair-wheel-command`
- All 3 upload-artifact steps now have `retention-days: 3`

## Related Issues/PRs

Part of org-wide CI/CD storage optimization (Actions storage at 2GB/2GB).

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)