### PR TITLE
feat(field): register BaseField → ExtensionField cast (constant-term embed)

### DIFF
--- a/zk_dtypes/_src/field_numpy.h
+++ b/zk_dtypes/_src/field_numpy.h
@@ -1224,6 +1224,43 @@ bool RegisterExtFieldIntegerCast(int numpy_type) {
   return true;
 }
 
+// Casts a contiguous run of BaseField values into ExtensionField via the
+// constant-term embed ``base → (base, 0, …, 0)``. Mirrors the
+// ``ExtensionField(const BaseField&)`` constructor.
+//
+// IMPORTANT: On NumPy 2.x, the legacy PyArray_RegisterCastFunc compatibility
+// layer may call this function WITHOUT the GIL held. Do NOT call any Python
+// C API functions here.
+template <typename BaseField, typename ExtFieldType>
+void NPyField_BaseToExtFieldCast(void* from_void, void* to_void, npy_intp n,
+                                 void* /*fromarr*/, void* /*toarr*/) {
+  const auto* from = reinterpret_cast<const BaseField*>(from_void);
+  auto* to = reinterpret_cast<ExtFieldType*>(to_void);
+  for (npy_intp i = 0; i < n; ++i) {
+    to[i] = ExtFieldType(from[i]);
+  }
+}
+
+// Registers the constant-term-embed cast from ``ExtFieldType::BaseField``
+// to ``ExtFieldType``. Numpy refuses to cast between two 'V'-kind dtypes
+// without an explicit cast function; without this registration,
+// ``np.array(pf_arr, dtype=ef)`` raises "Cannot cast scalar from
+// dtype(<pf>) to dtype(<ef>)" and JAX's convert-element-type constant
+// folder hits the same path during trace.
+template <typename ExtFieldType>
+bool RegisterBaseToExtFieldCast() {
+  using BaseField = typename ExtFieldType::BaseField;
+  if constexpr (!std::is_same_v<BaseField, ExtFieldType>) {
+    if (PyArray_RegisterCastFunc(
+            FieldTypeDescriptor<BaseField>::npy_descr,
+            TypeDescriptor<ExtFieldType>::Dtype(),
+            NPyField_BaseToExtFieldCast<BaseField, ExtFieldType>) < 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
 template <typename T>
 bool RegisterExtFieldIntegerCasts() {
   return RegisterExtFieldIntegerCast<T, bool>(NPY_BOOL) &&
@@ -1383,7 +1420,8 @@ bool RegisterFieldDtype(PyObject* numpy) {
   if constexpr (T::ExtensionDegree() == 1 || IsBinaryField<T>) {
     return RegisterFieldCasts<T>() && RegisterFieldUFuncs<T>(numpy);
   } else {
-    return RegisterExtFieldIntegerCasts<T>() && RegisterFieldUFuncs<T>(numpy) &&
+    return RegisterExtFieldIntegerCasts<T>() &&
+           RegisterBaseToExtFieldCast<T>() && RegisterFieldUFuncs<T>(numpy) &&
            RegisterMixedFieldUFuncs<T, typename T::BaseField>(numpy);
   }
 }

--- a/zk_dtypes/_src/field_numpy.h
+++ b/zk_dtypes/_src/field_numpy.h
@@ -1247,6 +1247,13 @@ void NPyField_BaseToExtFieldCast(void* from_void, void* to_void, npy_intp n,
 // ``np.array(pf_arr, dtype=ef)`` raises "Cannot cast scalar from
 // dtype(<pf>) to dtype(<ef>)" and JAX's convert-element-type constant
 // folder hits the same path during trace.
+//
+// The cast is also marked safe (``NPY_NOSCALAR``) because the constant-term
+// embed is lossless. This lets ``np.result_type(base, ext)`` resolve to
+// the extension type and lets ``np.concatenate([base_arr, ext_arr])`` work.
+// Exact-match mixed ufunc loops (see ``RegisterMixedFieldUFuncs``) still
+// win over promotion-via-safe-cast at ufunc dispatch time, so the
+// dedicated ``ExtField op BaseField`` fast paths are not bypassed.
 template <typename ExtFieldType>
 bool RegisterBaseToExtFieldCast() {
   using BaseField = typename ExtFieldType::BaseField;
@@ -1255,6 +1262,11 @@ bool RegisterBaseToExtFieldCast() {
             FieldTypeDescriptor<BaseField>::npy_descr,
             TypeDescriptor<ExtFieldType>::Dtype(),
             NPyField_BaseToExtFieldCast<BaseField, ExtFieldType>) < 0) {
+      return false;
+    }
+    if (PyArray_RegisterCanCast(FieldTypeDescriptor<BaseField>::npy_descr,
+                                TypeDescriptor<ExtFieldType>::Dtype(),
+                                NPY_NOSCALAR) < 0) {
       return false;
     }
   }

--- a/zk_dtypes/tests/extension_field_test.py
+++ b/zk_dtypes/tests/extension_field_test.py
@@ -497,6 +497,25 @@ class ExtensionFieldIntegerCastTest(parameterized.TestCase):
     for i, v in enumerate(base_vals):
       self.assertEqual(ext_arr2[i], scalar_type(v))
 
+  @parameterized.product(scalar_type=EXT_FIELD_TYPES)
+  def testBaseToExtFieldCastIsSafe(self, scalar_type):
+    """The base→ext embed is registered as a safe cast (NPY_NOSCALAR).
+
+    This unlocks numpy promotion paths the explicit mixed ufunc loops don't
+    cover: ``np.result_type``, ``np.concatenate``, and ``np.can_cast``.
+    The ext→base direction stays unsafe because it is lossy.
+    """
+    base_type = EXT_TO_BASE[scalar_type]
+    self.assertTrue(np.can_cast(base_type, scalar_type))
+    self.assertFalse(np.can_cast(scalar_type, base_type))
+    self.assertEqual(np.result_type(base_type, scalar_type), scalar_type)
+    base_arr = np.array([base_type(1), base_type(2)])
+    ext_arr = np.array([scalar_type(3), scalar_type(4)])
+    cat = np.concatenate([base_arr, ext_arr])
+    self.assertEqual(cat.dtype, scalar_type)
+    self.assertEqual(cat[0], scalar_type(1))
+    self.assertEqual(cat[2], scalar_type(3))
+
 
 EXT_TO_BASE = {
     babybearx4: zk_dtypes.babybear,

--- a/zk_dtypes/tests/extension_field_test.py
+++ b/zk_dtypes/tests/extension_field_test.py
@@ -472,6 +472,31 @@ class ExtensionFieldIntegerCastTest(parameterized.TestCase):
     with self.assertRaises(TypeError):
       arr.astype(np.int64)
 
+  @parameterized.product(scalar_type=EXT_FIELD_TYPES)
+  def testBaseFieldToExtFieldCast(self, scalar_type):
+    """BaseField arrays cast to ExtensionField via the constant-term embed.
+
+    Both PF and EF are 'V'-kind dtypes; without an explicit cast registration
+    numpy refuses with ``Cannot cast scalar from dtype(<pf>) to dtype(<ef>)
+    according to the rule 'unsafe'``. The embed is ``base → (base, 0, …, 0)``
+    via the ``ExtensionField(BaseField)`` ctor.
+    """
+    base_type = EXT_TO_BASE[scalar_type]
+    base_vals = [i + 1 for i in range(4)]
+    base_arr = np.array([base_type(v) for v in base_vals])
+    self.assertEqual(base_arr.dtype, base_type)
+    # The int-to-ext ctor is also the constant-term embed, so for any
+    # int ``v`` we have ``scalar_type(v) == cast(base_type(v))``.
+    ext_arr = base_arr.astype(scalar_type)
+    self.assertEqual(ext_arr.dtype, scalar_type)
+    for i, v in enumerate(base_vals):
+      self.assertEqual(ext_arr[i], scalar_type(v))
+    # Same via np.array(..., dtype=ext_type).
+    ext_arr2 = np.array(base_arr, dtype=scalar_type)
+    self.assertEqual(ext_arr2.dtype, scalar_type)
+    for i, v in enumerate(base_vals):
+      self.assertEqual(ext_arr2[i], scalar_type(v))
+
 
 EXT_TO_BASE = {
     babybearx4: zk_dtypes.babybear,


### PR DESCRIPTION
## Summary

- Add `NPyField_BaseToExtFieldCast<BaseField, ExtFieldType>` + `RegisterBaseToExtFieldCast<ExtFieldType>()` and wire it into `RegisterFieldDtype` for extension-field types.
- Cast implements the constant-term embed `base → (base, 0, …, 0)` — same shape as the existing `ExtensionField(BaseField)` C++ ctor and the existing int → EF registered cast.
- Add unit test covering all 7 extension dtypes (babybearx4/_mont, goldilocksx3/_mont, koalabearx4/_mont, mersenne31x2) for both `arr.astype(ext)` and `np.array(arr, dtype=ext)` paths.

## Why

Without this registration, `np.array(pf_arr, dtype=ef)` raises

```
TypeError: Cannot cast scalar from dtype(<pf>) to dtype(<ef>) according to the rule 'unsafe'
```

because numpy treats both `PF` and `EF` as `kind='V'` (structured) and has no generic cast rule between two structured dtypes. The PF→EF lift was only available at the C++ constructor level, never registered through numpy's legacy cast machinery.

Surfaced in JAX (jax_fork) when `promote_args(pf, ef)` → `convert_element_type` → constant-folder called `np.asarray(c).astype(new_dtype)`. The same crash hits any direct numpy/pandas/scipy consumer that does `np.array(pf, dtype=ef)`. Fix lives in the dtype provider (zk_dtypes) so every consumer benefits — the JAX-side patch was a workaround that pessimized constant folding.

## Behavior

```python
import numpy as np, zk_dtypes
PF, EF = zk_dtypes.koalabear_mont, zk_dtypes.koalabearx4_mont
pf = np.array([1, 2, 3], dtype=PF)
ef = np.array(pf, dtype=EF)          # was: TypeError; now: [[1,0,0,0] [2,0,0,0] [3,0,0,0]]
ef2 = pf.astype(EF)                  # same result
```

## Test plan

- [x] New unit test `ExtensionFieldIntegerCastTest.testBaseFieldToExtFieldCast` for all 7 extension dtypes passes locally (`bazel test //zk_dtypes:extension_field_test`).
- [x] Verified downstream JAX consumer (synthetic jagged_prover driver) now passes `jagged_prover.prove()` end-to-end with no JAX-side patch.
- [ ] CI green.

Drafting because the rw_live e2e validation that motivated this is still pending — the in-tree synthetic driver passes, but the full e2e is a multi-hour test that should also confirm before merging.