### PR TITLE
chore: add GitHub issue form templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-spec-driven-task.yml
+++ b/.github/ISSUE_TEMPLATE/01-spec-driven-task.yml
@@ -1,0 +1,117 @@
+name: "Spec-driven task"
+description: |
+  Issue created from a `/spec-driven-development` session. Bundles the spec,
+  the multi-PR plan, and relevant local knowledge so any agent or human can
+  pick the work up.
+title: "<type>(<area>): <one-line summary>"
+labels: ["area:spec-driven"]
+type: Task
+body:
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      description: Conventional-commit type. Drives version bump policy on merge.
+      options:
+        - feat
+        - fix
+        - perf
+        - refactor
+        - test
+        - chore
+        - ci
+        - docs
+    validations:
+      required: true
+
+  - type: input
+    id: area
+    attributes:
+      label: Area
+      description: Conventional-commit scope. Examples — `field`, `curve`, `bigint`, `montgomery`.
+      placeholder: curve
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why does this exist? What problem does it solve, what motivated the spec?
+    validations:
+      required: true
+
+  - type: textarea
+    id: spec
+    attributes:
+      label: Spec
+      description: |
+        Full spec body from `/spec-driven-development`. Behavior, acceptance
+        criteria, non-goals. Inline the content here — don't link to a local
+        file that the reviewer cannot open.
+    validations:
+      required: true
+
+  - type: textarea
+    id: plan
+    attributes:
+      label: Plan
+      description: |
+        Checkbox task list, one row per planned PR. GitHub renders the
+        completion ratio in the issue header.
+      value: |
+        - [ ] PR1: …
+        - [ ] PR2: …
+    validations:
+      required: true
+
+  - type: textarea
+    id: downstream_impact
+    attributes:
+      label: Downstream impact
+      description: |
+        zk_dtypes is consumed by prime-ir (constant folding / codegen) and
+        riscv-witness (precompile trace computation). Which consumers does this
+        type/operation change affect? Note ABI, layout, or value-representation
+        changes they must absorb. Leave blank if purely internal.
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproducer (required when Type = fix)
+      description: |
+        Minimum commands or input that reproduce the bug. Use `bazel test`
+        invocations, not built binary paths. Prefix file inputs with `$PWD`.
+        Leave blank for non-fix tasks.
+      render: shell
+
+  - type: input
+    id: parent
+    attributes:
+      label: Parent issue
+      description: |
+        Issue number or full URL of the tracking / parent issue this
+        work belongs to, if any. Same-repo form: `#1234`. Cross-repo
+        form: `https://github.com/<owner>/<repo>/issues/1234`. The
+        /workflow:create-issue skill registers the sub-issue link
+        automatically when filed via the CLI.
+      placeholder: "#1234 or https://github.com/<owner>/<repo>/issues/1234"
+
+  - type: textarea
+    id: knowledge
+    attributes:
+      label: Relevant knowledge
+      description: |
+        Excerpts from personal memory and links into the team wiki so other
+        agents can pick this up without your local `~/.claude/` directory.
+        Sanitize home paths, scratch dirs, and session IDs before pasting.
+      placeholder: |
+        - [[wiki/page-name]] — one-line hook
+        - Personal memo excerpt: "…"
+
+  - type: input
+    id: milestone
+    attributes:
+      label: Milestone (if multi-PR)
+      description: "Milestone name to attach. Convention — `<area>: <feature> v<n>`."
+      placeholder: "curve: bls12-381 v1"

--- a/.github/ISSUE_TEMPLATE/02-zk-dtypes-bug.yml
+++ b/.github/ISSUE_TEMPLATE/02-zk-dtypes-bug.yml
@@ -1,0 +1,69 @@
+name: "zk_dtypes bug"
+description: |
+  A bug in zk_dtypes itself — wrong field/curve arithmetic, a bad Montgomery
+  conversion, a broken SFINAE dispatch, a compile error, or a perf cliff,
+  observed while building or testing zk_dtypes directly (not surfaced through a
+  downstream consumer — use the downstream-bug template for that).
+title: "fix(<area>): <symptom>"
+labels: ["area:zk_dtypes"]
+type: Bug
+body:
+  - type: textarea
+    id: symptom
+    attributes:
+      label: Symptom
+      description: |
+        What you see — wrong field/point value, failed `CHECK`, a Montgomery vs
+        standard mismatch, template/SFINAE compile error, crash, perf cliff.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproducer
+      description: |
+        Minimum commands. Use `bazel test`, not built binary paths. Name the
+        field/curve config and the operation. Prefix file inputs with `$PWD`.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: diagnostic
+    attributes:
+      label: Captured diagnostic
+      description: |
+        Expected vs actual values (hex limbs), the failing assertion, the
+        compiler error excerpt, or a flamegraph hotspot. Do not link to scratch
+        paths or home-directory artifacts the reviewer cannot open.
+
+  - type: input
+    id: parent
+    attributes:
+      label: Parent issue
+      description: |
+        Issue number or full URL of the tracking / parent issue this
+        work belongs to, if any. Same-repo form: `#1234`. Cross-repo
+        form: `https://github.com/<owner>/<repo>/issues/1234`. The
+        /workflow:create-issue skill registers the sub-issue link
+        automatically when filed via the CLI.
+      placeholder: "#1234 or https://github.com/<owner>/<repo>/issues/1234"
+
+  - type: input
+    id: milestone
+    attributes:
+      label: Milestone
+      description: |
+        Existing milestone name to attach this issue to. The
+        /workflow:create-issue skill checks the milestone exists
+        before applying it.
+      placeholder: "e.g. <area>: <feature> v<n>"
+
+  - type: textarea
+    id: knowledge
+    attributes:
+      label: Relevant knowledge
+      description: |
+        Wiki links to related prior bugs, design notes, personal memo excerpts.
+        Strip session IDs and absolute home paths.

--- a/.github/ISSUE_TEMPLATE/03-downstream-bug.yml
+++ b/.github/ISSUE_TEMPLATE/03-downstream-bug.yml
@@ -1,0 +1,116 @@
+name: "Downstream bug (prime-ir / riscv-witness …)"
+description: |
+  A downstream consumer of zk_dtypes hit a bug — wrong value, a missing
+  type/operation, an ABI/layout break, or a perf regression — while building
+  its own workload. File this so the zk_dtypes owner can reproduce without the
+  consumer's environment. Once root-caused it often becomes a zk_dtypes bug;
+  the point of this template is to capture the consumer-side provenance the
+  maintainer doesn't have.
+title: "fix(<area>): <symptom> hit by <consumer>"
+labels: ["area:downstream"]
+type: Bug
+body:
+  - type: dropdown
+    id: consumer
+    attributes:
+      label: Consumer
+      description: Which downstream project hit this?
+      options:
+        - prime-ir
+        - riscv-witness
+        - zkx
+        - other (note in title)
+    validations:
+      required: true
+
+  - type: input
+    id: downstream_commit
+    attributes:
+      label: Downstream commit
+      description: |
+        Where the issue was observed — paste a permalink to the consumer's
+        commit/file (carries the repo + SHA), or a bare SHA.
+      placeholder: https://github.com/<org>/<repo>/commit/ce1bcfbb
+    validations:
+      required: true
+
+  - type: input
+    id: zk_dtypes_sha
+    attributes:
+      label: zk_dtypes commit / pin SHA
+      description: Which zk_dtypes revision was the consumer building against?
+      placeholder: e.g. 1a2b3c4d
+    validations:
+      required: true
+
+  - type: textarea
+    id: workload
+    attributes:
+      label: Workload
+      description: |
+        What was the consumer doing when it broke? The field/curve config, the
+        operation (mul, inverse, point add, …), standard vs Montgomery — enough
+        to narrow the surface.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproducer
+      description: |
+        Minimum commands or input that reproduce the issue, ideally reduced to
+        a zk_dtypes-only case. Use `bazel test`, not built binary paths. Prefix
+        file inputs with `$PWD`.
+      render: shell
+    validations:
+      required: true
+
+  - type: input
+    id: suspected_area
+    attributes:
+      label: Suspected zk_dtypes area (optional)
+      description: If you have a hunch where the root cause lives, name the type / operation.
+      placeholder: "e.g. Montgomery reduction, twisted-Edwards point add"
+
+  - type: input
+    id: parent
+    attributes:
+      label: Parent issue
+      description: |
+        Issue number or full URL of the tracking / parent issue this
+        work belongs to, if any. Same-repo form: `#1234`. Cross-repo
+        form: `https://github.com/<owner>/<repo>/issues/1234`. The
+        /workflow:create-issue skill registers the sub-issue link
+        automatically when filed via the CLI.
+      placeholder: "#1234 or https://github.com/<owner>/<repo>/issues/1234"
+
+  - type: input
+    id: milestone
+    attributes:
+      label: Milestone
+      description: |
+        Existing milestone name to attach this issue to. The
+        /workflow:create-issue skill checks the milestone exists
+        before applying it.
+      placeholder: "e.g. <area>: <feature> v<n>"
+
+  - type: textarea
+    id: knowledge
+    attributes:
+      label: Relevant knowledge (optional)
+      description: Wiki links or excerpts that contextualize the bug. Strip home paths and session IDs.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+# Controls the issue chooser experience. Disable blank issues so contributors
+# always pick a structured template — keeps downstream automation (/handle-issue,
+# milestone/project assignment) able to rely on the labels and required fields.
+blank_issues_enabled: false
+
+contact_links:
+  - name: Discussion / open-ended question
+    url: https://github.com/fractalyze/zk_dtypes/discussions
+    about: For design questions, RFCs, or anything not actionable as a single task.


### PR DESCRIPTION
Structured issue intake for zk_dtypes — three categories plus chooser config.

Templates:
- `01-spec-driven-task` — spec + multi-PR plan + downstream impact (prime-ir / riscv-witness)
- `02-zk-dtypes-bug` — bug in zk_dtypes itself (symptom / repro / diagnostic)
- `03-downstream-bug` — bug surfaced by a consumer (prime-ir / riscv-witness / zkx), with consumer-side provenance

Disables blank issues; routes open-ended questions to Discussions. Modeled on the riscv-witness / zkx template set.

Follow-up: the referenced labels (`area:spec-driven`, `area:zk_dtypes`, `area:downstream`, `type:fix`) must exist in the repo for GitHub to auto-apply them.