### PR TITLE
ci: capture bazel test logs on CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,12 @@ jobs:
             --config=ci \
             //...
 
+      # Capture the runner-local test.log a failed test leaves behind — the CI
+      # stream only carries the FAIL summary, not the gtest output.
+      - name: Upload bazel test logs
+        if: ${{ failure() }}
+        uses: fractalyze/.github/.github/actions/upload-bazel-testlogs@main
+
   pre-commit-style:
     runs-on: [self-hosted, cpu]
     steps:


### PR DESCRIPTION
## What

Add a failure-gated step after the `bazel test` step that uploads the
runner-local `test.log`/`test.xml` via the shared `upload-bazel-testlogs`
composite action (fractalyze/.github#20).

## Why

A failed test's gtest output lives only in a runner-local
`bazel-testlogs/.../test.log`; the CI stream carries only the FAIL summary, so
intermittent failures can't be triaged after the fact. Verified end-to-end on a
green run (the artifact captured a real `test.log`).

Closes #126
Part of fractalyze/.github#21