### PR TITLE
feat(field): accept Python int operands in scalar binops

### DIFF
--- a/zk_dtypes/_src/field_numpy.h
+++ b/zk_dtypes/_src/field_numpy.h
@@ -341,6 +341,13 @@ PyObject* PyField_tp_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
   return nullptr;
 }
 
+// Python-int operands are coerced via the same value→field path that the
+// constructor uses (FieldIntCaster, which respects Montgomery form). For
+// extension fields the int is coerced to ``BaseField`` so the dedicated
+// ``ExtField op BaseField`` fast paths apply (constant-term-only add/sub,
+// per-coefficient scalar mul) — coercing to ``T`` would force a full
+// polynomial-mul path. Non-int operands fall through to ``NotImplemented``
+// so Python's normal reflected-op machinery can take over.
 template <typename T>
 PyObject* PyField_nb_add(PyObject* a, PyObject* b) {
   T x, y;
@@ -356,6 +363,23 @@ PyObject* PyField_nb_add(PyObject* a, PyObject* b) {
     }
     if (PyField_Value<BaseField>(a, &base_val) && PyField_Value(b, &ext_val)) {
       return PyField_FromValue(base_val + ext_val).release();
+    }
+    if (PyField_Value(a, &ext_val) && PyLong_Check(b)) {
+      if (!CastToField<BaseField>(b, &base_val)) return nullptr;
+      return PyField_FromValue(ext_val + base_val).release();
+    }
+    if (PyLong_Check(a) && PyField_Value(b, &ext_val)) {
+      if (!CastToField<BaseField>(a, &base_val)) return nullptr;
+      return PyField_FromValue(base_val + ext_val).release();
+    }
+  } else {
+    if (PyField_Value(a, &x) && PyLong_Check(b)) {
+      if (!CastToField<T>(b, &y)) return nullptr;
+      return PyField_FromValue(x + y).release();
+    }
+    if (PyLong_Check(a) && PyField_Value(b, &y)) {
+      if (!CastToField<T>(a, &x)) return nullptr;
+      return PyField_FromValue(x + y).release();
     }
   }
   Py_INCREF(Py_NotImplemented);
@@ -377,6 +401,23 @@ PyObject* PyField_nb_subtract(PyObject* a, PyObject* b) {
     }
     if (PyField_Value<BaseField>(a, &base_val) && PyField_Value(b, &ext_val)) {
       return PyField_FromValue(base_val - ext_val).release();
+    }
+    if (PyField_Value(a, &ext_val) && PyLong_Check(b)) {
+      if (!CastToField<BaseField>(b, &base_val)) return nullptr;
+      return PyField_FromValue(ext_val - base_val).release();
+    }
+    if (PyLong_Check(a) && PyField_Value(b, &ext_val)) {
+      if (!CastToField<BaseField>(a, &base_val)) return nullptr;
+      return PyField_FromValue(base_val - ext_val).release();
+    }
+  } else {
+    if (PyField_Value(a, &x) && PyLong_Check(b)) {
+      if (!CastToField<T>(b, &y)) return nullptr;
+      return PyField_FromValue(x - y).release();
+    }
+    if (PyLong_Check(a) && PyField_Value(b, &y)) {
+      if (!CastToField<T>(a, &x)) return nullptr;
+      return PyField_FromValue(x - y).release();
     }
   }
   Py_INCREF(Py_NotImplemented);
@@ -418,6 +459,27 @@ PyObject* PyField_nb_multiply(PyObject* a, PyObject* b) {
     }
     if (PyField_Value<BaseField>(a, &base_val) && PyField_Value(b, &ext_val)) {
       return PyField_FromValue(base_val * ext_val).release();
+    }
+    if (PyField_Value(a, &ext_val) && PyLong_Check(b)) {
+      if (!CastToField<BaseField>(b, &base_val)) return nullptr;
+      return PyField_FromValue(ext_val * base_val).release();
+    }
+    if (PyLong_Check(a) && PyField_Value(b, &ext_val)) {
+      if (!CastToField<BaseField>(a, &base_val)) return nullptr;
+      return PyField_FromValue(base_val * ext_val).release();
+    }
+  } else {
+    // Python int operand for prime/binary fields. Handled before the EC
+    // dispatch below so ``Fr(5) * 3`` resolves as field mul rather than
+    // tripping the "invalid argument for multiplication" path in
+    // ``PyField_nb_ec_multiply``.
+    if (PyField_Value(a, &x) && PyLong_Check(b)) {
+      if (!CastToField<T>(b, &y)) return nullptr;
+      return PyField_FromValue(x * y).release();
+    }
+    if (PyLong_Check(a) && PyField_Value(b, &y)) {
+      if (!CastToField<T>(a, &x)) return nullptr;
+      return PyField_FromValue(x * y).release();
     }
   }
   // EC point multiplication
@@ -469,6 +531,39 @@ PyObject* PyField_nb_true_divide(PyObject* a, PyObject* b) {
         return nullptr;
       }
       return PyField_FromValue(base_val / ext_val).release();
+    }
+    if (PyField_Value(a, &ext_val) && PyLong_Check(b)) {
+      if (!CastToField<BaseField>(b, &base_val)) return nullptr;
+      if (base_val.IsZero()) {
+        PyErr_SetString(PyExc_ZeroDivisionError, "division by zero");
+        return nullptr;
+      }
+      return PyField_FromValue(ext_val / base_val).release();
+    }
+    if (PyLong_Check(a) && PyField_Value(b, &ext_val)) {
+      if (!CastToField<BaseField>(a, &base_val)) return nullptr;
+      if (ext_val.IsZero()) {
+        PyErr_SetString(PyExc_ZeroDivisionError, "division by zero");
+        return nullptr;
+      }
+      return PyField_FromValue(base_val / ext_val).release();
+    }
+  } else {
+    if (PyField_Value(a, &x) && PyLong_Check(b)) {
+      if (!CastToField<T>(b, &y)) return nullptr;
+      if (y.IsZero()) {
+        PyErr_SetString(PyExc_ZeroDivisionError, "division by zero");
+        return nullptr;
+      }
+      return PyField_FromValue(x / y).release();
+    }
+    if (PyLong_Check(a) && PyField_Value(b, &y)) {
+      if (!CastToField<T>(a, &x)) return nullptr;
+      if (y.IsZero()) {
+        PyErr_SetString(PyExc_ZeroDivisionError, "division by zero");
+        return nullptr;
+      }
+      return PyField_FromValue(x / y).release();
     }
   }
   Py_INCREF(Py_NotImplemented);

--- a/zk_dtypes/tests/binary_field_test.py
+++ b/zk_dtypes/tests/binary_field_test.py
@@ -212,6 +212,26 @@ class ScalarTest(parameterized.TestCase):
           # Verify: (v / w) * w = v
           self.assertEqual(out * scalar_type(w), scalar_type(v), msg=(v, w))
 
+  @parameterized.product(
+      scalar_type=BINARY_FIELD_TYPES,
+      op=[operator.add, operator.sub, operator.mul, operator.truediv],
+  )
+  def testPyIntCoercion(self, scalar_type, op):
+    """Binary ops accept a Python int on either side."""
+    mask = VALUE_MASKS[scalar_type]
+    int_values = [w for w in [1, 3, 7] if w <= mask]
+    for v in VALUES[scalar_type]:
+      if op is operator.truediv and v == 0:
+        continue
+      x = scalar_type(v)
+      for w in int_values:
+        out_r = op(x, w)
+        self.assertIsInstance(out_r, scalar_type)
+        self.assertEqual(out_r, op(x, scalar_type(w)), msg=(v, w, "right"))
+        out_l = op(w, x)
+        self.assertIsInstance(out_l, scalar_type)
+        self.assertEqual(out_l, op(scalar_type(w), x), msg=(v, w, "left"))
+
   @parameterized.product(scalar_type=BINARY_FIELD_TYPES)
   def testInverse(self, scalar_type):
     """Test multiplicative inverse: x * x^(-1) = 1."""

--- a/zk_dtypes/tests/extension_field_test.py
+++ b/zk_dtypes/tests/extension_field_test.py
@@ -188,6 +188,39 @@ class ExtensionFieldScalarTest(parameterized.TestCase):
     self.assertEqual(dt.name, name)
     self.assertEqual(repr(dt), f"dtype({name})")
 
+  @parameterized.product(
+      scalar_type=EXT_FIELD_TYPES,
+      op=[operator.add, operator.sub, operator.mul, operator.truediv],
+  )
+  def testPyIntCoercion(self, scalar_type, op):
+    """Binary ops accept a Python int on either side. The int embeds as the
+    constant term (matching the BaseField → ExtensionField cast), which
+    routes through the dedicated ExtField·BaseField fast paths."""
+    for v in VALUES[scalar_type]:
+      x = scalar_type(v)
+      if op is operator.truediv and x == scalar_type(0):
+        continue  # int / 0 covered by testDivByZeroRaisesError analogue
+      for w in [1, 3, -1, 100]:
+        out_r = op(x, w)
+        self.assertIsInstance(out_r, scalar_type)
+        self.assertEqual(out_r, op(x, scalar_type(w)), msg=(v, w, "right"))
+        out_l = op(w, x)
+        self.assertIsInstance(out_l, scalar_type)
+        self.assertEqual(out_l, op(scalar_type(w), x), msg=(v, w, "left"))
+
+  @parameterized.product(scalar_type=EXT_FIELD_TYPES)
+  def testPyIntCoercionConstantTermEmbed(self, scalar_type):
+    """A Python int on the additive side touches only the constant term —
+    confirms the int is coerced to BaseField (not to ExtF, which would
+    broadcast the value across all coefficients)."""
+    degree = efinfo(scalar_type).degree
+    coeffs = tuple(range(1, degree + 1))  # all-nonzero coeffs
+    x = scalar_type(coeffs)
+    out = x + 10
+    # Constant term shifted by 10; other coefficients unchanged.
+    expected = scalar_type((coeffs[0] + 10,) + coeffs[1:])
+    self.assertEqual(out, expected)
+
 
 @multi_threaded(num_workers=3)
 class ExtensionFieldArrayTest(parameterized.TestCase):

--- a/zk_dtypes/tests/prime_field_test.py
+++ b/zk_dtypes/tests/prime_field_test.py
@@ -235,6 +235,45 @@ class ScalarTest(parameterized.TestCase):
           self.assertIsInstance(out, scalar_type)
           self.assertEqual(out * scalar_type(w), scalar_type(v), msg=(v, w))
 
+  @parameterized.product(
+      scalar_type=FIELD_TYPES,
+      op=[operator.add, operator.sub, operator.mul, operator.truediv],
+  )
+  def testPyIntCoercion(self, scalar_type, op):
+    """Binary ops accept a Python int on either side, equivalent to wrapping
+    the int with the field constructor first."""
+    for v in VALUES[scalar_type]:
+      if op is operator.truediv and v == 0:
+        # Skip — w / scalar_type(0) would raise ZeroDivisionError; covered
+        # separately in testPyIntDivByZeroRaises.
+        continue
+      for w in [1, 3, -1, 100]:
+        x = scalar_type(v)
+        out_r = op(x, w)
+        self.assertIsInstance(out_r, scalar_type)
+        self.assertEqual(out_r, op(x, scalar_type(w)), msg=(v, w, "right"))
+        out_l = op(w, x)
+        self.assertIsInstance(out_l, scalar_type)
+        self.assertEqual(out_l, op(scalar_type(w), x), msg=(v, w, "left"))
+
+  @parameterized.product(scalar_type=FIELD_TYPES)
+  def testPyIntDivByZeroRaises(self, scalar_type):
+    with self.assertRaises(ZeroDivisionError):
+      scalar_type(1) / 0
+    with self.assertRaises(ZeroDivisionError):
+      1 / scalar_type(0)
+
+  @parameterized.product(scalar_type=FIELD_TYPES)
+  def testNonIntOperandReturnsNotImplemented(self, scalar_type):
+    """Non-int Python operands (e.g. float, str) fall through to Python's
+    standard reflected-op machinery, producing the canonical TypeError —
+    not a custom 'invalid argument' message from the field code."""
+    with self.assertRaises(TypeError) as cm:
+      _ = scalar_type(1) + 1.5
+    self.assertIn("unsupported operand", str(cm.exception))
+    with self.assertRaises(TypeError):
+      _ = "x" * scalar_type(1)
+
   @parameterized.product(scalar_type=FIELD_TYPES)
   def testPowerOp(self, scalar_type):
     if pfinfo(scalar_type).modulus > 2**64:


### PR DESCRIPTION
## Summary

Allows scalar binary ops to accept Python ints: ``3 * pf``, ``pf + 1``, ``2 - ef``, ``ef / 5``, ``1 / fr``, etc.

The array form ``3 * pf_arr`` already worked through numpy's ufunc dispatch + the existing uint cast registrations. Only the scalar path was missing — ``PyField_nb_{add,subtract,multiply,true_divide}`` accepted only ``PyField<T>`` (and base/ext siblings for extension fields). The Python constructor ``babybear(3)`` already handled ints correctly via ``FieldIntCaster::Cast(int64_t v) → T(v)`` (which respects Montgomery form), so the building block existed; this PR just wires it into the binop path.

## Key design choice — extension fields target BaseField

For extension fields the int is coerced to ``BaseField``, not to ``T``:

```cpp
if (PyField_Value(a, &ext_val) && PyLong_Check(b)) {
  BaseField base_val;
  if (!CastToField<BaseField>(b, &base_val)) return nullptr;
  return PyField_FromValue(ext_val * base_val).release();
}
```

This routes through the dedicated ``ExtField op BaseField`` fast paths added in #119 — ``+=``/``-=`` touch only the constant term, ``*=`` is a per-coefficient scalar multiply. Targeting ``T`` would zero-pad to a full extension and force the generic polynomial path.

This is also the natural semantics: matches the constant-term embed from ``RegisterBaseToExtFieldCast``. ``3 * ext`` and ``np.array(3, ext_dtype) * ext_arr`` agree by construction.

## Ordering in ``nb_multiply``

The int branch runs **before** the ``Fr * EcPoint`` dispatch so ``bn254_sf(5) * 3`` resolves as field mul rather than tripping ``PyField_nb_ec_multiply``'s ``"invalid argument for multiplication"`` error.

## What still doesn't work

``np.int64(3) * pf`` (numpy scalar, not Python int) still fails — that's a separate ufunc-loop gap, not addressed here. Workaround: cast through Python int or wrap in an array.

## Test plan

- [x] ``testPyIntCoercion`` for ``+``, ``-``, ``*``, ``/`` on prime/binary/extension fields, both orders (left and right int).
- [x] ``testPyIntDivByZeroRaises`` for ``pf / 0`` and ``int / scalar_type(0)``.
- [x] ``testNonIntOperandReturnsNotImplemented`` confirms ``pf + 1.5`` yields the canonical ``unsupported operand type(s)`` TypeError, not a custom error.
- [x] ``testPyIntCoercionConstantTermEmbed`` confirms ``ext + n`` shifts only the constant coefficient.
- [x] Full suite: 5388 passed / 52 skipped.