### PR TITLE
fix(field): restrict field scalar ctors to integral types

### DIFF
--- a/zk_dtypes/BUILD.bazel
+++ b/zk_dtypes/BUILD.bazel
@@ -246,6 +246,7 @@ cc_library(
     name = "big_binary_field",
     hdrs = ["include/field/big_binary_field.h"],
     deps = [
+        ":arithmetics",
         ":big_int",
         ":binary_field_config",
         ":binary_field_multiplication",
@@ -503,6 +504,7 @@ cc_library(
     name = "small_binary_field",
     hdrs = ["include/field/small_binary_field.h"],
     deps = [
+        ":arithmetics",
         ":big_int",
         ":binary_field_config",
         ":binary_field_multiplication",

--- a/zk_dtypes/include/arithmetics.h
+++ b/zk_dtypes/include/arithmetics.h
@@ -18,6 +18,8 @@ limitations under the License.
 
 #include <stdint.h>
 
+#include <type_traits>
+
 namespace zk_dtypes::internal {
 
 template <typename T>
@@ -137,6 +139,17 @@ class PromotedTypeImpl<int8_t> {
 
 template <typename T>
 using make_promoted_t = typename PromotedTypeImpl<T>::type;
+
+// Returns |value| as the corresponding unsigned type. Unlike std::abs, this
+// is well-defined for the minimum value (whose magnitude is not representable
+// in T): negation in the unsigned domain wraps modularly. The outer cast
+// undoes integer promotion for types narrower than int.
+template <typename T>
+constexpr std::make_unsigned_t<T> UnsignedAbs(T value) {
+  using U = std::make_unsigned_t<T>;
+  return static_cast<U>(value < 0 ? -static_cast<U>(value)
+                                  : static_cast<U>(value));
+}
 
 // Calculates a + b + carry.
 #define ADD_WITH_CARRY_IMPL(T)                                 \

--- a/zk_dtypes/include/field/big_binary_field.h
+++ b/zk_dtypes/include/field/big_binary_field.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include <string>
 #include <type_traits>
 
+#include "zk_dtypes/include/arithmetics.h"
 #include "zk_dtypes/include/big_int.h"
 #include "zk_dtypes/include/field/binary_field_config.h"
 #include "zk_dtypes/include/field/binary_field_multiplication.h"
@@ -62,10 +63,7 @@ class BinaryField<_Config, std::enable_if_t<(_Config::kStorageBits > 64)>>
                                          std::is_integral_v<T>>* = nullptr>
   constexpr BinaryField(T value)
       // In characteristic 2, -x == x, so a signed value maps to its magnitude.
-      // Negate in the unsigned domain: std::abs(min()) is UB.
-      : BinaryField(static_cast<std::make_unsigned_t<T>>(
-            value < 0 ? -static_cast<std::make_unsigned_t<T>>(value)
-                      : static_cast<std::make_unsigned_t<T>>(value))) {}
+      : BinaryField(internal::UnsignedAbs(value)) {}
   template <typename T, std::enable_if_t<std::is_unsigned_v<T>>* = nullptr>
   constexpr BinaryField(T value) : BinaryField(BigInt<N>(value)) {}
   template <typename T>

--- a/zk_dtypes/include/field/big_binary_field.h
+++ b/zk_dtypes/include/field/big_binary_field.h
@@ -59,7 +59,8 @@ class BinaryField<_Config, std::enable_if_t<(_Config::kStorageBits > 64)>>
 
   constexpr BinaryField() = default;
 
-  template <typename T, std::enable_if_t<std::is_signed_v<T>>* = nullptr>
+  template <typename T, std::enable_if_t<std::is_signed_v<T> &&
+                                         std::is_integral_v<T>>* = nullptr>
   constexpr BinaryField(T value)
       : BinaryField(static_cast<std::make_unsigned_t<T>>(std::abs(value))) {}
   template <typename T, std::enable_if_t<std::is_unsigned_v<T>>* = nullptr>

--- a/zk_dtypes/include/field/big_binary_field.h
+++ b/zk_dtypes/include/field/big_binary_field.h
@@ -19,7 +19,6 @@ limitations under the License.
 #include <stddef.h>
 #include <stdint.h>
 
-#include <cmath>
 #include <string>
 #include <type_traits>
 
@@ -62,7 +61,11 @@ class BinaryField<_Config, std::enable_if_t<(_Config::kStorageBits > 64)>>
   template <typename T, std::enable_if_t<std::is_signed_v<T> &&
                                          std::is_integral_v<T>>* = nullptr>
   constexpr BinaryField(T value)
-      : BinaryField(static_cast<std::make_unsigned_t<T>>(std::abs(value))) {}
+      // In characteristic 2, -x == x, so a signed value maps to its magnitude.
+      // Negate in the unsigned domain: std::abs(min()) is UB.
+      : BinaryField(static_cast<std::make_unsigned_t<T>>(
+            value < 0 ? -static_cast<std::make_unsigned_t<T>>(value)
+                      : static_cast<std::make_unsigned_t<T>>(value))) {}
   template <typename T, std::enable_if_t<std::is_unsigned_v<T>>* = nullptr>
   constexpr BinaryField(T value) : BinaryField(BigInt<N>(value)) {}
   template <typename T>

--- a/zk_dtypes/include/field/big_prime_field.h
+++ b/zk_dtypes/include/field/big_prime_field.h
@@ -59,7 +59,8 @@ class PrimeField<_Config, std::enable_if_t<(_Config::kStorageBits > 64)>>
   using UnderlyingType = BigInt<N>;
 
   constexpr PrimeField() = default;
-  template <typename T, std::enable_if_t<std::is_signed_v<T>>* = nullptr>
+  template <typename T, std::enable_if_t<std::is_signed_v<T> &&
+                                         std::is_integral_v<T>>* = nullptr>
   constexpr PrimeField(T value) {
     if (value == 0) return;
     if (value == 1) {

--- a/zk_dtypes/include/field/extension_field.h
+++ b/zk_dtypes/include/field/extension_field.h
@@ -157,7 +157,8 @@ class ExtensionField : public FiniteField<ExtensionField<_Config>>,
     }
   }
 
-  template <typename T, std::enable_if_t<std::is_signed_v<T>>* = nullptr>
+  template <typename T, std::enable_if_t<std::is_signed_v<T> &&
+                                         std::is_integral_v<T>>* = nullptr>
   constexpr ExtensionField(T value) {
     if (value == 0) return;
     if (value == 1) {

--- a/zk_dtypes/include/field/small_binary_field.h
+++ b/zk_dtypes/include/field/small_binary_field.h
@@ -67,7 +67,8 @@ class BinaryField<_Config, std::enable_if_t<(_Config::kStorageBits <= 64)>>
                                       BinaryField<SubfieldConfig>>;
 
   constexpr BinaryField() = default;
-  template <typename T, std::enable_if_t<std::is_signed_v<T>>* = nullptr>
+  template <typename T, std::enable_if_t<std::is_signed_v<T> &&
+                                         std::is_integral_v<T>>* = nullptr>
   constexpr BinaryField(T value)
       : BinaryField(static_cast<std::make_unsigned_t<T>>(std::abs(value))) {}
   template <typename T, std::enable_if_t<std::is_unsigned_v<T>>* = nullptr>

--- a/zk_dtypes/include/field/small_binary_field.h
+++ b/zk_dtypes/include/field/small_binary_field.h
@@ -19,7 +19,6 @@ limitations under the License.
 #include <stddef.h>
 #include <stdint.h>
 
-#include <cmath>
 #include <string>
 #include <type_traits>
 
@@ -70,7 +69,11 @@ class BinaryField<_Config, std::enable_if_t<(_Config::kStorageBits <= 64)>>
   template <typename T, std::enable_if_t<std::is_signed_v<T> &&
                                          std::is_integral_v<T>>* = nullptr>
   constexpr BinaryField(T value)
-      : BinaryField(static_cast<std::make_unsigned_t<T>>(std::abs(value))) {}
+      // In characteristic 2, -x == x, so a signed value maps to its magnitude.
+      // Negate in the unsigned domain: std::abs(min()) is UB.
+      : BinaryField(static_cast<std::make_unsigned_t<T>>(
+            value < 0 ? -static_cast<std::make_unsigned_t<T>>(value)
+                      : static_cast<std::make_unsigned_t<T>>(value))) {}
   template <typename T, std::enable_if_t<std::is_unsigned_v<T>>* = nullptr>
   constexpr BinaryField(T value) : value_(value) {
     DCHECK_EQ(value_, static_cast<UnderlyingType>(value) & Config::kValueMask);

--- a/zk_dtypes/include/field/small_binary_field.h
+++ b/zk_dtypes/include/field/small_binary_field.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include "absl/log/check.h"
 #include "absl/strings/str_cat.h"
 
+#include "zk_dtypes/include/arithmetics.h"
 #include "zk_dtypes/include/big_int.h"
 #include "zk_dtypes/include/field/binary_field_config.h"
 #include "zk_dtypes/include/field/binary_field_multiplication.h"
@@ -70,10 +71,7 @@ class BinaryField<_Config, std::enable_if_t<(_Config::kStorageBits <= 64)>>
                                          std::is_integral_v<T>>* = nullptr>
   constexpr BinaryField(T value)
       // In characteristic 2, -x == x, so a signed value maps to its magnitude.
-      // Negate in the unsigned domain: std::abs(min()) is UB.
-      : BinaryField(static_cast<std::make_unsigned_t<T>>(
-            value < 0 ? -static_cast<std::make_unsigned_t<T>>(value)
-                      : static_cast<std::make_unsigned_t<T>>(value))) {}
+      : BinaryField(internal::UnsignedAbs(value)) {}
   template <typename T, std::enable_if_t<std::is_unsigned_v<T>>* = nullptr>
   constexpr BinaryField(T value) : value_(value) {
     DCHECK_EQ(value_, static_cast<UnderlyingType>(value) & Config::kValueMask);

--- a/zk_dtypes/include/field/small_prime_field.h
+++ b/zk_dtypes/include/field/small_prime_field.h
@@ -71,7 +71,8 @@ class PrimeField<_Config, std::enable_if_t<(_Config::kStorageBits <= 64)>>
   using StdType = PrimeField<typename Config::StdConfig>;
 
   constexpr PrimeField() = default;
-  template <typename T, std::enable_if_t<std::is_signed_v<T>>* = nullptr>
+  template <typename T, std::enable_if_t<std::is_signed_v<T> &&
+                                         std::is_integral_v<T>>* = nullptr>
   constexpr PrimeField(T value) {
     if (value == 0) return;
     if (value == 1) {

--- a/zk_dtypes/tests/field/binary_field_unittest.cc
+++ b/zk_dtypes/tests/field/binary_field_unittest.cc
@@ -15,6 +15,9 @@ limitations under the License.
 
 #include "zk_dtypes/include/field/binary_field.h"
 
+#include <cstdint>
+#include <limits>
+
 #include "gtest/gtest.h"
 
 #include "zk_dtypes/include/field/big_binary_field.h"
@@ -85,6 +88,25 @@ TYPED_TEST(BinaryFieldTypedTest, Max) {
   } else {
     EXPECT_EQ(F::Max(), F(BigInt<2>::Max()));
   }
+}
+
+TYPED_TEST(BinaryFieldTypedTest, SignedConstructionUsesMagnitude) {
+  using F = TypeParam;
+  // In characteristic 2, -x == x, so signed values map to their magnitude.
+  EXPECT_EQ(F(-1), F(1));
+}
+
+TEST(BinaryFieldTest, SignedMinConstruction) {
+  // |int64_t min| is not representable in int64_t; the signed constructor
+  // must compute the magnitude without signed overflow.
+  constexpr uint64_t kMagnitude = uint64_t{1} << 63;
+  EXPECT_EQ(BinaryFieldT6(std::numeric_limits<int64_t>::min()),
+            BinaryFieldT6(kMagnitude));
+  EXPECT_EQ(BinaryFieldT7(std::numeric_limits<int64_t>::min()),
+            BinaryFieldT7(kMagnitude));
+  // Narrow types exercise integer promotion in the unsigned negation.
+  EXPECT_EQ(BinaryFieldT7(std::numeric_limits<int8_t>::min()),
+            BinaryFieldT7(uint64_t{128}));
 }
 
 TYPED_TEST(BinaryFieldTypedTest, AdditionIsXOR) {


### PR DESCRIPTION
The signed scalar ctor on prime, extension, and binary fields was enabled on
`std::is_signed_v<T>`, which is also true for float/double. A floating
argument therefore selected the signed overload; for binary fields it then
failed to compile inside `std::make_unsigned_t<T>`, and for prime/extension it
silently truncated the float to the storage integer.

Constrain every field scalar ctor to `is_signed_v<T> && is_integral_v<T>`.
A float now has no viable field ctor, making float→field a clean compile
error at the call site rather than a fabricated or ill-formed value. EC point
scalar ctors are gated by `is_constructible_v<ScalarField, T>`, so they inherit
the restriction with no change. Unsigned ctors are unchanged (no unsigned
float type).
