### PR TITLE
feat(elliptic_curve): add twisted Edwards curve and Curve25519/Ed25519 support

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -4,4 +4,6 @@ skip =
 
 ignore-words-list =
   arithmetics,
+  Te,
+  TE,
   Toom,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,153 @@
+# zk_dtypes
+
+## Purpose
+
+zk_dtypes is a C++ header-only library of zero-knowledge-friendly data types:
+prime fields, extension fields, elliptic curves, and big integers. It provides
+both standard and Montgomery representations with compile-time field
+configuration. Downstream consumers include **prime-ir** (MLIR constant folding
+and code generation) and **riscv-witness** (SP1 precompile trace computation).
+
+## Key Design Patterns
+
+### CRTP Operation Classes
+
+Point arithmetic is implemented via CRTP: `AffinePoint<Curve>` inherits
+`AffinePointOperation<AffinePoint<Curve>>`. The operation class calls back into
+the derived class for `ToCoords()`, `FromCoords()`, `CreateJacobianPoint()`,
+`GetCFOperation()`, etc.
+
+This same CRTP mechanism is used by **prime-ir** `PointCodeGenBase` and
+`PointOperationBase` — they inherit the same zk_dtypes operation classes,
+providing MLIR-Value-based or FieldOperation-based coordinates instead of field
+element values. This is why operation classes must use `GetCFOperation()` for
+control flow rather than plain `if/else`.
+
+### SFINAE Curve Family Dispatch
+
+`AffinePoint<Curve>` is partially specialized via SFINAE on
+`Curve::kType == CurveType::kShortWeierstrass` or `kTwistedEdwards`. This lets
+both curve families share the `AffinePoint<>` name while having completely
+different operation implementations. `PointTraits<>` is similarly SFINAE-split.
+
+### Montgomery Representations
+
+Every curve has both standard (`Config`) and Montgomery (`MontConfig`) variants.
+The Mont config stores curve constants (a, b/d, Gx, Gy) in Montgomery form via
+`BaseField::FromUnchecked(...)`. The standard config stores raw integer values.
+
+**Pitfall**: Use constructors (not `FromUnchecked`) for value→field conversion.
+Use `MontReduce()` for Montgomery→standard extraction. See knowledge-graph
+pitfall `montgomery-integer-field-conversion-bug.md`.
+
+### Full-Width Modulus Carry Bug
+
+For fields where `kModulusBits == kStorageBits` (no spare bit in top limb),
+`SlowMontMul` must propagate the final carry to `Reduce()`. secp256k1 Fq is the
+canonical example. Curve25519 Fq has a spare bit (255 < 256) so it uses
+`FastMontMul`.
+
+## Directory & Naming Conventions
+
+### Curve Directory Layout
+
+Follows the `<family>/<instance>/` nesting when the family has multiple curves
+sharing a base field:
+
+| Pattern                       | Example                   | When                                  |
+| ----------------------------- | ------------------------- | ------------------------------------- |
+| `<curve>/g1.h`                | `secp256k1/g1.h`          | Standalone curve, one group           |
+| `<family>/<curve>/g1.h`       | `bn/bn254/g1.h`           | Family with shared field              |
+| `<family>/<curve>/g1.h, g2.h` | `bn/bn254/g1.h, g2.h`     | Pairing curve                         |
+| `<field-family>/<curve>/g1.h` | `curve25519/ed25519/g1.h` | Different curve forms sharing a field |
+
+Field files (`fq.h`, `fr.h`) live at the family level when shared.
+
+### Namespace Convention
+
+Namespaces mirror the instance, NOT the directory:
+
+- `zk_dtypes::secp256k1` (flat — no family)
+- `zk_dtypes::bn254` (instance, not `bn::bn254`)
+- `zk_dtypes::ed25519` (instance, not `curve25519::ed25519`)
+
+Field types from the family namespace are imported via `using`:
+
+```cpp
+namespace zk_dtypes::ed25519 {
+using curve25519::Fq;
+using curve25519::FqMont;
+}
+```
+
+### Config Class Naming
+
+| Curve Type | Config            | Mont Config           | Std Types                                     | Mont Types                         |
+| ---------- | ----------------- | --------------------- | --------------------------------------------- | ---------------------------------- |
+| SW         | `G1SwCurveConfig` | `G1SwCurveMontConfig` | `G1Curve`, `G1AffinePoint`                    | `G1CurveMont`, `G1AffinePointMont` |
+| TE         | `G1TeCurveConfig` | `G1TeCurveMontConfig` | `G1Curve`, `G1AffinePoint`, `G1ExtendedPoint` | `G1CurveMont`, etc.                |
+
+### BUILD Target Naming
+
+- Field targets: `<family>_fq`, `<family>_fr` (e.g. `curve25519_fq`)
+- Curve targets: `<instance>_g1` (e.g. `ed25519_g1`, `secp256k1_g1`)
+- SW infra: `sw_curve`, `sw_affine_point`, `sw_jacobian_point`, `sw_point_xyzz`
+- TE infra: `te_curve`, `te_affine_point`, `te_extended_point`
+
+### Test Convention
+
+- Small-prime test config in `<curve_type>/test/<type>_curve_config.h` (e.g.
+  `twisted_edwards/test/te_curve_config.h` with F₁₃ curve)
+- Affine/extended/jacobian point unittests in `tests/elliptic_curve/`
+- Real-curve sanity tests (on-curve check, identity, inverse, double, Mont
+  consistency) in the same directory
+
+## Adding a New Curve
+
+1. **Field configs** (`fq.h`, `fr.h`): Compute Montgomery constants
+   (`kRSquared`, `kNPrime`, `kOne`) via Python. Verify
+   `kNPrime * p ≡ -1 mod 2⁶⁴`.
+1. **Curve config** (`g1.h`): Define `G1<Sw|Te>CurveConfig` with `kA`/`kB`/`kD`,
+   generator coords, and Mont variant with `FromUnchecked`. Verify generator is
+   on curve in a unittest.
+1. **BUILD.bazel**: Add `cc_library` targets. Add to `all_types` deps and the
+   appropriate type list macros in `all_types.h`.
+1. **Tests**: On-curve check, identity addition, inverse, double=add(self),
+   Mont/non-Mont consistency.
+
+## Downstream Integration
+
+### prime-ir
+
+prime-ir uses zk_dtypes for:
+
+- **Constant folding**: `PointOperationBase<Kind>::fromZkDtype()` converts
+  zk_dtypes points to MLIR attributes, then folds via the same CRTP operation
+  classes
+- **Code generation**: `PointCodeGenBase<Kind>` inherits the operation classes
+  with `FieldCodeGen` (MLIR Values) as the base field type
+- **Curve recognition**: `KnownCurves.cpp` matches `ShortWeierstrassAttr` /
+  `TwistedEdwardsAttr` parameters against zk_dtypes curve configs
+
+When adding a new curve to zk_dtypes, prime-ir needs:
+
+- `getPointType<T>()` case in `PointOperation.h`
+- `getTwistedEdwardsAttr<T>()` or `getShortWeierstrassAttr<T>()` specialization
+- BUILD dep on the new `@zk_dtypes` target
+
+### riscv-witness
+
+riscv-witness uses zk_dtypes for:
+
+- **Precompile computation**: `CurveField<Tag>::G1Point` and `FqMont` in
+  `HandleEcAdd<Tag>()` — reads raw limbs from emulated memory, converts to Mont,
+  computes, converts back
+- **Trace input generation**: `BatchEcAdd` computes intermediates needed by the
+  MLIR filler
+
+When adding a new curve, riscv-witness needs:
+
+- `CurveField<NewTag>` specialization in `field_adapter.h`
+- Syscall constant + dispatch case in `sp1_provider.cpp`
+- Collector in `SP1PrecompileTraceContext`
+- Chip registry entry + Rust trace tooling

--- a/zk_dtypes/BUILD.bazel
+++ b/zk_dtypes/BUILD.bazel
@@ -38,6 +38,7 @@ cc_library(
         ":bn254_fr",
         ":bn254_g1",
         ":bn254_g2",
+        ":ed25519_g1",
         ":goldilocks",
         ":goldilocksx3",
         ":koalabear",
@@ -606,6 +607,7 @@ cc_library(
     hdrs = ["include/geometry/point_declarations.h"],
     deps = [
         ":comparable_traits",
+        ":curve_type",
         ":group",
     ],
 )
@@ -949,6 +951,116 @@ cc_library(
     ],
 )
 
+############################
+# Twisted Edwards Curves   #
+############################
+
+cc_library(
+    name = "te_curve",
+    hdrs = ["include/elliptic_curve/twisted_edwards/te_curve.h"],
+    deps = [
+        ":curve_type",
+        ":point_declarations",
+    ],
+)
+
+cc_library(
+    name = "te_point_base",
+    hdrs = ["include/elliptic_curve/twisted_edwards/point_base.h"],
+    deps = [
+        ":control_flow_operation",
+        ":point_traits",
+        ":str_join",
+    ],
+)
+
+cc_library(
+    name = "te_affine_point_operation",
+    hdrs = ["include/elliptic_curve/twisted_edwards/affine_point_operation.h"],
+    deps = [
+        ":curve_type",
+        ":point_traits",
+    ],
+)
+
+cc_library(
+    name = "te_affine_point",
+    hdrs = ["include/elliptic_curve/twisted_edwards/affine_point.h"],
+    deps = [
+        ":curve_type",
+        ":point_declarations",
+        ":scalar_mul",
+        ":te_affine_point_operation",
+        ":te_curve",
+        ":te_point_base",
+    ],
+)
+
+cc_library(
+    name = "te_extended_point_operation",
+    hdrs = ["include/elliptic_curve/twisted_edwards/extended_point_operation.h"],
+    deps = [
+        ":curve_type",
+        ":point_traits",
+    ],
+)
+
+cc_library(
+    name = "te_extended_point",
+    hdrs = ["include/elliptic_curve/twisted_edwards/extended_point.h"],
+    deps = [
+        ":batch_inverse",
+        ":curve_type",
+        ":point_declarations",
+        ":scalar_mul",
+        ":te_curve",
+        ":te_extended_point_operation",
+        ":te_point_base",
+        ":template_util",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_library(
+    name = "te_test_curve_config",
+    hdrs = ["include/elliptic_curve/twisted_edwards/test/te_curve_config.h"],
+    deps = [
+        ":small_prime_field",
+        ":te_affine_point",
+        ":te_curve",
+        ":te_extended_point",
+    ],
+)
+
+##############
+# Curve25519 #
+##############
+
+cc_library(
+    name = "curve25519_fq",
+    hdrs = ["include/elliptic_curve/curve25519/fq.h"],
+    deps = [":big_prime_field"],
+)
+
+cc_library(
+    name = "curve25519_fr",
+    hdrs = ["include/elliptic_curve/curve25519/fr.h"],
+    deps = [":big_prime_field"],
+)
+
+cc_library(
+    name = "ed25519_g1",
+    hdrs = ["include/elliptic_curve/curve25519/ed25519/g1.h"],
+    deps = [
+        ":curve25519_fq",
+        ":curve25519_fr",
+        ":te_affine_point",
+        ":te_curve",
+        ":te_extended_point",
+    ],
+)
+
 cc_library(
     name = "twist_type",
     hdrs = ["include/elliptic_curve/pairing/twist_type.h"],
@@ -961,6 +1073,8 @@ cc_test(
         "tests/elliptic_curve/constexpr_curve_config_unittest.cc",
         "tests/elliptic_curve/jacobian_point_unittest.cc",
         "tests/elliptic_curve/point_xyzz_unittest.cc",
+        "tests/elliptic_curve/te_affine_point_unittest.cc",
+        "tests/elliptic_curve/te_extended_point_unittest.cc",
     ],
     deps = [
         ":bls12_381_g1",
@@ -970,6 +1084,19 @@ cc_test(
         ":secp256r1_fq",
         ":secp256r1_g1",
         ":sw_test_curve_config",
+        ":te_test_curve_config",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "ed25519_unittests",
+    srcs = [
+        "tests/elliptic_curve/ed25519_unittest.cc",
+    ],
+    deps = [
+        ":ed25519_g1",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],

--- a/zk_dtypes/BUILD.bazel
+++ b/zk_dtypes/BUILD.bazel
@@ -952,7 +952,7 @@ cc_library(
 )
 
 ############################
-# Twisted Edwards Curves   #
+# Twisted Edwards Curves #
 ############################
 
 cc_library(

--- a/zk_dtypes/include/all_types.h
+++ b/zk_dtypes/include/all_types.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/fr.h"
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/g1.h"
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/g2.h"
+#include "zk_dtypes/include/elliptic_curve/curve25519/ed25519/g1.h"
 #include "zk_dtypes/include/elliptic_curve/secp256k1/g1.h"
 #include "zk_dtypes/include/field/babybear/babybear.h"
 #include "zk_dtypes/include/field/babybear/babybearx4.h"
@@ -74,13 +75,15 @@ WITH_MONT(V, ::zk_dtypes::Goldilocks, Goldilocks, GOLDILOCKS, goldilocks) \
 WITH_MONT(V, ::zk_dtypes::Koalabear, Koalabear, KOALABEAR, koalabear)     \
 WITH_MONT(V, ::zk_dtypes::bn254::Fr, Bn254Sf, BN254_SF, bn254_sf)
 
-#define ZK_DTYPES_ALL_PRIME_FIELD_TYPE_LIST(V)                                    \
-ZK_DTYPES_PUBLIC_PRIME_FIELD_TYPE_LIST(V)                                         \
-WITH_MONT(V, ::zk_dtypes::bn254::Fq, Bn254Bf, BN254_BF, bn254_bf)                 \
-WITH_MONT(V, ::zk_dtypes::secp256k1::Fq, Secp256k1Bf, SECP256K1_BF, secp256k1_bf) \
-WITH_MONT(V, ::zk_dtypes::secp256k1::Fr, Secp256k1Sf, SECP256K1_SF, secp256k1_sf) \
-WITH_MONT(V, ::zk_dtypes::bls12_381::Fq, Bls12381Bf, BLS12_381_BF, bls12_381_bf)  \
-WITH_MONT(V, ::zk_dtypes::bls12_381::Fr, Bls12381Sf, BLS12_381_SF, bls12_381_sf)
+#define ZK_DTYPES_ALL_PRIME_FIELD_TYPE_LIST(V)                                        \
+ZK_DTYPES_PUBLIC_PRIME_FIELD_TYPE_LIST(V)                                             \
+WITH_MONT(V, ::zk_dtypes::bn254::Fq, Bn254Bf, BN254_BF, bn254_bf)                     \
+WITH_MONT(V, ::zk_dtypes::secp256k1::Fq, Secp256k1Bf, SECP256K1_BF, secp256k1_bf)     \
+WITH_MONT(V, ::zk_dtypes::secp256k1::Fr, Secp256k1Sf, SECP256K1_SF, secp256k1_sf)     \
+WITH_MONT(V, ::zk_dtypes::bls12_381::Fq, Bls12381Bf, BLS12_381_BF, bls12_381_bf)      \
+WITH_MONT(V, ::zk_dtypes::bls12_381::Fr, Bls12381Sf, BLS12_381_SF, bls12_381_sf)      \
+WITH_MONT(V, ::zk_dtypes::curve25519::Fq, Curve25519Bf, CURVE25519_BF, curve25519_bf) \
+WITH_MONT(V, ::zk_dtypes::curve25519::Fr, Curve25519Sf, CURVE25519_SF, curve25519_sf)
 
 //===----------------------------------------------------------------------===//
 // ExtendedField Types
@@ -136,7 +139,8 @@ ZK_DTYPES_PUBLIC_R2_AFFINE_POINT_TYPE_LIST(V)
 #define ZK_DTYPES_ALL_R1_AFFINE_POINT_TYPE_LIST(V)                                                               \
 ZK_DTYPES_PUBLIC_R1_AFFINE_POINT_TYPE_LIST(V)                                                                    \
 WITH_MONT(V, ::zk_dtypes::secp256k1::G1AffinePoint, Secp256k1G1Affine, SECP256K1_G1_AFFINE, secp256k1_g1_affine) \
-WITH_MONT(V, ::zk_dtypes::bls12_381::G1AffinePoint, Bls12381G1Affine, BLS12_381_G1_AFFINE, bls12_381_g1_affine)
+WITH_MONT(V, ::zk_dtypes::bls12_381::G1AffinePoint, Bls12381G1Affine, BLS12_381_G1_AFFINE, bls12_381_g1_affine)  \
+WITH_MONT(V, ::zk_dtypes::ed25519::G1AffinePoint, Ed25519G1Affine, ED25519_G1_AFFINE, ed25519_g1_affine)
 
 #define ZK_DTYPES_ALL_R2_AFFINE_POINT_TYPE_LIST(V) \
 ZK_DTYPES_PUBLIC_R2_AFFINE_POINT_TYPE_LIST(V)
@@ -198,6 +202,16 @@ ZK_DTYPES_ALL_R1_XYZZ_POINT_TYPE_LIST(V)      \
 ZK_DTYPES_ALL_R2_XYZZ_POINT_TYPE_LIST(V)
 
 //===----------------------------------------------------------------------===//
+// ExtendedPoint Types
+//===----------------------------------------------------------------------===//
+
+#define ZK_DTYPES_ALL_R1_EXTENDED_POINT_TYPE_LIST(V) \
+WITH_MONT(V, ::zk_dtypes::ed25519::G1ExtendedPoint, Ed25519G1Extended, ED25519_G1_EXTENDED, ed25519_g1_extended)
+
+#define ZK_DTYPES_ALL_EXTENDED_POINT_TYPE_LIST(V) \
+ZK_DTYPES_ALL_R1_EXTENDED_POINT_TYPE_LIST(V)
+
+//===----------------------------------------------------------------------===//
 // Elliptic Curve Point Types
 //===----------------------------------------------------------------------===//
 
@@ -216,7 +230,8 @@ ZK_DTYPES_PUBLIC_R1_EC_POINT_TYPE_LIST(V)      \
 ZK_DTYPES_PUBLIC_R2_EC_POINT_TYPE_LIST(V)
 
 #define ZK_DTYPES_ALL_R1_EC_POINT_TYPE_LIST(V) \
-ZK_DTYPES_PUBLIC_R1_EC_POINT_TYPE_LIST(V)
+ZK_DTYPES_PUBLIC_R1_EC_POINT_TYPE_LIST(V)      \
+ZK_DTYPES_ALL_R1_EXTENDED_POINT_TYPE_LIST(V)
 
 #define ZK_DTYPES_ALL_R2_EC_POINT_TYPE_LIST(V) \
 ZK_DTYPES_PUBLIC_R2_EC_POINT_TYPE_LIST(V)

--- a/zk_dtypes/include/elliptic_curve/curve25519/ed25519/g1.h
+++ b/zk_dtypes/include/elliptic_curve/curve25519/ed25519/g1.h
@@ -1,0 +1,95 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_CURVE25519_ED25519_G1_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_CURVE25519_ED25519_G1_H_
+
+#include "zk_dtypes/include/elliptic_curve/curve25519/fq.h"
+#include "zk_dtypes/include/elliptic_curve/curve25519/fr.h"
+#include "zk_dtypes/include/elliptic_curve/twisted_edwards/affine_point.h"
+#include "zk_dtypes/include/elliptic_curve/twisted_edwards/extended_point.h"
+#include "zk_dtypes/include/elliptic_curve/twisted_edwards/te_curve.h"
+
+namespace zk_dtypes::ed25519 {
+
+using curve25519::Fq;
+using curve25519::FqMont;
+using curve25519::Fr;
+using curve25519::FrMont;
+
+// Ed25519: -x² + y² = 1 + d * x² * y² over GF(2²⁵⁵ - 19)
+// See RFC 8032 §5.1 for the curve parameters and generator.
+class G1TeCurveConfig {
+ public:
+  constexpr static bool kUseMontgomery = false;
+  using StdConfig = G1TeCurveConfig;
+  using BaseField = Fq;
+  using ScalarField = Fr;
+
+  // a = -1 mod p
+  constexpr static BaseField kA = {
+      UINT64_C(18446744073709551596), UINT64_C(18446744073709551615),
+      UINT64_C(18446744073709551615), UINT64_C(9223372036854775807)};
+
+  // d = -121665/121666 mod p
+  constexpr static BaseField kD = {
+      UINT64_C(8496970652267935907), UINT64_C(31536524315187371),
+      UINT64_C(10144147576115030168), UINT64_C(5909686906226998899)};
+
+  // Generator from RFC 8032 §5.1
+  constexpr static BaseField kX = {
+      UINT64_C(14507833142362363162), UINT64_C(7578651490590762930),
+      UINT64_C(13881468655802702940), UINT64_C(2407515759118799870)};
+  constexpr static BaseField kY = {
+      UINT64_C(7378697629483820632), UINT64_C(7378697629483820646),
+      UINT64_C(7378697629483820646), UINT64_C(7378697629483820646)};
+};
+
+class G1TeCurveMontConfig {
+ public:
+  constexpr static bool kUseMontgomery = true;
+  using StdConfig = G1TeCurveConfig;
+  using BaseField = FqMont;
+  using ScalarField = FrMont;
+
+  // a = -1 mod p in Montgomery form
+  constexpr static BaseField kA = BaseField::FromUnchecked(
+      {UINT64_C(18446744073709551559), UINT64_C(18446744073709551615),
+       UINT64_C(18446744073709551615), UINT64_C(9223372036854775807)});
+
+  // d in Montgomery form
+  constexpr static BaseField kD = BaseField::FromUnchecked(
+      {UINT64_C(9290235533119187450), UINT64_C(1198387923977120115),
+       UINT64_C(16542726418180114064), UINT64_C(3207173552111338790)});
+
+  // Generator in Montgomery form
+  constexpr static BaseField kX = BaseField::FromUnchecked(
+      {UINT64_C(16342081272192803463), UINT64_C(11287595536805717129),
+       UINT64_C(10986974856635266487), UINT64_C(8475250514821412816)});
+  constexpr static BaseField kY = BaseField::FromUnchecked(
+      {UINT64_C(3689348814741910346), UINT64_C(3689348814741910323),
+       UINT64_C(3689348814741910323), UINT64_C(3689348814741910323)});
+};
+
+using G1Curve = TwistedEdwardsCurve<G1TeCurveConfig>;
+using G1CurveMont = TwistedEdwardsCurve<G1TeCurveMontConfig>;
+using G1AffinePoint = AffinePoint<G1Curve>;
+using G1AffinePointMont = AffinePoint<G1CurveMont>;
+using G1ExtendedPoint = ExtendedPoint<G1Curve>;
+using G1ExtendedPointMont = ExtendedPoint<G1CurveMont>;
+
+}  // namespace zk_dtypes::ed25519
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_CURVE25519_ED25519_G1_H_

--- a/zk_dtypes/include/elliptic_curve/curve25519/fq.h
+++ b/zk_dtypes/include/elliptic_curve/curve25519/fq.h
@@ -1,0 +1,101 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_CURVE25519_FQ_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_CURVE25519_FQ_H_
+
+#include "zk_dtypes/include/field/big_prime_field.h"
+
+namespace zk_dtypes::curve25519 {
+
+// Curve25519 base field: p = 2²⁵⁵ - 19
+struct FqBaseConfig {
+  constexpr static size_t kStorageBits = 256;
+  constexpr static size_t kModulusBits = 255;
+  constexpr static BigInt<4> kModulus = {
+      UINT64_C(18446744073709551597),
+      UINT64_C(18446744073709551615),
+      UINT64_C(18446744073709551615),
+      UINT64_C(9223372036854775807),
+  };
+
+  // p - 1 = 2² * t
+  constexpr static uint32_t kTwoAdicity = 2;
+
+  constexpr static BigInt<4> kTrace = {
+      UINT64_C(18446744073709551611),
+      UINT64_C(18446744073709551615),
+      UINT64_C(18446744073709551615),
+      UINT64_C(2305843009213693951),
+  };
+
+  constexpr static bool kHasTwoAdicRootOfUnity = true;
+  constexpr static bool kHasLargeSubgroupRootOfUnity = false;
+};
+
+struct FqConfig : public FqBaseConfig {
+  constexpr static bool kUseMontgomery = false;
+
+  using StdConfig = FqConfig;
+
+  constexpr static BigInt<4> kOne = 1;
+
+  // Primitive 4th root of unity: sqrt(-1) mod p
+  constexpr static BigInt<4> kTwoAdicRootOfUnity = {
+      UINT64_C(14190309331451158704),
+      UINT64_C(3405592160176694392),
+      UINT64_C(3120150775007532967),
+      UINT64_C(3135389899092516619),
+  };
+};
+
+struct FqMontConfig : public FqBaseConfig {
+  constexpr static bool kUseMontgomery = true;
+
+  using StdConfig = FqConfig;
+
+  // R² mod p where R = 2²⁵⁶
+  constexpr static BigInt<4> kRSquared = {
+      UINT64_C(1444),
+      UINT64_C(0),
+      UINT64_C(0),
+      UINT64_C(0),
+  };
+  // -p⁻¹ mod 2²⁶⁴
+  constexpr static uint64_t kNPrime = UINT64_C(9708812670373448219);
+
+  // R mod p (Montgomery form of 1)
+  constexpr static BigInt<4> kOne = {
+      UINT64_C(38),
+      UINT64_C(0),
+      UINT64_C(0),
+      UINT64_C(0),
+  };
+
+  // sqrt(-1) mod p in Montgomery form
+  constexpr static BigInt<4> kTwoAdicRootOfUnity = {
+      UINT64_C(4276176457567034116),
+      UINT64_C(285293570747525613),
+      UINT64_C(7885265008028943057),
+      UINT64_C(8464351723258321832),
+  };
+};
+
+using Fq = PrimeField<FqConfig>;
+using FqMont = PrimeField<FqMontConfig>;
+
+}  // namespace zk_dtypes::curve25519
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_CURVE25519_FQ_H_

--- a/zk_dtypes/include/elliptic_curve/curve25519/fr.h
+++ b/zk_dtypes/include/elliptic_curve/curve25519/fr.h
@@ -1,0 +1,100 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_CURVE25519_FR_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_CURVE25519_FR_H_
+
+#include "zk_dtypes/include/field/big_prime_field.h"
+
+namespace zk_dtypes::curve25519 {
+
+// Ed25519 scalar field (group order):
+// ell = 2²⁵² + 27742317777372353535851937790883648493
+struct FrBaseConfig {
+  constexpr static size_t kStorageBits = 256;
+  constexpr static size_t kModulusBits = 253;
+  constexpr static BigInt<4> kModulus = {
+      UINT64_C(6346243789798364141),
+      UINT64_C(1503914060200516822),
+      UINT64_C(0),
+      UINT64_C(1152921504606846976),
+  };
+
+  // ell - 1 = 2² * t
+  constexpr static uint32_t kTwoAdicity = 2;
+
+  constexpr static BigInt<4> kTrace = {
+      UINT64_C(10809932984304366843),
+      UINT64_C(375978515050129205),
+      UINT64_C(0),
+      UINT64_C(288230376151711744),
+  };
+
+  constexpr static bool kHasTwoAdicRootOfUnity = true;
+  constexpr static bool kHasLargeSubgroupRootOfUnity = false;
+};
+
+struct FrConfig : public FrBaseConfig {
+  constexpr static bool kUseMontgomery = false;
+
+  using StdConfig = FrConfig;
+
+  constexpr static BigInt<4> kOne = 1;
+
+  constexpr static BigInt<4> kTwoAdicRootOfUnity = {
+      UINT64_C(13729071593655502804),
+      UINT64_C(1076455226544653310),
+      UINT64_C(9024489490286232186),
+      UINT64_C(669474010940670439),
+  };
+};
+
+struct FrMontConfig : public FrBaseConfig {
+  constexpr static bool kUseMontgomery = true;
+
+  using StdConfig = FrConfig;
+
+  // R² mod ell
+  constexpr static BigInt<4> kRSquared = {
+      UINT64_C(11819153939886771969),
+      UINT64_C(14991950615390032711),
+      UINT64_C(14910419812499177061),
+      UINT64_C(259310039853996605),
+  };
+  // -ell⁻¹ mod 2²⁶⁴
+  constexpr static uint64_t kNPrime = UINT64_C(15183074304973897243);
+
+  // R mod ell
+  constexpr static BigInt<4> kOne = {
+      UINT64_C(15486807595281847581),
+      UINT64_C(14334777244411350896),
+      UINT64_C(18446744073709551614),
+      UINT64_C(1152921504606846975),
+  };
+
+  constexpr static BigInt<4> kTwoAdicRootOfUnity = {
+      UINT64_C(8969215743819189885),
+      UINT64_C(5516037659391044808),
+      UINT64_C(15508184678381615533),
+      UINT64_C(385507852950656554),
+  };
+};
+
+using Fr = PrimeField<FrConfig>;
+using FrMont = PrimeField<FrMontConfig>;
+
+}  // namespace zk_dtypes::curve25519
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_CURVE25519_FR_H_

--- a/zk_dtypes/include/elliptic_curve/twisted_edwards/affine_point.h
+++ b/zk_dtypes/include/elliptic_curve/twisted_edwards/affine_point.h
@@ -1,0 +1,97 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_TWISTED_EDWARDS_AFFINE_POINT_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_TWISTED_EDWARDS_AFFINE_POINT_H_
+
+#include <array>
+#include <type_traits>
+
+#include "zk_dtypes/include/elliptic_curve/twisted_edwards/affine_point_operation.h"
+#include "zk_dtypes/include/elliptic_curve/twisted_edwards/point_base.h"
+#include "zk_dtypes/include/elliptic_curve/twisted_edwards/te_curve.h"
+#include "zk_dtypes/include/geometry/curve_type.h"
+#include "zk_dtypes/include/geometry/point_declarations.h"
+#include "zk_dtypes/include/scalar_mul.h"
+
+namespace zk_dtypes {
+
+template <typename _Curve>
+class AffinePoint<_Curve,
+                  std::enable_if_t<_Curve::kType == CurveType::kTwistedEdwards>>
+    final : public TePointBase<AffinePoint<_Curve>>,
+            public AffinePointOperation<AffinePoint<_Curve>> {
+ public:
+  using Curve = _Curve;
+  using BaseField = typename Curve::BaseField;
+  using ScalarField = typename Curve::ScalarField;
+  using StdType =
+      AffinePoint<TwistedEdwardsCurve<typename Curve::Config::StdConfig>>;
+
+  using ExtendedPoint = zk_dtypes::ExtendedPoint<Curve>;
+
+  constexpr static bool kUseMontgomery = Curve::kUseMontgomery;
+  constexpr static size_t kByteWidth = BaseField::kByteWidth * 2;
+  constexpr static size_t kBitWidth = BaseField::kBitWidth * 2;
+
+  // Identity element for twisted Edwards: (0, 1).
+  constexpr AffinePoint() : AffinePoint(BaseField::Zero(), BaseField::One()) {}
+  template <typename T, std::enable_if_t<
+                            std::is_constructible_v<ScalarField, T>>* = nullptr>
+  constexpr AffinePoint(T value) : AffinePoint(ScalarField(value)) {}
+  constexpr AffinePoint(ScalarField value) {
+    AffinePoint point =
+        (AffinePoint::Generator().ToExtended() * value).ToAffine();
+    this->coords_ = point.coords_;
+  }
+  constexpr AffinePoint(const std::array<BaseField, 2>& coords)
+      : TePointBase<AffinePoint<_Curve>>(coords) {}
+  constexpr AffinePoint(const BaseField& x, const BaseField& y)
+      : TePointBase<AffinePoint<_Curve>>({x, y}) {}
+
+  // Identity element for twisted Edwards: (0, 1).
+  constexpr static AffinePoint Zero() { return AffinePoint(); }
+
+  constexpr static AffinePoint One() { return Generator(); }
+
+  constexpr static AffinePoint Generator() {
+    return {Curve::Config::kX, Curve::Config::kY};
+  }
+
+  constexpr static AffinePoint Random() {
+    return ExtendedPoint::Random().ToAffine();
+  }
+
+  constexpr const BaseField& x() const { return this->coords_[0]; }
+  constexpr const BaseField& y() const { return this->coords_[1]; }
+
+  constexpr ExtendedPoint operator*(const ScalarField& v) const {
+    if constexpr (kUseMontgomery) {
+      return ScalarMul(this->ToExtended(), v.MontReduce().value());
+    } else {
+      return ScalarMul(this->ToExtended(), v.value());
+    }
+  }
+
+  template <typename Curve2 = Curve,
+            std::enable_if_t<Curve2::kUseMontgomery>* = nullptr>
+  constexpr StdType MontReduce() const {
+    return {x().MontReduce(), y().MontReduce()};
+  }
+};
+
+}  // namespace zk_dtypes
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_TWISTED_EDWARDS_AFFINE_POINT_H_

--- a/zk_dtypes/include/elliptic_curve/twisted_edwards/affine_point_operation.h
+++ b/zk_dtypes/include/elliptic_curve/twisted_edwards/affine_point_operation.h
@@ -1,0 +1,160 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_TWISTED_EDWARDS_AFFINE_POINT_OPERATION_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_TWISTED_EDWARDS_AFFINE_POINT_OPERATION_H_
+
+#include <array>
+#include <type_traits>
+
+#include "zk_dtypes/include/geometry/curve_type.h"
+#include "zk_dtypes/include/geometry/point_traits.h"
+
+namespace zk_dtypes {
+
+// CRTP operation base for AffinePoint on a twisted Edwards curve. Mirrors the
+// short_weierstrass AffinePointOperation specialization but uses the unified
+// (complete) twisted Edwards addition formula
+//   x3 = (x1 * y2 + x2 * y1) / (1 + d * x1 * x2 * y1 * y2)
+//   y3 = (y1 * y2 - a * x1 * x2) / (1 - d * x1 * x2 * y1 * y2)
+// which is valid for ALL pairs of points (including the identity and inverses)
+// when the curve has prime-order subgroup with d a non-square — true for
+// Ed25519. There is therefore no need for IsZero / equality branching as in
+// the short Weierstrass formulas.
+template <typename AffinePoint>
+class AffinePointOperation<AffinePoint,
+                           std::enable_if_t<PointTraits<AffinePoint>::kType ==
+                                            CurveType::kTwistedEdwards>> {
+ public:
+  using ExtendedPoint = typename PointTraits<AffinePoint>::ExtendedPoint;
+  using BaseField = typename PointTraits<AffinePoint>::BaseField;
+
+  constexpr ExtendedPoint operator+(const AffinePoint& other) const {
+    return AddToExtended(other);
+  }
+
+  constexpr ExtendedPoint AddToExtended(const AffinePoint& other) const {
+    return DoAddToExtended(other);
+  }
+
+  constexpr ExtendedPoint operator+(const ExtendedPoint& other) const {
+    return other + static_cast<const AffinePoint&>(*this);
+  }
+
+  constexpr ExtendedPoint operator-(const AffinePoint& other) const {
+    return operator+(-other);
+  }
+
+  constexpr ExtendedPoint operator-(const ExtendedPoint& other) const {
+    return operator+(-other);
+  }
+
+  // For twisted Edwards: -P = (-x, y).
+  constexpr AffinePoint operator-() const {
+    const std::array<BaseField, 2>& p1 =
+        static_cast<const AffinePoint&>(*this).ToCoords();
+    std::array<BaseField, 2> p2;
+    p2[0] = -p1[0];
+    p2[1] = p1[1];
+    return static_cast<const AffinePoint&>(*this).FromCoords(p2);
+  }
+
+  constexpr ExtendedPoint Double() const { return DoubleToExtended(); }
+
+  constexpr ExtendedPoint DoubleToExtended() const {
+    return ToExtended().Double();
+  }
+
+  constexpr auto operator==(const AffinePoint& other) const {
+    const std::array<BaseField, 2>& p1 =
+        static_cast<const AffinePoint&>(*this).ToCoords();
+    const std::array<BaseField, 2>& p2 =
+        static_cast<const AffinePoint&>(other).ToCoords();
+    auto cf = static_cast<const AffinePoint&>(*this).GetCFOperation();
+    return cf.And(cf.Equal(p1[0], p2[0]), cf.Equal(p1[1], p2[1]));
+  }
+
+  constexpr auto operator!=(const AffinePoint& other) const {
+    auto cf = static_cast<const AffinePoint&>(*this).GetCFOperation();
+    return cf.Not(operator==(other));
+  }
+
+  // Identity element of the twisted Edwards group is (0, 1), not (0, 0).
+  constexpr auto IsZero() const {
+    const std::array<BaseField, 2>& p =
+        static_cast<const AffinePoint&>(*this).ToCoords();
+    auto cf = static_cast<const AffinePoint&>(*this).GetCFOperation();
+    BaseField zero = p[0].CreateConst(0);
+    BaseField one = p[0].CreateConst(1);
+    return cf.And(cf.Equal(p[0], zero), cf.Equal(p[1], one));
+  }
+
+  constexpr auto IsOne() const {
+    const std::array<BaseField, 2>& p =
+        static_cast<const AffinePoint&>(*this).ToCoords();
+    const BaseField& gx = static_cast<const AffinePoint&>(*this).GetX();
+    const BaseField& gy = static_cast<const AffinePoint&>(*this).GetY();
+    auto cf = static_cast<const AffinePoint&>(*this).GetCFOperation();
+    return cf.And(cf.Equal(p[0], gx), cf.Equal(p[1], gy));
+  }
+
+  // Affine -> Extended: (x, y) -> (x, y, 1, x*y).
+  constexpr ExtendedPoint ToExtended() const {
+    const std::array<BaseField, 2>& p =
+        static_cast<const AffinePoint&>(*this).ToCoords();
+    BaseField one = p[0].CreateConst(1);
+    return static_cast<const AffinePoint&>(*this).MaybeConvertToExtended(
+        static_cast<const AffinePoint&>(*this).CreateExtendedPoint(
+            std::array<BaseField, 4>{p[0], p[1], one, p[0] * p[1]}));
+  }
+
+ private:
+  // Unified affine addition. Two field inversions; only used for testing /
+  // golden checks. Production code should prefer the extended-coordinate path.
+  constexpr ExtendedPoint DoAddToExtended(const AffinePoint& other) const {
+    const std::array<BaseField, 2>& p1 =
+        static_cast<const AffinePoint&>(*this).ToCoords();
+    const std::array<BaseField, 2>& p2 =
+        static_cast<const AffinePoint&>(other).ToCoords();
+    const BaseField& x1 = p1[0];
+    const BaseField& y1 = p1[1];
+    const BaseField& x2 = p2[0];
+    const BaseField& y2 = p2[1];
+    BaseField a = static_cast<const AffinePoint&>(*this).GetA();
+    BaseField d = static_cast<const AffinePoint&>(*this).GetD();
+
+    BaseField x1y2 = x1 * y2;
+    BaseField y1x2 = y1 * x2;
+    BaseField y1y2 = y1 * y2;
+    BaseField x1x2 = x1 * x2;
+    BaseField dxxyy = d * x1x2 * y1y2;
+    BaseField one = x1.CreateConst(1);
+    BaseField num_x = x1y2 + y1x2;
+    BaseField num_y = y1y2 - a * x1x2;
+    BaseField den_x = (one + dxxyy).Inverse();
+    BaseField den_y = (one - dxxyy).Inverse();
+    BaseField x3 = num_x * den_x;
+    BaseField y3 = num_y * den_y;
+    BaseField z3 = one;
+    BaseField t3 = x3 * y3;
+    return static_cast<const AffinePoint&>(*this).MaybeConvertToExtended(
+        static_cast<const AffinePoint&>(*this).CreateExtendedPoint(
+            std::array<BaseField, 4>{x3, y3, z3, t3}));
+  }
+};
+
+}  // namespace zk_dtypes
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_TWISTED_EDWARDS_AFFINE_POINT_OPERATION_H_

--- a/zk_dtypes/include/elliptic_curve/twisted_edwards/extended_point.h
+++ b/zk_dtypes/include/elliptic_curve/twisted_edwards/extended_point.h
@@ -1,0 +1,140 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_TWISTED_EDWARDS_EXTENDED_POINT_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_TWISTED_EDWARDS_EXTENDED_POINT_H_
+
+#include <array>
+#include <type_traits>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/strings/substitute.h"
+
+#include "zk_dtypes/include/batch_inverse.h"
+#include "zk_dtypes/include/elliptic_curve/twisted_edwards/extended_point_operation.h"
+#include "zk_dtypes/include/elliptic_curve/twisted_edwards/point_base.h"
+#include "zk_dtypes/include/elliptic_curve/twisted_edwards/te_curve.h"
+#include "zk_dtypes/include/geometry/curve_type.h"
+#include "zk_dtypes/include/geometry/point_declarations.h"
+#include "zk_dtypes/include/scalar_mul.h"
+#include "zk_dtypes/include/template_util.h"
+
+namespace zk_dtypes {
+
+template <typename _Curve>
+class ExtendedPoint<
+    _Curve, std::enable_if_t<_Curve::kType == CurveType::kTwistedEdwards>>
+    final : public TePointBase<ExtendedPoint<_Curve>>,
+            public ExtendedPointOperation<ExtendedPoint<_Curve>> {
+ public:
+  using Curve = _Curve;
+  using BaseField = typename Curve::BaseField;
+  using ScalarField = typename Curve::ScalarField;
+  using StdType =
+      ExtendedPoint<TwistedEdwardsCurve<typename Curve::Config::StdConfig>>;
+
+  using AffinePoint = zk_dtypes::AffinePoint<Curve>;
+
+  constexpr static bool kUseMontgomery = Curve::kUseMontgomery;
+  constexpr static size_t kByteWidth = BaseField::kByteWidth * 4;
+  constexpr static size_t kBitWidth = BaseField::kBitWidth * 4;
+
+  // Identity element for twisted Edwards in extended coords: (0, 1, 1, 0).
+  constexpr ExtendedPoint()
+      : ExtendedPoint(BaseField::Zero(), BaseField::One(), BaseField::One(),
+                      BaseField::Zero()) {}
+  template <typename T, std::enable_if_t<
+                            std::is_constructible_v<ScalarField, T>>* = nullptr>
+  constexpr ExtendedPoint(T value) : ExtendedPoint(ScalarField(value)) {}
+  constexpr ExtendedPoint(ScalarField value) {
+    ExtendedPoint point = ExtendedPoint::Generator() * value;
+    this->coords_ = point.coords_;
+  }
+  constexpr ExtendedPoint(const std::array<BaseField, 4>& coords)
+      : TePointBase<ExtendedPoint<_Curve>>(coords) {}
+  constexpr ExtendedPoint(const BaseField& x, const BaseField& y,
+                          const BaseField& z, const BaseField& t)
+      : TePointBase<ExtendedPoint<_Curve>>({x, y, z, t}) {}
+
+  // Identity: (0, 1, 1, 0).
+  constexpr static ExtendedPoint Zero() { return ExtendedPoint(); }
+
+  constexpr static ExtendedPoint One() { return Generator(); }
+
+  constexpr static ExtendedPoint Generator() {
+    return {Curve::Config::kX, Curve::Config::kY, BaseField::One(),
+            Curve::Config::kX * Curve::Config::kY};
+  }
+
+  constexpr static ExtendedPoint Random() {
+    return ScalarField::Random() * Generator();
+  }
+
+  constexpr const BaseField& x() const { return this->coords_[0]; }
+  constexpr const BaseField& y() const { return this->coords_[1]; }
+  constexpr const BaseField& z() const { return this->coords_[2]; }
+  constexpr const BaseField& t() const { return this->coords_[3]; }
+
+  constexpr ExtendedPoint operator*(const ScalarField& v) const {
+    if constexpr (kUseMontgomery) {
+      return ScalarMul(*this, v.MontReduce().value());
+    } else {
+      return ScalarMul(*this, v.value());
+    }
+  }
+
+  constexpr ExtendedPoint& operator*=(const ScalarField& v) {
+    return *this = operator*(v);
+  }
+
+  template <typename Curve2 = Curve,
+            std::enable_if_t<Curve2::kUseMontgomery>* = nullptr>
+  constexpr StdType MontReduce() const {
+    return {x().MontReduce(), y().MontReduce(), z().MontReduce(),
+            t().MontReduce()};
+  }
+
+  template <typename ExtendedContainer, typename AffineContainer>
+  static absl::Status BatchToAffine(const ExtendedContainer& extended_points,
+                                    AffineContainer* affine_points) {
+    if constexpr (internal::has_resize_v<AffineContainer>) {
+      affine_points->resize(std::size(extended_points));
+    } else {
+      if (std::size(extended_points) != std::size(*affine_points)) {
+        return absl::InvalidArgumentError(absl::Substitute(
+            "size do not match $0 vs $1", std::size(extended_points),
+            std::size(*affine_points)));
+      }
+    }
+    std::vector<BaseField> z_inverses;
+    z_inverses.reserve(std::size(extended_points));
+    for (const ExtendedPoint& point : extended_points) {
+      z_inverses.push_back(point.z());
+    }
+    absl::Status status = BatchInverse(z_inverses, &z_inverses);
+    if (!status.ok()) return status;
+    for (size_t i = 0; i < std::size(*affine_points); ++i) {
+      const BaseField& z_inv = z_inverses[i];
+      (*affine_points)[i] = {extended_points[i].x() * z_inv,
+                             extended_points[i].y() * z_inv};
+    }
+    return absl::OkStatus();
+  }
+};
+
+}  // namespace zk_dtypes
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_TWISTED_EDWARDS_EXTENDED_POINT_H_

--- a/zk_dtypes/include/elliptic_curve/twisted_edwards/extended_point.h
+++ b/zk_dtypes/include/elliptic_curve/twisted_edwards/extended_point.h
@@ -115,7 +115,7 @@ class ExtendedPoint<
     } else {
       if (std::size(extended_points) != std::size(*affine_points)) {
         return absl::InvalidArgumentError(absl::Substitute(
-            "size do not match $0 vs $1", std::size(extended_points),
+            "sizes do not match $0 vs $1", std::size(extended_points),
             std::size(*affine_points)));
       }
     }

--- a/zk_dtypes/include/elliptic_curve/twisted_edwards/extended_point_operation.h
+++ b/zk_dtypes/include/elliptic_curve/twisted_edwards/extended_point_operation.h
@@ -1,0 +1,198 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_TWISTED_EDWARDS_EXTENDED_POINT_OPERATION_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_TWISTED_EDWARDS_EXTENDED_POINT_OPERATION_H_
+
+#include <array>
+#include <type_traits>
+
+#include "zk_dtypes/include/geometry/curve_type.h"
+#include "zk_dtypes/include/geometry/point_traits.h"
+
+namespace zk_dtypes {
+
+// Extended-coordinate operations for twisted Edwards curves using
+// Hisil-Wong-Carter-Dawson (HWCD-2008) formulas. Extended coordinates
+// represent a point as (X : Y : Z : T) with the invariant T = X * Y / Z
+// and affine coordinates recovered as x = X / Z, y = Y / Z.
+//
+// Reference formulas:
+//   https://www.hyperelliptic.org/EFD/g1p/auto-twisted-extended.html
+//
+// The addition formula is unified (works for all input pairs including
+// identity and inverses) when the curve has d non-square, which is the case
+// for all standard twisted Edwards curves (Ed25519, etc.).
+template <typename Point>
+class ExtendedPointOperation<
+    Point,
+    std::enable_if_t<PointTraits<Point>::kType == CurveType::kTwistedEdwards>> {
+ public:
+  using AffinePoint = typename PointTraits<Point>::AffinePoint;
+  using ExtendedPoint = typename PointTraits<Point>::ExtendedPoint;
+  using BaseField = typename PointTraits<Point>::BaseField;
+
+  // Unified addition.
+  // https://www.hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-unified-2008-hcd
+  constexpr ExtendedPoint operator+(const ExtendedPoint& other) const {
+    return DoAdd(other);
+  }
+
+  // Mixed addition: Affine -> Extended -> add.
+  constexpr ExtendedPoint operator+(const AffinePoint& other) const {
+    return DoAdd(other.ToExtended());
+  }
+
+  constexpr ExtendedPoint operator-(const ExtendedPoint& other) const {
+    return operator+(-other);
+  }
+
+  constexpr ExtendedPoint operator-(const AffinePoint& other) const {
+    return operator+(-other);
+  }
+
+  // For twisted Edwards: -(X, Y, Z, T) = (-X, Y, Z, -T).
+  constexpr ExtendedPoint operator-() const {
+    const std::array<BaseField, 4>& p1 =
+        static_cast<const ExtendedPoint&>(*this).ToCoords();
+    return static_cast<const ExtendedPoint&>(*this).FromCoords(
+        {-p1[0], p1[1], p1[2], -p1[3]});
+  }
+
+  // Dedicated doubling formula (faster than adding to self).
+  // https://www.hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#doubling-dbl-2008-hwcd
+  constexpr ExtendedPoint Double() const {
+    const std::array<BaseField, 4>& p1 =
+        static_cast<const ExtendedPoint&>(*this).ToCoords();
+    const BaseField& x1 = p1[0];
+    const BaseField& y1 = p1[1];
+    const BaseField& z1 = p1[2];
+    BaseField a = static_cast<const ExtendedPoint&>(*this).GetA();
+
+    // A = X1²
+    BaseField aa = x1.Square();
+    // B = Y1²
+    BaseField bb = y1.Square();
+    // C = 2 * Z1²
+    BaseField cc = z1.Square().Double();
+    // D = a * A
+    BaseField dd = a * aa;
+    // E = (X1 + Y1)² - A - B
+    BaseField ee = (x1 + y1).Square() - aa - bb;
+    // G = D + B
+    BaseField gg = dd + bb;
+    // F = G - C
+    BaseField ff = gg - cc;
+    // H = D - B
+    BaseField hh = dd - bb;
+    // X3 = E * F
+    BaseField x3 = ee * ff;
+    // Y3 = G * H
+    BaseField y3 = gg * hh;
+    // T3 = E * H
+    BaseField t3 = ee * hh;
+    // Z3 = F * G
+    BaseField z3 = ff * gg;
+
+    return static_cast<const ExtendedPoint&>(*this).MaybeConvertToExtended(
+        static_cast<const ExtendedPoint&>(*this).CreateExtendedPoint(
+            {x3, y3, z3, t3}));
+  }
+
+  constexpr auto operator==(const ExtendedPoint& other) const {
+    // Two projective points are equal iff X1 * Z2 == X2 * Z1 and
+    // Y1 * Z2 == Y2 * Z1.
+    const std::array<BaseField, 4>& p1 =
+        static_cast<const ExtendedPoint&>(*this).ToCoords();
+    const std::array<BaseField, 4>& p2 =
+        static_cast<const ExtendedPoint&>(other).ToCoords();
+    auto cf = static_cast<const ExtendedPoint&>(*this).GetCFOperation();
+    return cf.And(cf.Equal(p1[0] * p2[2], p2[0] * p1[2]),
+                  cf.Equal(p1[1] * p2[2], p2[1] * p1[2]));
+  }
+
+  constexpr auto operator!=(const ExtendedPoint& other) const {
+    auto cf = static_cast<const ExtendedPoint&>(*this).GetCFOperation();
+    return cf.Not(operator==(other));
+  }
+
+  // Identity in extended coords: (0, 1, 1, 0).
+  constexpr auto IsZero() const {
+    return static_cast<const ExtendedPoint&>(*this) == ExtendedPoint::Zero();
+  }
+
+  // Extended -> Affine: x = X / Z, y = Y / Z.
+  constexpr AffinePoint ToAffine() const {
+    const std::array<BaseField, 4>& p =
+        static_cast<const ExtendedPoint&>(*this).ToCoords();
+    BaseField z_inv = p[2].Inverse();
+    return static_cast<const ExtendedPoint&>(*this).MaybeConvertToAffine(
+        static_cast<const ExtendedPoint&>(*this).CreateAffinePoint(
+            {p[0] * z_inv, p[1] * z_inv}));
+  }
+
+ private:
+  // Unified addition.
+  // https://www.hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-unified-2008-hcd
+  constexpr ExtendedPoint DoAdd(const ExtendedPoint& other) const {
+    const std::array<BaseField, 4>& p1 =
+        static_cast<const ExtendedPoint&>(*this).ToCoords();
+    const std::array<BaseField, 4>& p2 =
+        static_cast<const ExtendedPoint&>(other).ToCoords();
+    const BaseField& x1 = p1[0];
+    const BaseField& y1 = p1[1];
+    const BaseField& z1 = p1[2];
+    const BaseField& t1 = p1[3];
+    const BaseField& x2 = p2[0];
+    const BaseField& y2 = p2[1];
+    const BaseField& z2 = p2[2];
+    const BaseField& t2 = p2[3];
+    BaseField a = static_cast<const ExtendedPoint&>(*this).GetA();
+    BaseField d = static_cast<const ExtendedPoint&>(*this).GetD();
+
+    // A = X1 * X2
+    BaseField aa = x1 * x2;
+    // B = Y1 * Y2
+    BaseField bb = y1 * y2;
+    // C = T1 * d * T2
+    BaseField cc = t1 * d * t2;
+    // D = Z1 * Z2
+    BaseField dd = z1 * z2;
+    // E = (X1 + Y1) * (X2 + Y2) - A - B
+    BaseField ee = (x1 + y1) * (x2 + y2) - aa - bb;
+    // F = D - C
+    BaseField ff = dd - cc;
+    // G = D + C
+    BaseField gg = dd + cc;
+    // H = B - a * A
+    BaseField hh = bb - a * aa;
+    // X3 = E * F
+    BaseField x3 = ee * ff;
+    // Y3 = G * H
+    BaseField y3 = gg * hh;
+    // T3 = E * H
+    BaseField t3 = ee * hh;
+    // Z3 = F * G
+    BaseField z3 = ff * gg;
+
+    return static_cast<const ExtendedPoint&>(*this).MaybeConvertToExtended(
+        static_cast<const ExtendedPoint&>(*this).CreateExtendedPoint(
+            {x3, y3, z3, t3}));
+  }
+};
+
+}  // namespace zk_dtypes
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_TWISTED_EDWARDS_EXTENDED_POINT_OPERATION_H_

--- a/zk_dtypes/include/elliptic_curve/twisted_edwards/point_base.h
+++ b/zk_dtypes/include/elliptic_curve/twisted_edwards/point_base.h
@@ -1,0 +1,101 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_TWISTED_EDWARDS_POINT_BASE_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_TWISTED_EDWARDS_POINT_BASE_H_
+
+#include <array>
+#include <string>
+#include <utility>
+
+#include "zk_dtypes/include/control_flow_operation.h"
+#include "zk_dtypes/include/geometry/point_traits.h"
+#include "zk_dtypes/include/str_join.h"
+
+namespace zk_dtypes {
+
+// CRTP base for twisted Edwards point types. Mirrors
+// short_weierstrass/point_base.h but exposes only the AffinePoint /
+// ExtendedPoint hooks because the twisted Edwards model has no Jacobian or
+// XYZZ representations.
+template <typename Derived>
+class TePointBase {
+ public:
+  constexpr static size_t N = PointTraits<Derived>::kNumCoords;
+
+  using Curve = typename PointTraits<Derived>::Curve;
+  using AffinePoint = typename PointTraits<Derived>::AffinePoint;
+  using ExtendedPoint = typename PointTraits<Derived>::ExtendedPoint;
+  using BaseField = typename Curve::BaseField;
+
+  constexpr TePointBase() = default;
+  constexpr TePointBase(const std::array<BaseField, N>& coords)
+      : coords_(coords) {}
+
+  constexpr const BaseField& operator[](size_t i) const { return coords_[i]; }
+
+  std::string ToString() const {
+    return StrJoin(
+        coords_,
+        [](std::ostream& os, const BaseField& value) {
+          os << value.ToString();
+        },
+        ", ", "(", ")");
+  }
+  std::string ToHexString(bool pad_zero = false) const {
+    return StrJoin(
+        coords_,
+        [pad_zero](std::ostream& os, const BaseField& value) {
+          os << value.ToHexString(pad_zero);
+        },
+        ", ", "(", ")");
+  }
+
+  constexpr Derived FromCoords(const std::array<BaseField, N>& coords) const {
+    return Derived(coords);
+  }
+  constexpr const std::array<BaseField, N>& ToCoords() const { return coords_; }
+
+  // Curve constants `a` and `d` for the twisted Edwards equation
+  // a * x² + y² = 1 + d * x² * y², plus the generator coordinates Gx/Gy.
+  constexpr const BaseField& GetA() const { return Curve::Config::kA; }
+  constexpr const BaseField& GetD() const { return Curve::Config::kD; }
+  constexpr const BaseField& GetX() const { return Curve::Config::kX; }
+  constexpr const BaseField& GetY() const { return Curve::Config::kY; }
+  constexpr ControlFlowOperation<bool> GetCFOperation() const { return {}; }
+
+  constexpr AffinePoint CreateAffinePoint(
+      const std::array<BaseField, 2>& coords) const {
+    return AffinePoint(coords);
+  }
+  constexpr ExtendedPoint CreateExtendedPoint(
+      const std::array<BaseField, 4>& coords) const {
+    return ExtendedPoint(coords);
+  }
+  constexpr AffinePoint&& MaybeConvertToAffine(AffinePoint&& point) const {
+    return std::move(point);
+  }
+  constexpr ExtendedPoint&& MaybeConvertToExtended(
+      ExtendedPoint&& point) const {
+    return std::move(point);
+  }
+
+ protected:
+  std::array<BaseField, N> coords_;
+};
+
+}  // namespace zk_dtypes
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_TWISTED_EDWARDS_POINT_BASE_H_

--- a/zk_dtypes/include/elliptic_curve/twisted_edwards/te_curve.h
+++ b/zk_dtypes/include/elliptic_curve/twisted_edwards/te_curve.h
@@ -1,0 +1,45 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_TWISTED_EDWARDS_TE_CURVE_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_TWISTED_EDWARDS_TE_CURVE_H_
+
+#include "zk_dtypes/include/geometry/curve_type.h"
+#include "zk_dtypes/include/geometry/point_declarations.h"
+
+namespace zk_dtypes {
+
+// Curve for Twisted Edwards model.
+// See https://www.hyperelliptic.org/EFD/g1p/auto-twisted.html for details.
+// This config represents a * x² + y² = 1 + d * x² * y², where a and d are
+// non-zero constants. The standard untwisted Edwards form is recovered when
+// a = 1, while Ed25519 uses a = -1.
+template <typename _Config>
+class TwistedEdwardsCurve {
+ public:
+  using Config = _Config;
+
+  using BaseField = typename Config::BaseField;
+  using ScalarField = typename Config::ScalarField;
+  using AffinePoint = zk_dtypes::AffinePoint<TwistedEdwardsCurve<Config>>;
+  using ExtendedPoint = zk_dtypes::ExtendedPoint<TwistedEdwardsCurve<Config>>;
+
+  constexpr static bool kUseMontgomery = Config::kUseMontgomery;
+  constexpr static CurveType kType = CurveType::kTwistedEdwards;
+};
+
+}  // namespace zk_dtypes
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_TWISTED_EDWARDS_TE_CURVE_H_

--- a/zk_dtypes/include/elliptic_curve/twisted_edwards/test/te_curve_config.h
+++ b/zk_dtypes/include/elliptic_curve/twisted_edwards/test/te_curve_config.h
@@ -1,0 +1,85 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_TWISTED_EDWARDS_TEST_TE_CURVE_CONFIG_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_TWISTED_EDWARDS_TEST_TE_CURVE_CONFIG_H_
+
+#include "zk_dtypes/include/elliptic_curve/twisted_edwards/affine_point.h"
+#include "zk_dtypes/include/elliptic_curve/twisted_edwards/extended_point.h"
+#include "zk_dtypes/include/elliptic_curve/twisted_edwards/te_curve.h"
+#include "zk_dtypes/include/field/small_prime_field.h"
+
+namespace zk_dtypes::test {
+
+// Small field F_13 for testing twisted Edwards curves.
+struct TeTestFqBaseConfig {
+  constexpr static size_t kStorageBits = 8;
+  constexpr static size_t kModulusBits = 4;
+  constexpr static uint8_t kModulus = 13;
+
+  constexpr static uint32_t kTwoAdicity = 2;
+  constexpr static uint8_t kTrace = 3;  // (13-1)/4 = 3
+
+  constexpr static bool kHasTwoAdicRootOfUnity = true;
+  constexpr static bool kHasLargeSubgroupRootOfUnity = false;
+};
+
+struct TeTestFqConfig : public TeTestFqBaseConfig {
+  constexpr static bool kUseMontgomery = false;
+  constexpr static bool kUseBarrett = false;
+
+  using StdConfig = TeTestFqConfig;
+
+  constexpr static uint8_t kOne = 1;
+  constexpr static uint8_t kTwoAdicRootOfUnity = 5;  // 5^2 = 25 = -1 mod 13
+};
+
+using TeTestFq = PrimeField<TeTestFqConfig>;
+
+// Twisted Edwards curve over F_13: -x^2 + y^2 = 1 + 2*x^2*y^2
+// Has 16 points (cofactor 16 / prime subgroup). Generator: (2, 4).
+//
+// Scalar multiples of G = (2, 4):
+//   0*G = (0, 1)    [identity]
+//   1*G = (2, 4)
+//   2*G = (10, 11)
+//   3*G = (6, 10)
+//   4*G = (8, 0)
+//   5*G = (6, 3)
+//   6*G = (10, 2)
+//   7*G = (2, 9)
+//   8*G = (0, 12)   [-identity = (0, -1)]
+//   ...
+//  15*G = (11, 4)
+class TeTestCurveConfig {
+ public:
+  constexpr static bool kUseMontgomery = false;
+  using StdConfig = TeTestCurveConfig;
+  using BaseField = TeTestFq;
+  using ScalarField = TeTestFq;
+
+  constexpr static BaseField kA = 12;  // -1 mod 13
+  constexpr static BaseField kD = 2;   // non-square mod 13
+  constexpr static BaseField kX = 2;   // Generator x
+  constexpr static BaseField kY = 4;   // Generator y
+};
+
+using TeTestCurve = TwistedEdwardsCurve<TeTestCurveConfig>;
+using TeAffinePoint = AffinePoint<TeTestCurve>;
+using TeExtendedPoint = ExtendedPoint<TeTestCurve>;
+
+}  // namespace zk_dtypes::test
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_TWISTED_EDWARDS_TEST_TE_CURVE_CONFIG_H_

--- a/zk_dtypes/include/geometry/curve_type.h
+++ b/zk_dtypes/include/geometry/curve_type.h
@@ -20,6 +20,7 @@ namespace zk_dtypes {
 
 enum class CurveType {
   kShortWeierstrass,
+  kTwistedEdwards,
 };
 
 }  // namespace zk_dtypes

--- a/zk_dtypes/include/geometry/point_declarations.h
+++ b/zk_dtypes/include/geometry/point_declarations.h
@@ -17,8 +17,10 @@ limitations under the License.
 #define ZK_DTYPES_INCLUDE_GEOMETRY_POINT_DECLARATIONS_H_
 
 #include <ostream>
+#include <type_traits>
 
 #include "zk_dtypes/include/comparable_traits.h"
+#include "zk_dtypes/include/geometry/curve_type.h"
 #include "zk_dtypes/include/group/group.h"
 
 namespace zk_dtypes {
@@ -32,6 +34,9 @@ class JacobianPoint;
 template <typename Curve, typename SFINAE = void>
 class PointXyzz;
 
+template <typename Curve, typename SFINAE = void>
+class ExtendedPoint;
+
 template <typename Derived, typename SFINAE = void>
 class AffinePointOperation;
 
@@ -40,6 +45,9 @@ class JacobianPointOperation;
 
 template <typename Derived, typename SFINAE = void>
 class PointXyzzOperation;
+
+template <typename Derived, typename SFINAE = void>
+class ExtendedPointOperation;
 
 template <typename T>
 struct IsAffinePointImpl {
@@ -81,8 +89,21 @@ template <typename T>
 constexpr bool IsPointXyzz = IsPointXyzzImpl<T>::value;
 
 template <typename T>
-constexpr bool IsEcPoint =
-    IsAffinePoint<T> || IsJacobianPoint<T> || IsPointXyzz<T>;
+struct IsExtendedPointImpl {
+  constexpr static bool value = false;
+};
+
+template <typename Curve>
+struct IsExtendedPointImpl<ExtendedPoint<Curve>> {
+  constexpr static bool value = true;
+};
+
+template <typename T>
+constexpr bool IsExtendedPoint = IsExtendedPointImpl<T>::value;
+
+template <typename T>
+constexpr bool IsEcPoint = IsAffinePoint<T> || IsJacobianPoint<T> ||
+                           IsPointXyzz<T> || IsExtendedPoint<T>;
 
 template <typename T>
 struct IsAdditiveGroupImpl<T, std::enable_if_t<IsEcPoint<T>>> {
@@ -94,14 +115,27 @@ struct IsComparableImpl<T, std::enable_if_t<IsEcPoint<T>>> {
   constexpr static bool value = false;
 };
 
-template <typename T>
+template <typename T, typename SFINAE = void>
 struct AddResult {
   using Type = T;
 };
 
 template <typename Curve>
-struct AddResult<AffinePoint<Curve>> {
+struct AddResult<
+    AffinePoint<Curve>,
+    std::enable_if_t<Curve::kType == CurveType::kShortWeierstrass>> {
   using Type = JacobianPoint<Curve>;
+};
+
+template <typename Curve>
+struct AddResult<AffinePoint<Curve>,
+                 std::enable_if_t<Curve::kType == CurveType::kTwistedEdwards>> {
+  using Type = ExtendedPoint<Curve>;
+};
+
+template <typename Curve>
+struct AddResult<ExtendedPoint<Curve>> {
+  using Type = ExtendedPoint<Curve>;
 };
 
 template <typename ScalarField, typename Curve,
@@ -125,6 +159,13 @@ auto operator*(const ScalarField& v, const PointXyzz<Curve>& point) {
   return point * v;
 }
 
+template <typename ScalarField, typename Curve,
+          std::enable_if_t<std::is_same_v<
+              ScalarField, typename Curve::ScalarField>>* = nullptr>
+auto operator*(const ScalarField& v, const ExtendedPoint<Curve>& point) {
+  return point * v;
+}
+
 template <typename Curve>
 std::ostream& operator<<(std::ostream& os, const AffinePoint<Curve>& point) {
   return os << point.ToString();
@@ -137,6 +178,11 @@ std::ostream& operator<<(std::ostream& os, const JacobianPoint<Curve>& point) {
 
 template <typename Curve>
 std::ostream& operator<<(std::ostream& os, const PointXyzz<Curve>& point) {
+  return os << point.ToString();
+}
+
+template <typename Curve>
+std::ostream& operator<<(std::ostream& os, const ExtendedPoint<Curve>& point) {
   return os << point.ToString();
 }
 

--- a/zk_dtypes/include/geometry/point_traits.h
+++ b/zk_dtypes/include/geometry/point_traits.h
@@ -16,16 +16,20 @@ limitations under the License.
 #ifndef ZK_DTYPES_INCLUDE_GEOMETRY_POINT_TRAITS_H_
 #define ZK_DTYPES_INCLUDE_GEOMETRY_POINT_TRAITS_H_
 
+#include <type_traits>
+
 #include "zk_dtypes/include/geometry/curve_type.h"
 #include "zk_dtypes/include/geometry/point_declarations.h"
 
 namespace zk_dtypes {
 
-template <typename Curve>
+template <typename Point, typename SFINAE = void>
 class PointTraits;
 
 template <typename _Curve>
-class PointTraits<AffinePoint<_Curve>> {
+class PointTraits<
+    AffinePoint<_Curve>,
+    std::enable_if_t<_Curve::kType == CurveType::kShortWeierstrass>> {
  public:
   using Curve = _Curve;
 
@@ -65,6 +69,36 @@ class PointTraits<PointXyzz<_Curve>> {
   using AffinePoint = zk_dtypes::AffinePoint<Curve>;
   using JacobianPoint = zk_dtypes::JacobianPoint<Curve>;
   using PointXyzz = zk_dtypes::PointXyzz<Curve>;
+  using BaseField = typename Curve::BaseField;
+  using ScalarField = typename Curve::ScalarField;
+};
+
+template <typename _Curve>
+class PointTraits<
+    AffinePoint<_Curve>,
+    std::enable_if_t<_Curve::kType == CurveType::kTwistedEdwards>> {
+ public:
+  using Curve = _Curve;
+
+  constexpr static CurveType kType = Curve::kType;
+  constexpr static size_t kNumCoords = 2;
+
+  using AffinePoint = zk_dtypes::AffinePoint<Curve>;
+  using ExtendedPoint = zk_dtypes::ExtendedPoint<Curve>;
+  using BaseField = typename Curve::BaseField;
+  using ScalarField = typename Curve::ScalarField;
+};
+
+template <typename _Curve>
+class PointTraits<ExtendedPoint<_Curve>> {
+ public:
+  using Curve = _Curve;
+
+  constexpr static CurveType kType = Curve::kType;
+  constexpr static size_t kNumCoords = 4;
+
+  using AffinePoint = zk_dtypes::AffinePoint<Curve>;
+  using ExtendedPoint = zk_dtypes::ExtendedPoint<Curve>;
   using BaseField = typename Curve::BaseField;
   using ScalarField = typename Curve::ScalarField;
 };

--- a/zk_dtypes/tests/elliptic_curve/ed25519_unittest.cc
+++ b/zk_dtypes/tests/elliptic_curve/ed25519_unittest.cc
@@ -1,0 +1,104 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "gtest/gtest.h"
+
+#include "zk_dtypes/include/elliptic_curve/curve25519/ed25519/g1.h"
+
+namespace zk_dtypes::ed25519 {
+namespace {
+
+using Ap = G1AffinePoint;
+using Ep = G1ExtendedPoint;
+using ApMont = G1AffinePointMont;
+using EpMont = G1ExtendedPointMont;
+
+TEST(Ed25519Test, IdentityIsOnCurve) {
+  Ap id = Ap::Zero();
+  EXPECT_EQ(id.x(), Fq(0));
+  EXPECT_EQ(id.y(), Fq(1));
+  EXPECT_TRUE(id.IsZero());
+}
+
+TEST(Ed25519Test, GeneratorIsOnCurve) {
+  Fq gx = G1TeCurveConfig::kX;
+  Fq gy = G1TeCurveConfig::kY;
+  Fq a = G1TeCurveConfig::kA;
+  Fq d = G1TeCurveConfig::kD;
+  Fq lhs = a * gx.Square() + gy.Square();
+  Fq rhs = Fq::One() + d * gx.Square() * gy.Square();
+  EXPECT_EQ(lhs, rhs);
+}
+
+TEST(Ed25519Test, GeneratorMontIsOnCurve) {
+  FqMont gx = G1TeCurveMontConfig::kX;
+  FqMont gy = G1TeCurveMontConfig::kY;
+  FqMont a = G1TeCurveMontConfig::kA;
+  FqMont d = G1TeCurveMontConfig::kD;
+  FqMont lhs = a * gx.Square() + gy.Square();
+  FqMont rhs = FqMont::One() + d * gx.Square() * gy.Square();
+  EXPECT_EQ(lhs, rhs);
+}
+
+TEST(Ed25519Test, IdentityAddition) {
+  Ep gen = Ep::Generator();
+  Ep zero = Ep::Zero();
+  EXPECT_EQ((gen + zero).ToAffine(), gen.ToAffine());
+  EXPECT_EQ((zero + gen).ToAffine(), gen.ToAffine());
+}
+
+TEST(Ed25519Test, InverseProperty) {
+  Ep gen = Ep::Generator();
+  Ep neg_gen = -gen;
+  Ep sum = gen + neg_gen;
+  EXPECT_TRUE(sum.IsZero());
+}
+
+TEST(Ed25519Test, DoubleEqualsAddSelf) {
+  Ep gen = Ep::Generator();
+  Ep g2_add = gen + gen;
+  Ep g2_dbl = gen.Double();
+  EXPECT_EQ(g2_add, g2_dbl);
+}
+
+TEST(Ed25519Test, AdditionAssociativity) {
+  Ep g = Ep::Generator();
+  Ep g2 = g.Double();
+  Ep g3 = g2 + g;
+  EXPECT_EQ(g3, g + g2);
+}
+
+TEST(Ed25519Test, MontNonMontConsistency) {
+  Ep g = Ep::Generator();
+  Ep g2 = g.Double();
+  Ap g2_aff = g2.ToAffine();
+
+  EpMont gm = EpMont::Generator();
+  EpMont g2m = gm.Double();
+  ApMont g2m_aff = g2m.ToAffine();
+
+  EXPECT_EQ(g2_aff.x(), g2m_aff.MontReduce().x());
+  EXPECT_EQ(g2_aff.y(), g2m_aff.MontReduce().y());
+}
+
+TEST(Ed25519Test, FourGEqualsDoubleTwice) {
+  Ep g = Ep::Generator();
+  Ep g4_via_double = g.Double().Double();
+  Ep g4_via_add = g + g + g + g;
+  EXPECT_EQ(g4_via_double, g4_via_add);
+}
+
+}  // namespace
+}  // namespace zk_dtypes::ed25519

--- a/zk_dtypes/tests/elliptic_curve/te_affine_point_unittest.cc
+++ b/zk_dtypes/tests/elliptic_curve/te_affine_point_unittest.cc
@@ -1,0 +1,109 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "gtest/gtest.h"
+
+#include "zk_dtypes/include/elliptic_curve/twisted_edwards/test/te_curve_config.h"
+
+namespace zk_dtypes::test {
+namespace {
+
+// Test curve: -x² + y² = 1 + 2*x²*y² over F_13
+// Identity: (0, 1). Generator: (2, 4). Group order: 16.
+
+TEST(TeAffinePointTest, Traits) {
+  static_assert(!IsComparable<TeAffinePoint>);
+  static_assert(IsAdditiveGroup<TeAffinePoint>);
+  static_assert(IsEcPoint<TeAffinePoint>);
+  static_assert(IsAffinePoint<TeAffinePoint>);
+  static_assert(!IsExtendedPoint<TeAffinePoint>);
+}
+
+TEST(TeAffinePointTest, Zero) {
+  // Identity on twisted Edwards is (0, 1), not (0, 0).
+  TeAffinePoint zero = TeAffinePoint::Zero();
+  EXPECT_TRUE(zero.IsZero());
+  EXPECT_EQ(zero.x(), TeTestFq(0));
+  EXPECT_EQ(zero.y(), TeTestFq(1));
+}
+
+TEST(TeAffinePointTest, Generator) {
+  TeAffinePoint gen = TeAffinePoint::Generator();
+  EXPECT_EQ(gen.x(), TeTestFq(2));
+  EXPECT_EQ(gen.y(), TeTestFq(4));
+  EXPECT_TRUE(gen.IsOne());
+}
+
+TEST(TeAffinePointTest, Equality) {
+  TeAffinePoint p(2, 4);
+  TeAffinePoint p2(10, 11);
+  EXPECT_EQ(p, p);
+  EXPECT_NE(p, p2);
+}
+
+TEST(TeAffinePointTest, Negate) {
+  // For twisted Edwards: -(x, y) = (-x, y).
+  TeAffinePoint gen(2, 4);
+  TeAffinePoint neg_gen = -gen;
+  EXPECT_EQ(neg_gen, TeAffinePoint(11, 4));  // -2 mod 13 = 11
+
+  // Identity negation: -(0, 1) = (0, 1).
+  EXPECT_EQ(-TeAffinePoint::Zero(), TeAffinePoint::Zero());
+}
+
+TEST(TeAffinePointTest, AffineAddition) {
+  TeAffinePoint g(2, 4);
+  TeExtendedPoint g2_ext = g + g;
+  TeAffinePoint g2 = g2_ext.ToAffine();
+  EXPECT_EQ(g2, TeAffinePoint(10, 11));  // 2*G
+
+  TeExtendedPoint g3_ext = g + g2_ext;
+  TeAffinePoint g3 = g3_ext.ToAffine();
+  EXPECT_EQ(g3, TeAffinePoint(6, 10));  // 3*G
+}
+
+TEST(TeAffinePointTest, AffineSubtraction) {
+  TeAffinePoint g(2, 4);
+  TeAffinePoint g2(10, 11);
+  TeAffinePoint g3(6, 10);
+  TeExtendedPoint result = g3 - g2;
+  EXPECT_EQ(result.ToAffine(), g);  // 3G - 2G = G
+}
+
+TEST(TeAffinePointTest, IdentityAddition) {
+  TeAffinePoint g(2, 4);
+  TeAffinePoint zero = TeAffinePoint::Zero();
+  // G + 0 should give G (via extended coords).
+  TeExtendedPoint result = g + zero;
+  EXPECT_EQ(result.ToAffine(), g);
+}
+
+TEST(TeAffinePointTest, ToExtended) {
+  TeAffinePoint p(2, 4);
+  TeExtendedPoint ext = p.ToExtended();
+  EXPECT_EQ(ext.x(), TeTestFq(2));
+  EXPECT_EQ(ext.y(), TeTestFq(4));
+  EXPECT_EQ(ext.z(), TeTestFq(1));
+  EXPECT_EQ(ext.t(), TeTestFq(2 * 4 % 13));  // T = x*y = 8
+}
+
+TEST(TeAffinePointTest, Double) {
+  TeAffinePoint g(2, 4);
+  TeExtendedPoint g2 = g.Double();
+  EXPECT_EQ(g2.ToAffine(), TeAffinePoint(10, 11));  // 2*G
+}
+
+}  // namespace
+}  // namespace zk_dtypes::test

--- a/zk_dtypes/tests/elliptic_curve/te_extended_point_unittest.cc
+++ b/zk_dtypes/tests/elliptic_curve/te_extended_point_unittest.cc
@@ -1,0 +1,167 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "gtest/gtest.h"
+
+#include "zk_dtypes/include/elliptic_curve/twisted_edwards/test/te_curve_config.h"
+
+namespace zk_dtypes::test {
+namespace {
+
+// Test curve: -x² + y² = 1 + 2*x²*y² over F₁₃
+// Identity (extended): (0, 1, 1, 0). Generator: (2, 4, 1, 8). Order: 16.
+
+TEST(TeExtendedPointTest, Traits) {
+  static_assert(!IsComparable<TeExtendedPoint>);
+  static_assert(IsAdditiveGroup<TeExtendedPoint>);
+  static_assert(IsEcPoint<TeExtendedPoint>);
+  static_assert(IsExtendedPoint<TeExtendedPoint>);
+  static_assert(!IsAffinePoint<TeExtendedPoint>);
+}
+
+TEST(TeExtendedPointTest, Zero) {
+  TeExtendedPoint zero = TeExtendedPoint::Zero();
+  EXPECT_TRUE(zero.IsZero());
+  EXPECT_EQ(zero.x(), TeTestFq(0));
+  EXPECT_EQ(zero.y(), TeTestFq(1));
+  EXPECT_EQ(zero.z(), TeTestFq(1));
+  EXPECT_EQ(zero.t(), TeTestFq(0));
+}
+
+TEST(TeExtendedPointTest, Generator) {
+  TeExtendedPoint gen = TeExtendedPoint::Generator();
+  EXPECT_EQ(gen.x(), TeTestFq(2));
+  EXPECT_EQ(gen.y(), TeTestFq(4));
+  EXPECT_EQ(gen.z(), TeTestFq(1));
+  EXPECT_EQ(gen.t(), TeTestFq(8));  // 2 * 4 = 8
+}
+
+TEST(TeExtendedPointTest, Negate) {
+  TeExtendedPoint gen = TeExtendedPoint::Generator();
+  TeExtendedPoint neg_gen = -gen;
+  // -(X, Y, Z, T) = (-X, Y, Z, -T)
+  EXPECT_EQ(neg_gen.x(), TeTestFq(11));  // -2 mod 13
+  EXPECT_EQ(neg_gen.y(), TeTestFq(4));
+  EXPECT_EQ(neg_gen.z(), TeTestFq(1));
+  EXPECT_EQ(neg_gen.t(), TeTestFq(5));  // -8 mod 13
+}
+
+TEST(TeExtendedPointTest, Addition) {
+  TeExtendedPoint gen = TeExtendedPoint::Generator();
+  TeExtendedPoint g2 = gen + gen;
+  EXPECT_EQ(g2.ToAffine(), TeAffinePoint(10, 11));  // 2*G
+
+  TeExtendedPoint g3 = g2 + gen;
+  EXPECT_EQ(g3.ToAffine(), TeAffinePoint(6, 10));  // 3*G
+
+  TeExtendedPoint g4 = g3 + gen;
+  EXPECT_EQ(g4.ToAffine(), TeAffinePoint(8, 0));  // 4*G
+}
+
+TEST(TeExtendedPointTest, Double) {
+  TeExtendedPoint gen = TeExtendedPoint::Generator();
+  TeExtendedPoint g2 = gen.Double();
+  EXPECT_EQ(g2.ToAffine(), TeAffinePoint(10, 11));
+
+  TeExtendedPoint g4 = g2.Double();
+  EXPECT_EQ(g4.ToAffine(), TeAffinePoint(8, 0));  // 4*G
+
+  TeExtendedPoint g8 = g4.Double();
+  EXPECT_EQ(g8.ToAffine(), TeAffinePoint(0, 12));  // 8*G = (0, -1)
+}
+
+TEST(TeExtendedPointTest, IdentityProperties) {
+  TeExtendedPoint gen = TeExtendedPoint::Generator();
+  TeExtendedPoint zero = TeExtendedPoint::Zero();
+
+  // G + 0 = G
+  EXPECT_EQ((gen + zero).ToAffine(), gen.ToAffine());
+
+  // 0 + G = G
+  EXPECT_EQ((zero + gen).ToAffine(), gen.ToAffine());
+
+  // G + (-G) = 0
+  TeExtendedPoint sum = gen + (-gen);
+  EXPECT_TRUE(sum.IsZero());
+}
+
+TEST(TeExtendedPointTest, Subtraction) {
+  TeExtendedPoint gen = TeExtendedPoint::Generator();
+  TeExtendedPoint g3 = gen + gen + gen;
+  TeExtendedPoint g2 = gen.Double();
+
+  TeExtendedPoint result = g3 - g2;
+  EXPECT_EQ(result.ToAffine(), gen.ToAffine());  // 3G - 2G = G
+}
+
+TEST(TeExtendedPointTest, Equality) {
+  TeExtendedPoint gen = TeExtendedPoint::Generator();
+  TeExtendedPoint gen2 = TeExtendedPoint::Generator();
+  EXPECT_EQ(gen, gen2);
+
+  // Same point in different projective coordinates.
+  TeExtendedPoint g2a = gen + gen;
+  TeExtendedPoint g2b = gen.Double();
+  EXPECT_EQ(g2a, g2b);
+}
+
+TEST(TeExtendedPointTest, GroupOrderIs16) {
+  TeExtendedPoint gen = TeExtendedPoint::Generator();
+  TeExtendedPoint current = gen;
+  for (int i = 1; i < 16; ++i) {
+    EXPECT_FALSE(current.IsZero()) << "Order divides " << i;
+    current = current + gen;
+  }
+  EXPECT_TRUE(current.IsZero()) << "16*G should be identity";
+}
+
+TEST(TeExtendedPointTest, ToAffineRoundTrip) {
+  TeExtendedPoint gen = TeExtendedPoint::Generator();
+  TeAffinePoint affine = gen.ToAffine();
+  TeExtendedPoint back = affine.ToExtended();
+  EXPECT_EQ(gen, back);
+}
+
+TEST(TeExtendedPointTest, MixedAddition) {
+  TeExtendedPoint gen = TeExtendedPoint::Generator();
+  TeAffinePoint gen_aff = TeAffinePoint::Generator();
+
+  // Extended + Affine
+  TeExtendedPoint g2_via_mixed = gen + gen_aff;
+  TeExtendedPoint g2_via_ext = gen + gen;
+  EXPECT_EQ(g2_via_mixed, g2_via_ext);
+}
+
+TEST(TeExtendedPointTest, BatchToAffine) {
+  TeExtendedPoint gen = TeExtendedPoint::Generator();
+  std::vector<TeExtendedPoint> extended_points;
+  TeExtendedPoint current = TeExtendedPoint::Zero();
+  for (int i = 0; i < 4; ++i) {
+    extended_points.push_back(current);
+    current = current + gen;
+  }
+
+  std::vector<TeAffinePoint> affine_points;
+  ASSERT_TRUE(
+      TeExtendedPoint::BatchToAffine(extended_points, &affine_points).ok());
+  ASSERT_EQ(affine_points.size(), 4);
+  EXPECT_EQ(affine_points[0], TeAffinePoint(0, 1));    // 0*G = identity
+  EXPECT_EQ(affine_points[1], TeAffinePoint(2, 4));    // 1*G
+  EXPECT_EQ(affine_points[2], TeAffinePoint(10, 11));  // 2*G
+  EXPECT_EQ(affine_points[3], TeAffinePoint(6, 10));   // 3*G
+}
+
+}  // namespace
+}  // namespace zk_dtypes::test


### PR DESCRIPTION
## Description

Add generic `TwistedEdwardsCurve<Config>` with HWCD-2008 extended coordinate
formulas (unified addition, dedicated doubling), mirroring the existing short
Weierstrass infrastructure. Instantiate for Ed25519 (a=−1, d=−121665/121666
over GF(2²⁵⁵−19)) with both standard and Montgomery field representations.

**Geometry layer**: `CurveType::kTwistedEdwards`, `ExtendedPoint<Curve>` forward
decl + `IsExtendedPoint` trait, SFINAE-split `PointTraits` and `AddResult` per
curve family. `AffinePoint` is shared between SW and TE via SFINAE on
`Curve::kType`.

**Directory structure**: `curve25519/ed25519/g1.h` following `bn/bn254/g1.h`
pattern. Namespace `zk_dtypes::ed25519` (instance-level, not family-level).

Unblocks prime-ir `PointCodeGeneration` for Edwards curves and the riscv-witness
SP1 `ed_add` precompile.

## Related Issues/PRs

Unblocks: fractalyze/prime-ir feat/twisted-edwards-point-operations (Phase 2)
Unblocks: riscv-witness SP1 ed_add precompile wiring (Phase 3)

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline