### PR TITLE
feat(field): add Goldilocks3Pil, pil2-stark's x³ − x − 1 cubic extension

### DIFF
--- a/zk_dtypes/BUILD.bazel
+++ b/zk_dtypes/BUILD.bazel
@@ -402,6 +402,15 @@ cc_library(
 )
 
 cc_library(
+    name = "goldilocks3_pil",
+    hdrs = ["include/field/goldilocks/goldilocks3_pil.h"],
+    deps = [
+        ":extension_field",
+        ":goldilocks",
+    ],
+)
+
+cc_library(
     name = "goldilocks_multiplication",
     hdrs = ["include/field/goldilocks_multiplication.h"],
     deps = [":arithmetics"],
@@ -575,12 +584,14 @@ cc_test(
     srcs = [
         "tests/field/binary_field_unittest.cc",
         "tests/field/extension_field_unittest.cc",
+        "tests/field/goldilocks3_pil_unittest.cc",
         "tests/field/prime_field_unittest.cc",
         "tests/field/root_of_unity_unittest.cc",
         "tests/field/square_root_algorithms_unittest.cc",
     ],
     deps = [
         ":all_types",
+        ":goldilocks3_pil",
         # TODO(chokobole33): Remove this.
         ":mersenne31x2x2",
         ":random",

--- a/zk_dtypes/include/field/cubic_extension_field_operation.h
+++ b/zk_dtypes/include/field/cubic_extension_field_operation.h
@@ -38,12 +38,11 @@ class CubicExtensionFieldOperation : public ExtensionFieldOperation<Derived>,
     if constexpr (internal::HasModulusLowCoeffs<Derived>::value) {
       // The CH-SQR2 branch below is specific to the binomial modulus u³ = ξ;
       // a general monic modulus squares through Karatsuba's generic fold.
-      // (`if constexpr` + return keeps the ξ code below uninstantiated —
-      // NonResidue() does not exist on a modulus-registered field.)
+      // (The `else` keeps the ξ code uninstantiated — NonResidue() does not
+      // exist on a modulus-registered field.)
       return this->KaratsubaSquare();
-    } else if (ExtensionFieldMulAlgorithm algorithm =
-                   static_cast<const Derived&>(*this).GetSquareAlgorithm();
-               algorithm == ExtensionFieldMulAlgorithm::kCustom) {
+    } else if (static_cast<const Derived&>(*this).GetSquareAlgorithm() ==
+               ExtensionFieldMulAlgorithm::kCustom) {
       // [Comparison]
       // Custom Algorithm (Chung-Hasan):
       // - square: 3, mul: 2, mul by non-residue: 2, add: 5, sub: 3, double: 2

--- a/zk_dtypes/include/field/cubic_extension_field_operation.h
+++ b/zk_dtypes/include/field/cubic_extension_field_operation.h
@@ -35,9 +35,15 @@ class CubicExtensionFieldOperation : public ExtensionFieldOperation<Derived>,
   }
 
   Derived Square() const {
-    ExtensionFieldMulAlgorithm algorithm =
-        static_cast<const Derived&>(*this).GetSquareAlgorithm();
-    if (algorithm == ExtensionFieldMulAlgorithm::kCustom) {
+    if constexpr (internal::HasModulusLowCoeffs<Derived>::value) {
+      // The CH-SQR2 branch below is specific to the binomial modulus u³ = ξ;
+      // a general monic modulus squares through Karatsuba's generic fold.
+      // (`if constexpr` + return keeps the ξ code below uninstantiated —
+      // NonResidue() does not exist on a modulus-registered field.)
+      return this->KaratsubaSquare();
+    } else if (ExtensionFieldMulAlgorithm algorithm =
+                   static_cast<const Derived&>(*this).GetSquareAlgorithm();
+               algorithm == ExtensionFieldMulAlgorithm::kCustom) {
       // [Comparison]
       // Custom Algorithm (Chung-Hasan):
       // - square: 3, mul: 2, mul by non-residue: 2, add: 5, sub: 3, double: 2
@@ -136,52 +142,83 @@ class CubicExtensionFieldOperation : public ExtensionFieldOperation<Derived>,
 
   // Returns the multiplicative inverse. Returns Zero() if not invertible.
   Derived Inverse() const {
-    // [Comparison]
-    // This Algorithm (Matrix Method / Cramer's Rule):
-    // - square: 3, mul: 9, inv: 1 (base field ops)
-    // Standard Itoh-Tsujii:
-    // - square: 3, mul: 12, inv: 1 (approx. 1 Full Fp3-Mul + Dot Product)
-    //
-    // Conclusion:
-    // This algorithm saves ~3 Multiplications. The Matrix Method computes
-    // the first column of the inverse directly, avoiding the overhead of
-    // a full extension field multiplication required by Itoh-Tsujii.
-    const std::array<BaseField, 3>& x =
-        static_cast<const Derived&>(*this).ToCoeffs();
-    BaseField xi = static_cast<const Derived&>(*this)
-                       .NonResidue();  // ξ: Irreducible polynomial constant
-                                       // [Comparison]
+    if constexpr (internal::HasModulusLowCoeffs<Derived>::value) {
+      // General monic modulus u³ ≡ m₀ + m₁u + m₂u²: y = x⁻¹ is the first
+      // column of M⁻¹, where M's columns are x·u⁰, x·u¹, x·u² (the
+      // multiplication-by-x matrix; each ·u is a coefficient shift plus the
+      // modulus fold of the overflowing slot). Expand by the first row's
+      // cofactors — the ξ-matrix method below is exactly this M at
+      // m = (ξ, 0, 0).
+      const std::array<BaseField, 3>& x =
+          static_cast<const Derived&>(*this).ToCoeffs();
+      const std::array<BaseField, 3>& m =
+          static_cast<const Derived&>(*this).ModulusLowCoeffs();
 
-    // Representing an element (x₀ + x₁w + x₂w²) as a 3×3 Matrix:
-    //   [ x₀  ξx₂  ξx₁ ]
-    //   [ x₁  x₀   ξx₂ ]
-    //   [ x₂  x₁   x₀  ]
-    // The inverse is (1 / det) * Adjugate(M).
+      std::array<BaseField, 3> xu = {m[0] * x[2], x[0] + m[1] * x[2],
+                                     x[1] + m[2] * x[2]};
+      std::array<BaseField, 3> xu2 = {m[0] * xu[2], xu[0] + m[1] * xu[2],
+                                      xu[1] + m[2] * xu[2]};
 
-    // 1. Calculate the first column of the Adjugate Matrix (Cofactors)
-    // t₀, t₁, t₂ are the cofactors of the first column of the representation
-    // matrix.
-    // t₀ = x₀² - ξx₁x₂
-    BaseField t0 = x[0].Square() - xi * (x[1] * x[2]);
-    // t₁ = ξx₂² - x₀x₁
-    BaseField t1 = xi * x[2].Square() - x[0] * x[1];
-    // t₂ = x₁² - x₀x₂
-    BaseField t2 = x[1].Square() - x[0] * x[2];
+      // First-row cofactors of M = [x | xu | xu2].
+      BaseField t0 = xu[1] * xu2[2] - xu2[1] * xu[2];
+      BaseField t1 = xu2[1] * x[2] - x[1] * xu2[2];
+      BaseField t2 = x[1] * xu[2] - xu[1] * x[2];
 
-    // 2. Calculate the Determinant (t₃)
-    // Using Laplace expansion along the first column: det = x₀*t₀ + ξx₂*t₁ +
-    // ξx₁*t₂
-    BaseField t3 = x[0] * t0 + xi * (x[2] * t1 + x[1] * t2);
+      // Laplace expansion along the first row. Inverse() returns Zero() if
+      // not invertible, preserving the Zero-for-non-invertible contract.
+      BaseField det_inv = (x[0] * t0 + xu[0] * t1 + xu2[0] * t2).Inverse();
 
-    // 3. Invert the determinant. Inverse() returns Zero() if not invertible.
-    BaseField t3_inv = t3.Inverse();
+      return static_cast<const Derived&>(*this).FromCoeffs(
+          {t0 * det_inv, t1 * det_inv, t2 * det_inv});
+    } else {
+      // [Comparison]
+      // This Algorithm (Matrix Method / Cramer's Rule):
+      // - square: 3, mul: 9, inv: 1 (base field ops)
+      // Standard Itoh-Tsujii:
+      // - square: 3, mul: 12, inv: 1 (approx. 1 Full Fp3-Mul + Dot Product)
+      //
+      // Conclusion:
+      // This algorithm saves ~3 Multiplications. The Matrix Method computes
+      // the first column of the inverse directly, avoiding the overhead of
+      // a full extension field multiplication required by Itoh-Tsujii.
+      const std::array<BaseField, 3>& x =
+          static_cast<const Derived&>(*this).ToCoeffs();
+      BaseField xi = static_cast<const Derived&>(*this)
+                         .NonResidue();  // ξ: Irreducible polynomial constant
+                                         // [Comparison]
 
-    // 4. Final Inverse result: (t₀, t₁, t₂) / det
-    // Since the field is commutative, we only need the first column of the
-    // adjugate.
-    std::array<BaseField, 3> y{t0 * t3_inv, t1 * t3_inv, t2 * t3_inv};
+      // Representing an element (x₀ + x₁w + x₂w²) as a 3×3 Matrix:
+      //   [ x₀  ξx₂  ξx₁ ]
+      //   [ x₁  x₀   ξx₂ ]
+      //   [ x₂  x₁   x₀  ]
+      // The inverse is (1 / det) * Adjugate(M).
 
-    return static_cast<const Derived&>(*this).FromCoeffs(y);
+      // 1. Calculate the first column of the Adjugate Matrix (Cofactors)
+      // t₀, t₁, t₂ are the cofactors of the first column of the
+      // representation matrix.
+      // t₀ = x₀² - ξx₁x₂
+      BaseField t0 = x[0].Square() - xi * (x[1] * x[2]);
+      // t₁ = ξx₂² - x₀x₁
+      BaseField t1 = xi * x[2].Square() - x[0] * x[1];
+      // t₂ = x₁² - x₀x₂
+      BaseField t2 = x[1].Square() - x[0] * x[2];
+
+      // 2. Calculate the Determinant (t₃)
+      // Using Laplace expansion along the first column: det = x₀*t₀ + ξx₂*t₁
+      // + ξx₁*t₂
+      BaseField t3 = x[0] * t0 + xi * (x[2] * t1 + x[1] * t2);
+
+      // 3. Invert the determinant. Inverse() returns Zero() if not
+      // invertible.
+      BaseField t3_inv = t3.Inverse();
+
+      // 4. Final Inverse result: (t₀, t₁, t₂) / det
+      // Since the field is commutative, we only need the first column of the
+      // adjugate.
+      std::array<BaseField, 3> y{t0 * t3_inv, t1 * t3_inv, t2 * t3_inv};
+
+      return static_cast<const Derived&>(*this).FromCoeffs(y);
+    }
   }
 };
 

--- a/zk_dtypes/include/field/extension_field.h
+++ b/zk_dtypes/include/field/extension_field.h
@@ -109,10 +109,12 @@ limitations under the License.
 // x³ - x - 1, registered as m = 1, 1, 0). The config carries
 // kModulusLowCoeffs INSTEAD of kNonResidue; the operation mixins detect the
 // member and route reduction/inverse through the general fold, so binomial
-// fields keep their closed forms untouched. Frobenius stays binomial-only
-// (its diagonal-coefficient form needs uᴺ = ξ); a modulus-registered field
-// has no kNonResidue, so a Frobenius call fails to compile rather than
-// silently miscomputing.
+// fields keep their closed forms untouched. Only the shared Karatsuba fold
+// and the cubic Square/Inverse are generalized so far: Frobenius (its
+// diagonal-coefficient form needs uᴺ = ξ), the quadratic/quartic closed
+// forms, sparse MulBy*, and ToomCook still read kNonResidue — on a
+// modulus-registered field that member does not exist, so any such call
+// fails to compile rather than silently miscomputing.
 #define REGISTER_EXTENSION_FIELD_CONFIGS_WITH_MONT_MODULUS(              \
     Name, BaseFieldIn, BasePrimeFieldIn, Degree, ...)                    \
   template <typename BaseField>                                          \
@@ -152,20 +154,6 @@ namespace zk_dtypes {
 // Forward declaration
 template <typename _Config>
 class ExtensionField;
-
-namespace internal {
-
-// Detects a config registered with a general monic modulus
-// (REGISTER_EXTENSION_FIELD_*_WITH_MONT_MODULUS) rather than a binomial
-// non-residue.
-template <typename C, typename = void>
-struct ConfigHasModulusLowCoeffs : std::false_type {};
-
-template <typename C>
-struct ConfigHasModulusLowCoeffs<C, std::void_t<decltype(C::kModulusLowCoeffs)>>
-    : std::true_type {};
-
-}  // namespace internal
 
 // Selects the appropriate extension field operation based on degree.
 template <typename Config, size_t Degree>
@@ -592,10 +580,9 @@ class ExtensionField : public FiniteField<ExtensionField<_Config>>,
   constexpr const BaseField& NonResidue() const { return Config::kNonResidue; }
   // Present only on a modulus-registered field (uᴺ ≡ Σⱼ mⱼ·uʲ); the operation
   // mixins detect this member to pick the general fold over the ξ closed
-  // forms.
-  template <typename C = Config,
-            std::enable_if_t<internal::ConfigHasModulusLowCoeffs<C>::value>* =
-                nullptr>
+  // forms, so its existence must track the config member exactly — hence the
+  // direct SFINAE on kModulusLowCoeffs rather than a separate trait.
+  template <typename C = Config, typename = decltype(C::kModulusLowCoeffs)>
   constexpr const std::array<BaseField, N>& ModulusLowCoeffs() const {
     return C::kModulusLowCoeffs;
   }

--- a/zk_dtypes/include/field/extension_field.h
+++ b/zk_dtypes/include/field/extension_field.h
@@ -103,11 +103,69 @@ limitations under the License.
   REGISTER_EXTENSION_FIELD_CONFIGS(Name, BaseFieldIn, BasePrimeFieldIn,     \
                                    Degree, __VA_ARGS__)
 
+// Registration for a general monic modulus uᴰᵉᵍʳᵉᵉ = Σⱼ mⱼ·uʲ — the variadic
+// tail is the modulus's low coefficients m₀, m₁, ... (Degree of them). Used
+// when the modulus is not a binomial uᴰᵉᵍʳᵉᵉ - ξ (e.g. pil2-stark's
+// x³ - x - 1, registered as m = 1, 1, 0). The config carries
+// kModulusLowCoeffs INSTEAD of kNonResidue; the operation mixins detect the
+// member and route reduction/inverse through the general fold, so binomial
+// fields keep their closed forms untouched. Frobenius stays binomial-only
+// (its diagonal-coefficient form needs uᴺ = ξ); a modulus-registered field
+// has no kNonResidue, so a Frobenius call fails to compile rather than
+// silently miscomputing.
+#define REGISTER_EXTENSION_FIELD_CONFIGS_WITH_MONT_MODULUS(              \
+    Name, BaseFieldIn, BasePrimeFieldIn, Degree, ...)                    \
+  template <typename BaseField>                                          \
+  class Name##BaseConfig {                                               \
+   public:                                                               \
+    constexpr static uint32_t kDegreeOverBaseField = Degree;             \
+    constexpr static std::array<BaseField, Degree> kModulusLowCoeffs = { \
+        __VA_ARGS__};                                                    \
+  };                                                                     \
+                                                                         \
+  class Name##Config : public Name##BaseConfig<BaseFieldIn> {            \
+   public:                                                               \
+    constexpr static bool kUseMontgomery = false;                        \
+    using StdConfig = Name##Config;                                      \
+    using BaseField = BaseFieldIn;                                       \
+    using BasePrimeField = BasePrimeFieldIn;                             \
+  };                                                                     \
+                                                                         \
+  class Name##MontConfig : public Name##BaseConfig<BaseFieldIn##Mont> {  \
+   public:                                                               \
+    constexpr static bool kUseMontgomery = true;                         \
+    using StdConfig = Name##Config;                                      \
+    using BaseField = BaseFieldIn##Mont;                                 \
+    using BasePrimeField = BasePrimeFieldIn##Mont;                       \
+  };                                                                     \
+                                                                         \
+  using Name = ExtensionField<Name##Config>;                             \
+  using Name##Mont = ExtensionField<Name##MontConfig>
+
+#define REGISTER_EXTENSION_FIELD_WITH_MONT_MODULUS(Name, BaseFieldIn, Degree, \
+                                                   ...)                       \
+  REGISTER_EXTENSION_FIELD_CONFIGS_WITH_MONT_MODULUS(                         \
+      Name, BaseFieldIn, BaseFieldIn, Degree, __VA_ARGS__)
+
 namespace zk_dtypes {
 
 // Forward declaration
 template <typename _Config>
 class ExtensionField;
+
+namespace internal {
+
+// Detects a config registered with a general monic modulus
+// (REGISTER_EXTENSION_FIELD_*_WITH_MONT_MODULUS) rather than a binomial
+// non-residue.
+template <typename C, typename = void>
+struct ConfigHasModulusLowCoeffs : std::false_type {};
+
+template <typename C>
+struct ConfigHasModulusLowCoeffs<C, std::void_t<decltype(C::kModulusLowCoeffs)>>
+    : std::true_type {};
+
+}  // namespace internal
 
 // Selects the appropriate extension field operation based on degree.
 template <typename Config, size_t Degree>
@@ -532,6 +590,15 @@ class ExtensionField : public FiniteField<ExtensionField<_Config>>,
     return BaseField(value);
   }
   constexpr const BaseField& NonResidue() const { return Config::kNonResidue; }
+  // Present only on a modulus-registered field (uᴺ ≡ Σⱼ mⱼ·uʲ); the operation
+  // mixins detect this member to pick the general fold over the ξ closed
+  // forms.
+  template <typename C = Config,
+            std::enable_if_t<internal::ConfigHasModulusLowCoeffs<C>::value>* =
+                nullptr>
+  constexpr const std::array<BaseField, N>& ModulusLowCoeffs() const {
+    return C::kModulusLowCoeffs;
+  }
   ExtensionFieldMulAlgorithm GetMulAlgorithm() const {
     if (mul_algorithm_.has_value()) {
       return mul_algorithm_.value();

--- a/zk_dtypes/include/field/goldilocks/goldilocks3_pil.h
+++ b/zk_dtypes/include/field/goldilocks/goldilocks3_pil.h
@@ -1,0 +1,36 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_FIELD_GOLDILOCKS_GOLDILOCKS3_PIL_H_
+#define ZK_DTYPES_INCLUDE_FIELD_GOLDILOCKS_GOLDILOCKS3_PIL_H_
+
+#include "zk_dtypes/include/field/extension_field.h"
+#include "zk_dtypes/include/field/goldilocks/goldilocks.h"
+
+namespace zk_dtypes {
+
+// pil2-stark's Goldilocks cubic extension (`Goldilocks3`):
+// Goldilocks[u] / (u³ - u - 1), elements [c₀, c₁, c₂] = c₀ + c₁·u + c₂·u².
+// A trinomial modulus, so it registers through the monic-modulus path
+// (u³ ≡ 1 + u → m = 1, 1, 0); the existing GoldilocksX3 (u³ - 7) is a
+// DIFFERENT field representation kept untouched for its holders — pil2
+// byte-match is only possible on this one.
+// https://github.com/0xPolygonHermez/pil2-proofman/blob/v0.18.0/pil2-stark/src/goldilocks/src/goldilocks_cubic_extension.hpp
+REGISTER_EXTENSION_FIELD_WITH_MONT_MODULUS(Goldilocks3Pil, Goldilocks, 3, 1, 1,
+                                           0);
+
+}  // namespace zk_dtypes
+
+#endif  // ZK_DTYPES_INCLUDE_FIELD_GOLDILOCKS_GOLDILOCKS3_PIL_H_

--- a/zk_dtypes/include/field/karatsuba_operation.h
+++ b/zk_dtypes/include/field/karatsuba_operation.h
@@ -18,10 +18,27 @@ limitations under the License.
 
 #include <array>
 #include <cstddef>
+#include <type_traits>
+#include <utility>
 
 #include "zk_dtypes/include/field/extension_field_operation_traits_forward.h"
 
 namespace zk_dtypes {
+namespace internal {
+
+// Detects whether `Derived` carries a non-binomial monic modulus by exposing
+// `ModulusLowCoeffs()` (uᴺ ≡ Σⱼ mⱼ·uʲ, registered via
+// REGISTER_EXTENSION_FIELD_WITH_MONT_MODULUS). Binomial fields keep the
+// scalar `NonResidue()` hook and never define it.
+template <typename T, typename = void>
+struct HasModulusLowCoeffs : std::false_type {};
+
+template <typename T>
+struct HasModulusLowCoeffs<
+    T, std::void_t<decltype(std::declval<const T&>().ModulusLowCoeffs())>>
+    : std::true_type {};
+
+}  // namespace internal
 
 // clang-format off
 // Generalized Karatsuba Multiplication and Squaring for Extension Fields.
@@ -203,17 +220,38 @@ class KaratsubaOperation {
   // 3. Reduction Step (Modulo uᴺ - ξ)
   // ----------------------------------------------------------------------
 
-  // Reduces the product polynomial C(u) modulo (uⁿ - ξ).
-  // Since uⁿ ≡ ξ, we have uⁱ⁺ⁿ ≡ ξ·uⁱ.
-  // The resulting coefficients are zᵢ = cᵢ + ξ·cᵢ₊ₙ.
+  // Reduces the product polynomial C(u) modulo the field's monic modulus.
+  //
+  // Binomial uⁿ - ξ: uⁱ⁺ⁿ ≡ ξ·uⁱ, so zᵢ = cᵢ + ξ·cᵢ₊ₙ.
+  //
+  // General monic modulus (Derived exposes ModulusLowCoeffs; uⁿ ≡ Σⱼ mⱼ·uʲ):
+  // fold each overflow coefficient downward, highest degree first — a fold
+  // landing on another overflow slot (mⱼ ≠ 0 for j > 0) is itself folded
+  // when the descending loop reaches that slot.
   Derived Reduce(const std::array<BaseField, kNumEvaluation>& c) const {
-    BaseField non_residue = static_cast<const Derived&>(*this).NonResidue();
-    std::array<BaseField, kDegree> ret;
-    for (size_t i = 0; i < kDegree - 1; ++i) {
-      ret[i] = c[i] + non_residue * c[i + kDegree];
+    if constexpr (internal::HasModulusLowCoeffs<Derived>::value) {
+      const std::array<BaseField, kDegree>& m =
+          static_cast<const Derived&>(*this).ModulusLowCoeffs();
+      std::array<BaseField, kNumEvaluation> folded = c;
+      for (size_t i = kNumEvaluation - 1; i >= kDegree; --i) {
+        for (size_t j = 0; j < kDegree; ++j) {
+          folded[i - kDegree + j] += m[j] * folded[i];
+        }
+      }
+      std::array<BaseField, kDegree> ret;
+      for (size_t i = 0; i < kDegree; ++i) {
+        ret[i] = folded[i];
+      }
+      return static_cast<const Derived&>(*this).FromCoeffs(ret);
+    } else {
+      BaseField non_residue = static_cast<const Derived&>(*this).NonResidue();
+      std::array<BaseField, kDegree> ret;
+      for (size_t i = 0; i < kDegree - 1; ++i) {
+        ret[i] = c[i] + non_residue * c[i + kDegree];
+      }
+      ret[kDegree - 1] = c[kDegree - 1];
+      return static_cast<const Derived&>(*this).FromCoeffs(ret);
     }
-    ret[kDegree - 1] = c[kDegree - 1];
-    return static_cast<const Derived&>(*this).FromCoeffs(ret);
   }
 };
 

--- a/zk_dtypes/tests/field/goldilocks3_pil_unittest.cc
+++ b/zk_dtypes/tests/field/goldilocks3_pil_unittest.cc
@@ -30,8 +30,7 @@ constexpr uint64_t B[3] = {UINT64_C(987654321), UINT64_C(0xFFFFFFFEFFFFFFFF),
                            UINT64_C(0xDEADBEEFCAFEBABE)};
 
 Goldilocks3Pil FromU64(const uint64_t (&v)[3]) {
-  return Goldilocks3Pil(
-      {Goldilocks(v[0]), Goldilocks(v[1]), Goldilocks(v[2])});
+  return Goldilocks3Pil({Goldilocks(v[0]), Goldilocks(v[1]), Goldilocks(v[2])});
 }
 
 Goldilocks3PilMont FromU64Mont(const uint64_t (&v)[3]) {
@@ -52,8 +51,7 @@ TEST(Goldilocks3PilTest, MulMatchesPil2) {
                                      UINT64_C(11556631869400146760),
                                      UINT64_C(13619946544752105600)};
   EXPECT_EQ(FromU64(A) * FromU64(B), FromU64(kExpected));
-  EXPECT_EQ((FromU64Mont(A) * FromU64Mont(B)).MontReduce(),
-            FromU64(kExpected));
+  EXPECT_EQ((FromU64Mont(A) * FromU64Mont(B)).MontReduce(), FromU64(kExpected));
 }
 
 TEST(Goldilocks3PilTest, SquareMatchesPil2) {

--- a/zk_dtypes/tests/field/goldilocks3_pil_unittest.cc
+++ b/zk_dtypes/tests/field/goldilocks3_pil_unittest.cc
@@ -1,0 +1,116 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "zk_dtypes/include/field/goldilocks/goldilocks3_pil.h"
+
+#include "gtest/gtest.h"
+
+namespace zk_dtypes {
+namespace {
+
+// The byte-match vectors below were generated from pil2-proofman v0.18.0's
+// `fields` crate (`CubicExtensionField<Goldilocks>` — the exact arithmetic
+// the ZisK prover runs) on the fixed inputs in `A` and `B`:
+// https://github.com/0xPolygonHermez/pil2-proofman/blob/v0.18.0/fields/src/extended_field.rs
+constexpr uint64_t A[3] = {UINT64_C(0xFFFFFFFF00000000),
+                           UINT64_C(12345678901234567), UINT64_C(3)};
+constexpr uint64_t B[3] = {UINT64_C(987654321), UINT64_C(0xFFFFFFFEFFFFFFFF),
+                           UINT64_C(0xDEADBEEFCAFEBABE)};
+
+Goldilocks3Pil FromU64(const uint64_t (&v)[3]) {
+  return Goldilocks3Pil(
+      {Goldilocks(v[0]), Goldilocks(v[1]), Goldilocks(v[2])});
+}
+
+Goldilocks3PilMont FromU64Mont(const uint64_t (&v)[3]) {
+  return Goldilocks3PilMont(
+      {GoldilocksMont(v[0]), GoldilocksMont(v[1]), GoldilocksMont(v[2])});
+}
+
+TEST(Goldilocks3PilTest, ModulusIsXCubedMinusXMinusOne) {
+  // u³ must reduce to 1 + u — the pil2 `Goldilocks3` convention, and the
+  // single fact that distinguishes this field from GoldilocksX3 (u³ = 7).
+  Goldilocks3Pil u({Goldilocks(0), Goldilocks(1), Goldilocks(0)});
+  Goldilocks3Pil expected({Goldilocks(1), Goldilocks(1), Goldilocks(0)});
+  EXPECT_EQ(u * u * u, expected);
+}
+
+TEST(Goldilocks3PilTest, MulMatchesPil2) {
+  constexpr uint64_t kExpected[3] = {UINT64_C(16583703172221849613),
+                                     UINT64_C(11556631869400146760),
+                                     UINT64_C(13619946544752105600)};
+  EXPECT_EQ(FromU64(A) * FromU64(B), FromU64(kExpected));
+  EXPECT_EQ((FromU64Mont(A) * FromU64Mont(B)).MontReduce(),
+            FromU64(kExpected));
+}
+
+TEST(Goldilocks3PilTest, SquareMatchesPil2) {
+  constexpr uint64_t kExpectedA[3] = {UINT64_C(74074073407407403),
+                                      UINT64_C(49382715604938277),
+                                      UINT64_C(18132399027456170824)};
+  constexpr uint64_t kExpectedB[3] = {UINT64_C(10579673397435916141),
+                                      UINT64_C(13434714062957531168),
+                                      UINT64_C(9427914128801059483)};
+  EXPECT_EQ(FromU64(A).Square(), FromU64(kExpectedA));
+  EXPECT_EQ(FromU64(B).Square(), FromU64(kExpectedB));
+  EXPECT_EQ(FromU64Mont(A).Square().MontReduce(), FromU64(kExpectedA));
+  EXPECT_EQ(FromU64Mont(B).Square().MontReduce(), FromU64(kExpectedB));
+}
+
+TEST(Goldilocks3PilTest, InverseMatchesPil2) {
+  constexpr uint64_t kExpectedA[3] = {UINT64_C(7422903702349599745),
+                                      UINT64_C(4764441002090916551),
+                                      UINT64_C(17439373525960107448)};
+  constexpr uint64_t kExpectedB[3] = {UINT64_C(17210005891561599323),
+                                      UINT64_C(11708350379886342939),
+                                      UINT64_C(2232599005831579362)};
+  EXPECT_EQ(FromU64(A).Inverse(), FromU64(kExpectedA));
+  EXPECT_EQ(FromU64(B).Inverse(), FromU64(kExpectedB));
+  EXPECT_EQ(FromU64Mont(A).Inverse().MontReduce(), FromU64(kExpectedA));
+  EXPECT_EQ(FromU64Mont(B).Inverse().MontReduce(), FromU64(kExpectedB));
+}
+
+TEST(Goldilocks3PilTest, FieldProperties) {
+  for (int i = 0; i < 100; ++i) {
+    Goldilocks3Pil a = Goldilocks3Pil::Random();
+    Goldilocks3Pil b = Goldilocks3Pil::Random();
+    Goldilocks3Pil c = Goldilocks3Pil::Random();
+    EXPECT_EQ(a * b, b * a);
+    EXPECT_EQ((a * b) * c, a * (b * c));
+    EXPECT_EQ(a * (b + c), a * b + a * c);
+    EXPECT_EQ(a.Square(), a * a);
+    if (!a.IsZero()) {
+      EXPECT_TRUE((a * a.Inverse()).IsOne());
+    }
+  }
+}
+
+TEST(Goldilocks3PilTest, InverseOfZeroIsZero) {
+  EXPECT_TRUE(Goldilocks3Pil::Zero().Inverse().IsZero());
+  EXPECT_TRUE(Goldilocks3PilMont::Zero().Inverse().IsZero());
+}
+
+TEST(Goldilocks3PilTest, MontStdConsistency) {
+  for (int i = 0; i < 100; ++i) {
+    Goldilocks3PilMont a = Goldilocks3PilMont::Random();
+    Goldilocks3PilMont b = Goldilocks3PilMont::Random();
+    EXPECT_EQ((a * b).MontReduce(), a.MontReduce() * b.MontReduce());
+    EXPECT_EQ(a.Square().MontReduce(), a.MontReduce().Square());
+    EXPECT_EQ(a.Inverse().MontReduce(), a.MontReduce().Inverse());
+  }
+}
+
+}  // namespace
+}  // namespace zk_dtypes


### PR DESCRIPTION
## Description

zisk-zorch's FRI slice needs the exact extension field pil2-stark draws FRI challenges in, and the existing `GoldilocksX3` (u³ − 7) is a different field representation, so byte-match is impossible on it. Renaming or changing `GoldilocksX3` would silently change semantics for its holders, hence a separate dtype.

The extension machinery assumed a binomial modulus uᴺ = ξ everywhere a non-residue multiply appears. Rather than hand-writing one-off x³ − x − 1 ops, the registration grows a general monic-modulus path (`REGISTER_EXTENSION_FIELD_WITH_MONT_MODULUS`): the config carries the modulus's low coefficients (uᴺ ≡ Σⱼ mⱼ·uʲ) instead of `kNonResidue`, the Karatsuba reduction folds overflow coefficients highest-degree-first (so a fold that re-overflows is folded again when the loop reaches it), and the cubic inverse builds the multiplication-by-x matrix column by column (each ·u is a shift plus modulus fold) and expands by first-row cofactors — the existing ξ closed forms are exactly this matrix at m = (ξ, 0, 0). Binomial fields keep their closed forms via `if constexpr` detection of the new member, so no existing field changes behavior.

Frobenius stays binomial-only: its diagonal-coefficient form needs uᴺ = ξ, and a modulus-registered field has no `kNonResidue`, so a Frobenius call fails to compile rather than silently miscomputing.

Mul/square/inverse byte-match vectors were generated from pil2-proofman v0.18.0's `fields` crate (`CubicExtensionField<Goldilocks>`, the arithmetic the ZisK prover runs) and are checked on both standard and Montgomery variants.

jax/zkx dtype-table wiring and NTT auto-decomposition follow separately.

## Related Issues/PRs

Part of #133

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline