### PR TITLE
fix(field): avoid UB left-shift of negative transition-matrix entries

### DIFF
--- a/zk_dtypes/include/byinverter.h
+++ b/zk_dtypes/include/byinverter.h
@@ -347,8 +347,12 @@ class BYInverter {
       steps -= zeros;
       delta += zeros;
       g >>= zeros;
-      t[0][0] <<= zeros;
-      t[0][1] <<= zeros;
+      // t[0][*] can be negative (negated in the delta > 0 branch below);
+      // left-shifting a negative signed value is UB. Shift in the unsigned
+      // domain, which yields the identical two's-complement bit pattern
+      // (multiply by 2^zeros mod 2^64) the transition matrix expects.
+      t[0][0] = static_cast<int64_t>(static_cast<uint64_t>(t[0][0]) << zeros);
+      t[0][1] = static_cast<int64_t>(static_cast<uint64_t>(t[0][1]) << zeros);
 
       if (steps == 0) {
         break;


### PR DESCRIPTION
## What

`BYInverter::Jump` (Bernstein–Yang modular inverse) left-shifts the
transition-matrix entries `t[0][0]` / `t[0][1]`. Those entries become
negative once the `delta > 0` branch negates them, and left-shifting a
negative signed integer is undefined behavior in C++. The shift now goes
through `uint64_t`, yielding the identical two's-complement bit pattern
(multiply by `2^zeros mod 2^64`) the algorithm already depends on, but
defined.

## Why

Surfaced as a red sanitizer CI in `stablehlo`: parsing a Montgomery
extension-field type (`!field.ef<...>`) runs a field inversion through
this path, so every such test aborted under `-fsanitize=undefined`:

```
byinverter.h:350:15: runtime error: left shift of negative value -1
  #0 zk_dtypes::BYInverter<1ul>::Jump(...)
  #1 zk_dtypes::BYInverter<1ul>::Invert(...)
```

## Verification

Reproduced and confirmed fixed under `--config=asan --config=ubsan` via
the consuming `stablehlo` build (override of this checkout): the
four field/EC tests that aborted — `constant`, `reduce`,
`canonicalize_zk`, `transforms_stablehlo_refine_shapes` — all pass. No
behavioral change in non-sanitizer builds (same result bits).