### PR TITLE
fix: use LDFLAGS for .so stripping instead of repair-wheel-command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ test-command = "pytest {project}/zk_dtypes/tests"
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]
+environment = { LDFLAGS = "-Wl,-s" }
 before-all = """
     ARCH="$(uname -m)"
     if [ "$ARCH" = "aarch64" ]; then
@@ -69,22 +70,8 @@ before-all = """
     chmod +x bazelisk
     mv bazelisk /usr/local/bin/bazel
 """
-repair-wheel-command = """
-    python -m wheel unpack {wheel} -d /tmp/whl-unpack && \
-    find /tmp/whl-unpack -name '*.so' -exec strip -s {} + && \
-    python -m wheel pack /tmp/whl-unpack/* -d /tmp/whl-stripped && \
-    auditwheel repair -w {dest_dir} /tmp/whl-stripped/*.whl && \
-    rm -rf /tmp/whl-unpack /tmp/whl-stripped
-"""
 
 [tool.cibuildwheel.macos]
 archs = ["arm64"]
 before-all = "brew install bazelisk"
-environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
-repair-wheel-command = """
-    python -m wheel unpack {wheel} -d /tmp/whl-unpack && \
-    find /tmp/whl-unpack -name '*.so' -exec strip -x {} + && \
-    python -m wheel pack /tmp/whl-unpack/* -d /tmp/whl-stripped && \
-    delocate-wheel --require-archs {delocate_archs} -w {dest_dir} /tmp/whl-stripped/*.whl && \
-    rm -rf /tmp/whl-unpack /tmp/whl-stripped
-"""
+environment = { MACOSX_DEPLOYMENT_TARGET = "11.0", LDFLAGS = "-Wl,-x" }


### PR DESCRIPTION
## Description

The `repair-wheel-command` approach from #116 failed in CI:
- **Linux**: `wheel pack -d /tmp/whl-stripped` — directory not created, `FileNotFoundError`
- **macOS**: `python -m wheel` — module not available in cibuildwheel's build venv

Switch to linker-level stripping via `LDFLAGS`, which is simpler and more robust.
setuptools passes `LDFLAGS` to the linker automatically when building C extensions.

- Linux: `LDFLAGS=-Wl,-s` (strip all symbols at link time)
- macOS: `LDFLAGS=-Wl,-x` (strip local symbols, keep exported for dyld)

No custom `repair-wheel-command` needed — cibuildwheel defaults (auditwheel/delocate) are used.

## Related Issues/PRs

- fixes regression from #116

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)