### PR TITLE
ci: restore linux-aarch64 and macos-arm64 wheel builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,10 +40,44 @@ jobs:
           path: wheelhouse/*.whl
           retention-days: 3
 
+  build-linux-aarch64:
+    name: Build / Linux aarch64
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.22
+        env:
+          CIBW_ARCHS_LINUX: aarch64
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-linux-aarch64
+          path: wheelhouse/*.whl
+          retention-days: 3
+
+  build-macos-arm64:
+    name: Build / macOS arm64
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.22
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos-arm64
+          path: wheelhouse/*.whl
+          retention-days: 3
+
   publish:
     name: Publish
     if: inputs.target != 'build-only'
-    needs: [build-linux-x86_64]
+    needs: [build-linux-x86_64, build-linux-aarch64, build-macos-arm64]
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
## Description

Reverts #122, which temporarily dropped the linux-aarch64 and macos-arm64 wheel
builds from `publish.yml` while downstream consumers ran only on x86_64 Linux.
This restores the full wheel matrix (exact inverse of that change).

## Related Issues/PRs

Reverts #122

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline