### PR TITLE
feat(elliptic_curve): add MNT4-298 and MNT6-298 curves and dtypes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,21 @@ using curve25519::FqMont;
    appropriate type list macros in `all_types.h`.
 1. **Tests**: On-curve check, identity addition, inverse, double=add(self),
    Mont/non-Mont consistency.
+1. **numpy exposure** (only if the curve is used from Python, like bn254): only
+   the **PUBLIC** `all_types.h` lists become numpy dtypes — expose the scalar
+   field + G1/G2 point types there; the base field and G2 extension field stay
+   in the `ALL` lists (C++-only, no dtype, no `TypeDescriptorBase`). Then add
+   `TypeDescriptorBase` specializations in `_src/dtypes.cc` and the
+   imports/dtypes/dispatch in `_ecinfo.py` / `_pfinfo.py` / `__init__.py`, plus
+   a python test. **Gotcha — two hardcoded per-scalar-field `if constexpr`
+   dispatches need an arm for the new `Fr`, or the extension module fails to
+   load (or `scalar * point` silently no-ops):** `RegisterEcPointMultiplyUFunc`
+   in `_src/ec_point_numpy.h` (its `else { return false; }` aborts module init)
+   and `PyField_nb_multiply` in `_src/field_numpy.h`. Both `#include` curve
+   headers directly (not `all_types.h`), so add the new curve's includes there
+   too. A curve with G2 over a non-quadratic extension (e.g. MNT6's Fp³) also
+   needs the G2 extension degree threaded into the `_ecinfo.py` storage-size
+   computation.
 
 ## Downstream Integration
 

--- a/zk_dtypes/BUILD.bazel
+++ b/zk_dtypes/BUILD.bazel
@@ -46,6 +46,11 @@ cc_library(
         ":mersenne31",
         ":mersenne31x2",
         ":mersenne31x2x2",
+        ":mnt4_298_fq",
+        ":mnt4_298_fqx2",
+        ":mnt4_298_fr",
+        ":mnt4_298_g1",
+        ":mnt4_298_g2",
         ":secp256k1_g1",
         ":secp256r1_g1",
     ],
@@ -712,6 +717,62 @@ cc_library(
 )
 
 cc_library(
+    name = "mnt4_298_fq",
+    hdrs = ["include/elliptic_curve/mnt4_298/fq.h"],
+    deps = [":big_prime_field"],
+)
+
+cc_library(
+    name = "mnt4_298_fr",
+    hdrs = ["include/elliptic_curve/mnt4_298/fr.h"],
+    deps = [":big_prime_field"],
+)
+
+cc_library(
+    name = "mnt4_298_fqx2",
+    hdrs = ["include/elliptic_curve/mnt4_298/fqx2.h"],
+    deps = [
+        ":extension_field",
+        ":mnt4_298_fq",
+    ],
+)
+
+cc_library(
+    name = "mnt4_298_fqx4",
+    hdrs = ["include/elliptic_curve/mnt4_298/fqx4.h"],
+    deps = [
+        ":extension_field",
+        ":mnt4_298_fqx2",
+    ],
+)
+
+cc_library(
+    name = "mnt4_298_g1",
+    hdrs = ["include/elliptic_curve/mnt4_298/g1.h"],
+    deps = [
+        ":mnt4_298_fq",
+        ":mnt4_298_fr",
+        ":sw_affine_point",
+        ":sw_curve",
+        ":sw_jacobian_point",
+        ":sw_point_xyzz",
+    ],
+)
+
+cc_library(
+    name = "mnt4_298_g2",
+    hdrs = ["include/elliptic_curve/mnt4_298/g2.h"],
+    deps = [
+        ":mnt4_298_fqx2",
+        ":mnt4_298_fr",
+        ":sw_affine_point",
+        ":sw_curve",
+        ":sw_jacobian_point",
+        ":sw_point_xyzz",
+    ],
+)
+
+cc_library(
     name = "secp256k1_fq",
     hdrs = ["include/elliptic_curve/secp256k1/fq.h"],
     deps = [":big_prime_field"],
@@ -1083,6 +1144,9 @@ cc_test(
         ":bls12_381_g1",
         ":bn254_g1",
         ":bn254_g2",
+        ":mnt4_298_fqx4",
+        ":mnt4_298_g1",
+        ":mnt4_298_g2",
         ":secp256k1_g1",
         ":secp256r1_fq",
         ":secp256r1_g1",
@@ -1196,6 +1260,17 @@ py_test(
     main = "tests/ec_point_test.py",
     deps = [
         ":test_utils",
+        ":zk_dtypes_py",
+        "@pypi//absl_py",
+        "@pypi//numpy",
+    ],
+)
+
+py_test(
+    name = "mnt4_298_test",
+    srcs = ["tests/mnt4_298_test.py"],
+    main = "tests/mnt4_298_test.py",
+    deps = [
         ":zk_dtypes_py",
         "@pypi//absl_py",
         "@pypi//numpy",

--- a/zk_dtypes/BUILD.bazel
+++ b/zk_dtypes/BUILD.bazel
@@ -51,6 +51,11 @@ cc_library(
         ":mnt4_298_fr",
         ":mnt4_298_g1",
         ":mnt4_298_g2",
+        ":mnt6_298_fq",
+        ":mnt6_298_fqx3",
+        ":mnt6_298_fr",
+        ":mnt6_298_g1",
+        ":mnt6_298_g2",
         ":secp256k1_g1",
         ":secp256r1_g1",
     ],
@@ -773,6 +778,62 @@ cc_library(
 )
 
 cc_library(
+    name = "mnt6_298_fq",
+    hdrs = ["include/elliptic_curve/mnt6_298/fq.h"],
+    deps = [":big_prime_field"],
+)
+
+cc_library(
+    name = "mnt6_298_fr",
+    hdrs = ["include/elliptic_curve/mnt6_298/fr.h"],
+    deps = [":big_prime_field"],
+)
+
+cc_library(
+    name = "mnt6_298_fqx3",
+    hdrs = ["include/elliptic_curve/mnt6_298/fqx3.h"],
+    deps = [
+        ":extension_field",
+        ":mnt6_298_fq",
+    ],
+)
+
+cc_library(
+    name = "mnt6_298_fqx6",
+    hdrs = ["include/elliptic_curve/mnt6_298/fqx6.h"],
+    deps = [
+        ":extension_field",
+        ":mnt6_298_fqx3",
+    ],
+)
+
+cc_library(
+    name = "mnt6_298_g1",
+    hdrs = ["include/elliptic_curve/mnt6_298/g1.h"],
+    deps = [
+        ":mnt6_298_fq",
+        ":mnt6_298_fr",
+        ":sw_affine_point",
+        ":sw_curve",
+        ":sw_jacobian_point",
+        ":sw_point_xyzz",
+    ],
+)
+
+cc_library(
+    name = "mnt6_298_g2",
+    hdrs = ["include/elliptic_curve/mnt6_298/g2.h"],
+    deps = [
+        ":mnt6_298_fqx3",
+        ":mnt6_298_fr",
+        ":sw_affine_point",
+        ":sw_curve",
+        ":sw_jacobian_point",
+        ":sw_point_xyzz",
+    ],
+)
+
+cc_library(
     name = "secp256k1_fq",
     hdrs = ["include/elliptic_curve/secp256k1/fq.h"],
     deps = [":big_prime_field"],
@@ -1147,6 +1208,9 @@ cc_test(
         ":mnt4_298_fqx4",
         ":mnt4_298_g1",
         ":mnt4_298_g2",
+        ":mnt6_298_fqx6",
+        ":mnt6_298_g1",
+        ":mnt6_298_g2",
         ":secp256k1_g1",
         ":secp256r1_fq",
         ":secp256r1_g1",
@@ -1270,6 +1334,17 @@ py_test(
     name = "mnt4_298_test",
     srcs = ["tests/mnt4_298_test.py"],
     main = "tests/mnt4_298_test.py",
+    deps = [
+        ":zk_dtypes_py",
+        "@pypi//absl_py",
+        "@pypi//numpy",
+    ],
+)
+
+py_test(
+    name = "mnt6_298_test",
+    srcs = ["tests/mnt6_298_test.py"],
+    main = "tests/mnt6_298_test.py",
     deps = [
         ":zk_dtypes_py",
         "@pypi//absl_py",

--- a/zk_dtypes/__init__.py
+++ b/zk_dtypes/__init__.py
@@ -42,6 +42,8 @@ __all__ = [
     "bn254_sf_mont",
     "mnt4_298_sf",
     "mnt4_298_sf_mont",
+    "mnt6_298_sf",
+    "mnt6_298_sf_mont",
     # Extension field types
     "babybearx4",
     "babybearx4_mont",
@@ -84,6 +86,18 @@ __all__ = [
     "mnt4_298_g2_jacobian_mont",
     "mnt4_298_g2_xyzz",
     "mnt4_298_g2_xyzz_mont",
+    "mnt6_298_g1_affine",
+    "mnt6_298_g1_affine_mont",
+    "mnt6_298_g1_jacobian",
+    "mnt6_298_g1_jacobian_mont",
+    "mnt6_298_g1_xyzz",
+    "mnt6_298_g1_xyzz_mont",
+    "mnt6_298_g2_affine",
+    "mnt6_298_g2_affine_mont",
+    "mnt6_298_g2_jacobian",
+    "mnt6_298_g2_jacobian_mont",
+    "mnt6_298_g2_xyzz",
+    "mnt6_298_g2_xyzz_mont",
 ]
 
 from typing import Type
@@ -111,6 +125,8 @@ from zk_dtypes._zk_dtypes_ext import bn254_sf
 from zk_dtypes._zk_dtypes_ext import bn254_sf_mont
 from zk_dtypes._zk_dtypes_ext import mnt4_298_sf
 from zk_dtypes._zk_dtypes_ext import mnt4_298_sf_mont
+from zk_dtypes._zk_dtypes_ext import mnt6_298_sf
+from zk_dtypes._zk_dtypes_ext import mnt6_298_sf_mont
 from zk_dtypes._zk_dtypes_ext import babybearx4
 from zk_dtypes._zk_dtypes_ext import babybearx4_mont
 from zk_dtypes._zk_dtypes_ext import goldilocksx3
@@ -150,6 +166,18 @@ from zk_dtypes._zk_dtypes_ext import mnt4_298_g2_jacobian
 from zk_dtypes._zk_dtypes_ext import mnt4_298_g2_jacobian_mont
 from zk_dtypes._zk_dtypes_ext import mnt4_298_g2_xyzz
 from zk_dtypes._zk_dtypes_ext import mnt4_298_g2_xyzz_mont
+from zk_dtypes._zk_dtypes_ext import mnt6_298_g1_affine
+from zk_dtypes._zk_dtypes_ext import mnt6_298_g1_affine_mont
+from zk_dtypes._zk_dtypes_ext import mnt6_298_g1_jacobian
+from zk_dtypes._zk_dtypes_ext import mnt6_298_g1_jacobian_mont
+from zk_dtypes._zk_dtypes_ext import mnt6_298_g1_xyzz
+from zk_dtypes._zk_dtypes_ext import mnt6_298_g1_xyzz_mont
+from zk_dtypes._zk_dtypes_ext import mnt6_298_g2_affine
+from zk_dtypes._zk_dtypes_ext import mnt6_298_g2_affine_mont
+from zk_dtypes._zk_dtypes_ext import mnt6_298_g2_jacobian
+from zk_dtypes._zk_dtypes_ext import mnt6_298_g2_jacobian_mont
+from zk_dtypes._zk_dtypes_ext import mnt6_298_g2_xyzz
+from zk_dtypes._zk_dtypes_ext import mnt6_298_g2_xyzz_mont
 
 import numpy as np
 
@@ -172,6 +200,8 @@ bn254_sf: Type[np.generic]
 bn254_sf_mont: Type[np.generic]
 mnt4_298_sf: Type[np.generic]
 mnt4_298_sf_mont: Type[np.generic]
+mnt6_298_sf: Type[np.generic]
+mnt6_298_sf_mont: Type[np.generic]
 babybearx4: Type[np.generic]
 babybearx4_mont: Type[np.generic]
 goldilocksx3: Type[np.generic]
@@ -211,5 +241,17 @@ mnt4_298_g2_jacobian: Type[np.generic]
 mnt4_298_g2_jacobian_mont: Type[np.generic]
 mnt4_298_g2_xyzz: Type[np.generic]
 mnt4_298_g2_xyzz_mont: Type[np.generic]
+mnt6_298_g1_affine: Type[np.generic]
+mnt6_298_g1_affine_mont: Type[np.generic]
+mnt6_298_g1_jacobian: Type[np.generic]
+mnt6_298_g1_jacobian_mont: Type[np.generic]
+mnt6_298_g1_xyzz: Type[np.generic]
+mnt6_298_g1_xyzz_mont: Type[np.generic]
+mnt6_298_g2_affine: Type[np.generic]
+mnt6_298_g2_affine_mont: Type[np.generic]
+mnt6_298_g2_jacobian: Type[np.generic]
+mnt6_298_g2_jacobian_mont: Type[np.generic]
+mnt6_298_g2_xyzz: Type[np.generic]
+mnt6_298_g2_xyzz_mont: Type[np.generic]
 
 del np, Type

--- a/zk_dtypes/__init__.py
+++ b/zk_dtypes/__init__.py
@@ -40,6 +40,8 @@ __all__ = [
     # Big prime field types
     "bn254_sf",
     "bn254_sf_mont",
+    "mnt4_298_sf",
+    "mnt4_298_sf_mont",
     # Extension field types
     "babybearx4",
     "babybearx4_mont",
@@ -70,6 +72,18 @@ __all__ = [
     "bn254_g2_jacobian_mont",
     "bn254_g2_xyzz",
     "bn254_g2_xyzz_mont",
+    "mnt4_298_g1_affine",
+    "mnt4_298_g1_affine_mont",
+    "mnt4_298_g1_jacobian",
+    "mnt4_298_g1_jacobian_mont",
+    "mnt4_298_g1_xyzz",
+    "mnt4_298_g1_xyzz_mont",
+    "mnt4_298_g2_affine",
+    "mnt4_298_g2_affine_mont",
+    "mnt4_298_g2_jacobian",
+    "mnt4_298_g2_jacobian_mont",
+    "mnt4_298_g2_xyzz",
+    "mnt4_298_g2_xyzz_mont",
 ]
 
 from typing import Type
@@ -95,6 +109,8 @@ from zk_dtypes._zk_dtypes_ext import koalabear_mont
 from zk_dtypes._zk_dtypes_ext import mersenne31
 from zk_dtypes._zk_dtypes_ext import bn254_sf
 from zk_dtypes._zk_dtypes_ext import bn254_sf_mont
+from zk_dtypes._zk_dtypes_ext import mnt4_298_sf
+from zk_dtypes._zk_dtypes_ext import mnt4_298_sf_mont
 from zk_dtypes._zk_dtypes_ext import babybearx4
 from zk_dtypes._zk_dtypes_ext import babybearx4_mont
 from zk_dtypes._zk_dtypes_ext import goldilocksx3
@@ -122,6 +138,18 @@ from zk_dtypes._zk_dtypes_ext import bn254_g2_jacobian
 from zk_dtypes._zk_dtypes_ext import bn254_g2_jacobian_mont
 from zk_dtypes._zk_dtypes_ext import bn254_g2_xyzz
 from zk_dtypes._zk_dtypes_ext import bn254_g2_xyzz_mont
+from zk_dtypes._zk_dtypes_ext import mnt4_298_g1_affine
+from zk_dtypes._zk_dtypes_ext import mnt4_298_g1_affine_mont
+from zk_dtypes._zk_dtypes_ext import mnt4_298_g1_jacobian
+from zk_dtypes._zk_dtypes_ext import mnt4_298_g1_jacobian_mont
+from zk_dtypes._zk_dtypes_ext import mnt4_298_g1_xyzz
+from zk_dtypes._zk_dtypes_ext import mnt4_298_g1_xyzz_mont
+from zk_dtypes._zk_dtypes_ext import mnt4_298_g2_affine
+from zk_dtypes._zk_dtypes_ext import mnt4_298_g2_affine_mont
+from zk_dtypes._zk_dtypes_ext import mnt4_298_g2_jacobian
+from zk_dtypes._zk_dtypes_ext import mnt4_298_g2_jacobian_mont
+from zk_dtypes._zk_dtypes_ext import mnt4_298_g2_xyzz
+from zk_dtypes._zk_dtypes_ext import mnt4_298_g2_xyzz_mont
 
 import numpy as np
 
@@ -142,6 +170,8 @@ koalabear_mont: Type[np.generic]
 mersenne31: Type[np.generic]
 bn254_sf: Type[np.generic]
 bn254_sf_mont: Type[np.generic]
+mnt4_298_sf: Type[np.generic]
+mnt4_298_sf_mont: Type[np.generic]
 babybearx4: Type[np.generic]
 babybearx4_mont: Type[np.generic]
 goldilocksx3: Type[np.generic]
@@ -169,5 +199,17 @@ bn254_g2_jacobian: Type[np.generic]
 bn254_g2_jacobian_mont: Type[np.generic]
 bn254_g2_xyzz: Type[np.generic]
 bn254_g2_xyzz_mont: Type[np.generic]
+mnt4_298_g1_affine: Type[np.generic]
+mnt4_298_g1_affine_mont: Type[np.generic]
+mnt4_298_g1_jacobian: Type[np.generic]
+mnt4_298_g1_jacobian_mont: Type[np.generic]
+mnt4_298_g1_xyzz: Type[np.generic]
+mnt4_298_g1_xyzz_mont: Type[np.generic]
+mnt4_298_g2_affine: Type[np.generic]
+mnt4_298_g2_affine_mont: Type[np.generic]
+mnt4_298_g2_jacobian: Type[np.generic]
+mnt4_298_g2_jacobian_mont: Type[np.generic]
+mnt4_298_g2_xyzz: Type[np.generic]
+mnt4_298_g2_xyzz_mont: Type[np.generic]
 
 del np, Type

--- a/zk_dtypes/_ecinfo.py
+++ b/zk_dtypes/_ecinfo.py
@@ -29,30 +29,38 @@ from zk_dtypes._zk_dtypes_ext import bn254_g2_jacobian
 from zk_dtypes._zk_dtypes_ext import bn254_g2_jacobian_mont
 from zk_dtypes._zk_dtypes_ext import bn254_g2_xyzz
 from zk_dtypes._zk_dtypes_ext import bn254_g2_xyzz_mont
+from zk_dtypes._zk_dtypes_ext import mnt4_298_sf
+from zk_dtypes._zk_dtypes_ext import mnt4_298_sf_mont
+from zk_dtypes._zk_dtypes_ext import mnt4_298_g1_affine
+from zk_dtypes._zk_dtypes_ext import mnt4_298_g1_affine_mont
+from zk_dtypes._zk_dtypes_ext import mnt4_298_g1_jacobian
+from zk_dtypes._zk_dtypes_ext import mnt4_298_g1_jacobian_mont
+from zk_dtypes._zk_dtypes_ext import mnt4_298_g1_xyzz
+from zk_dtypes._zk_dtypes_ext import mnt4_298_g1_xyzz_mont
+from zk_dtypes._zk_dtypes_ext import mnt4_298_g2_affine
+from zk_dtypes._zk_dtypes_ext import mnt4_298_g2_affine_mont
+from zk_dtypes._zk_dtypes_ext import mnt4_298_g2_jacobian
+from zk_dtypes._zk_dtypes_ext import mnt4_298_g2_jacobian_mont
+from zk_dtypes._zk_dtypes_ext import mnt4_298_g2_xyzz
+from zk_dtypes._zk_dtypes_ext import mnt4_298_g2_xyzz_mont
 
 import numpy as np
 
 _bn254_sf_dtype = np.dtype(bn254_sf)
 _bn254_sf_mont_dtype = np.dtype(bn254_sf_mont)
-_bn254_g1_affine_dtype = np.dtype(bn254_g1_affine)
-_bn254_g1_affine_mont_dtype = np.dtype(bn254_g1_affine_mont)
-_bn254_g1_jacobian_dtype = np.dtype(bn254_g1_jacobian)
-_bn254_g1_jacobian_mont_dtype = np.dtype(bn254_g1_jacobian_mont)
-_bn254_g1_xyzz_dtype = np.dtype(bn254_g1_xyzz)
-_bn254_g1_xyzz_mont_dtype = np.dtype(bn254_g1_xyzz_mont)
-_bn254_g2_affine_dtype = np.dtype(bn254_g2_affine)
-_bn254_g2_affine_mont_dtype = np.dtype(bn254_g2_affine_mont)
-_bn254_g2_jacobian_dtype = np.dtype(bn254_g2_jacobian)
-_bn254_g2_jacobian_mont_dtype = np.dtype(bn254_g2_jacobian_mont)
-_bn254_g2_xyzz_dtype = np.dtype(bn254_g2_xyzz)
-_bn254_g2_xyzz_mont_dtype = np.dtype(bn254_g2_xyzz_mont)
+_mnt4_298_sf_dtype = np.dtype(mnt4_298_sf)
+_mnt4_298_sf_mont_dtype = np.dtype(mnt4_298_sf_mont)
 
-_BN254_A = 0
-_BN254_B = 3
+# ---------------------------------------------------------------------------
+# bn254 curve parameters (y² = x³ + ax + b). G2 lives over Fp² = Fq[u]/(u²-β).
+# ---------------------------------------------------------------------------
+_BN254_G1_A = 0
+_BN254_G1_B = 3
 _BN254_G1_GX = 1
 _BN254_G1_GY = 2
 
 # G1 Montgomery form: each value * R mod Fq
+_BN254_G1_A_MONT = 0
 _BN254_G1_B_MONT = 19052624634359457937016868847204597229365286637454337178037183604060995791063
 _BN254_G1_GX_MONT = (
     6350874878119819312338956282401532409788428879151445726012394534686998597021
@@ -60,6 +68,7 @@ _BN254_G1_GX_MONT = (
 _BN254_G1_GY_MONT = 12701749756239638624677912564803064819576857758302891452024789069373997194042
 
 # G2 standard form: Fp2 elements [c₀, c₁] where val = c₀ + c₁ * u
+_BN254_G2_A = [0, 0]
 _BN254_G2_B = [
     19485874751759354771024239261021720505790618469301721065564631296452457478373,
     266929791119991161246907387137283842545076965332900288569378510910307636690,
@@ -75,6 +84,7 @@ _BN254_G2_GY = [
 _BN254_G2_NON_RESIDUE = 21888242871839275222246405745257275088696311157297823662689037894645226208582
 
 # G2 Montgomery form: each Fp² component * R mod Fq
+_BN254_G2_A_MONT = [0, 0]
 _BN254_G2_B_MONT = [
     16772280239760917788496391897731603718812008455956943122563801666366297604776,
     568440292453150825972223760836185707764922522371208948902804025364325400423,
@@ -88,6 +98,184 @@ _BN254_G2_GY_MONT = [
     6170940445994484564222204938066213705353407449799250191249554538140978927342,
 ]
 _BN254_G2_NON_RESIDUE_MONT = 15537367993719455909907449462855742678907882278146377936676643359958227611562
+
+# ---------------------------------------------------------------------------
+# MNT4-298 curve parameters (ark-mnt4-298). G1: y² = x³ + 2x + b over Fq.
+# G2 over Fp² = Fq[u]/(u²-17); twist a = (34, 0), b = (0, b·17). 320-bit field.
+# Montgomery form = value * R mod p, R = 2³²⁰.
+# ---------------------------------------------------------------------------
+_MNT4_298_G1_A = 2
+_MNT4_298_G1_B = 423894536526684178289416011533888240029318103673896002803341544124054745019340795360841685
+_MNT4_298_G1_GX = 60760244141852568949126569781626075788424196370144486719385562369396875346601926534016838
+_MNT4_298_G1_GY = 363732850702582978263902770815145784459747722357071843971107674179038674942891694705904306
+
+_MNT4_298_G1_A_MONT = 446729296652562829877603410718446059103655029145798501270518660890454746243743614887200952
+_MNT4_298_G1_B_MONT = 179877917358261777753314219897940120444991346955733434661847233718565124864239546371263281
+_MNT4_298_G1_GX_MONT = 354680644509934968175469258381357629814402639583090735032750513901318014671205221931808948
+_MNT4_298_G1_GY_MONT = 445280841095252623635668290173967960852066584341969329684246826090979024898521426833907837
+
+_MNT4_298_G2_A = [34, 0]
+_MNT4_298_G2_B = [
+    0,
+    67372828414711144619833451280373307321534573815811166723479321465776723059456513877937430,
+]
+_MNT4_298_G2_GX = [
+    438374926219350099854919100077809681842783509163790991847867546339851681564223481322252708,
+    37620953615500480110935514360923278605464476459712393277679280819942849043649216370485641,
+]
+_MNT4_298_G2_GY = [
+    37437409008528968268352521034936931842973546441370663118543015118291998305624025037512482,
+    424621479598893882672393190337420680597584695892317197646113820787463109735345923009077489,
+]
+_MNT4_298_G2_NON_RESIDUE = 17
+
+_MNT4_298_G2_A_MONT = [
+    455563750554648221619019237417856231585262306838153640665490306494576743874304445826044969,
+    0,
+]
+_MNT4_298_G2_B_MONT = [
+    0,
+    202390878074882267286246240346691338294103622791300036878072201758345545784337485408927291,
+]
+_MNT4_298_G2_GX_MONT = [
+    187432131579426194088031088405014791977840906396261280983391303286363730912415292160457714,
+    266760376307210572592346313524809001086973414552101896394659348925629059473236215626936176,
+]
+_MNT4_298_G2_GY_MONT = [
+    306057346885993003434071827587844987524397598107209712539417326681795274602240783738183828,
+    250975396713672639336952031314618276534945250112062301003586398268356393471632083123571796,
+]
+_MNT4_298_G2_NON_RESIDUE_MONT = 465743018361954773686184243535452341565193593040424183030522717535393503346130123154901525
+
+# Per-(curve, group, is_montgomery) curve coefficient + generator tables.
+_CURVE_PARAMS = {
+    ('bn254', 'g1', False): dict(
+        a=_BN254_G1_A,
+        b=_BN254_G1_B,
+        gx=_BN254_G1_GX,
+        gy=_BN254_G1_GY,
+        non_residue=None,
+    ),
+    ('bn254', 'g1', True): dict(
+        a=_BN254_G1_A_MONT,
+        b=_BN254_G1_B_MONT,
+        gx=_BN254_G1_GX_MONT,
+        gy=_BN254_G1_GY_MONT,
+        non_residue=None,
+    ),
+    ('bn254', 'g2', False): dict(
+        a=_BN254_G2_A,
+        b=_BN254_G2_B,
+        gx=_BN254_G2_GX,
+        gy=_BN254_G2_GY,
+        non_residue=_BN254_G2_NON_RESIDUE,
+    ),
+    ('bn254', 'g2', True): dict(
+        a=_BN254_G2_A_MONT,
+        b=_BN254_G2_B_MONT,
+        gx=_BN254_G2_GX_MONT,
+        gy=_BN254_G2_GY_MONT,
+        non_residue=_BN254_G2_NON_RESIDUE_MONT,
+    ),
+    ('mnt4_298', 'g1', False): dict(
+        a=_MNT4_298_G1_A,
+        b=_MNT4_298_G1_B,
+        gx=_MNT4_298_G1_GX,
+        gy=_MNT4_298_G1_GY,
+        non_residue=None,
+    ),
+    ('mnt4_298', 'g1', True): dict(
+        a=_MNT4_298_G1_A_MONT,
+        b=_MNT4_298_G1_B_MONT,
+        gx=_MNT4_298_G1_GX_MONT,
+        gy=_MNT4_298_G1_GY_MONT,
+        non_residue=None,
+    ),
+    ('mnt4_298', 'g2', False): dict(
+        a=_MNT4_298_G2_A,
+        b=_MNT4_298_G2_B,
+        gx=_MNT4_298_G2_GX,
+        gy=_MNT4_298_G2_GY,
+        non_residue=_MNT4_298_G2_NON_RESIDUE,
+    ),
+    ('mnt4_298', 'g2', True): dict(
+        a=_MNT4_298_G2_A_MONT,
+        b=_MNT4_298_G2_B_MONT,
+        gx=_MNT4_298_G2_GX_MONT,
+        gy=_MNT4_298_G2_GY_MONT,
+        non_residue=_MNT4_298_G2_NON_RESIDUE_MONT,
+    ),
+}
+
+# (group, repr, num_coords, ext_degree): storage = num_coords * ext * field_bits.
+_EC_LAYOUT = [
+    ('g1', 'affine', 2, 1),
+    ('g1', 'jacobian', 3, 1),
+    ('g1', 'xyzz', 4, 1),
+    ('g2', 'affine', 2, 2),
+    ('g2', 'jacobian', 3, 2),
+    ('g2', 'xyzz', 4, 2),
+]
+
+
+def _build_meta(curve, field_bits, scalar_std, scalar_mont, dtype_table):
+  """Maps each registered point dtype -> (curve, group, repr, is_mont,
+  storage_bits, base_field_dtype)."""
+  meta = {}
+  for group, repr_, num_coords, ext in _EC_LAYOUT:
+    bits = num_coords * ext * field_bits
+    for is_mont in (False, True):
+      dt = np.dtype(dtype_table[(group, repr_, is_mont)])
+      base = scalar_mont if is_mont else scalar_std
+      meta[dt] = (curve, group, repr_, is_mont, bits, base)
+  return meta
+
+
+_EC_DTYPE_META = {}
+_EC_DTYPE_META.update(
+    _build_meta(
+        'bn254',
+        256,
+        _bn254_sf_dtype,
+        _bn254_sf_mont_dtype,
+        {
+            ('g1', 'affine', False): bn254_g1_affine,
+            ('g1', 'affine', True): bn254_g1_affine_mont,
+            ('g1', 'jacobian', False): bn254_g1_jacobian,
+            ('g1', 'jacobian', True): bn254_g1_jacobian_mont,
+            ('g1', 'xyzz', False): bn254_g1_xyzz,
+            ('g1', 'xyzz', True): bn254_g1_xyzz_mont,
+            ('g2', 'affine', False): bn254_g2_affine,
+            ('g2', 'affine', True): bn254_g2_affine_mont,
+            ('g2', 'jacobian', False): bn254_g2_jacobian,
+            ('g2', 'jacobian', True): bn254_g2_jacobian_mont,
+            ('g2', 'xyzz', False): bn254_g2_xyzz,
+            ('g2', 'xyzz', True): bn254_g2_xyzz_mont,
+        },
+    )
+)
+_EC_DTYPE_META.update(
+    _build_meta(
+        'mnt4_298',
+        320,
+        _mnt4_298_sf_dtype,
+        _mnt4_298_sf_mont_dtype,
+        {
+            ('g1', 'affine', False): mnt4_298_g1_affine,
+            ('g1', 'affine', True): mnt4_298_g1_affine_mont,
+            ('g1', 'jacobian', False): mnt4_298_g1_jacobian,
+            ('g1', 'jacobian', True): mnt4_298_g1_jacobian_mont,
+            ('g1', 'xyzz', False): mnt4_298_g1_xyzz,
+            ('g1', 'xyzz', True): mnt4_298_g1_xyzz_mont,
+            ('g2', 'affine', False): mnt4_298_g2_affine,
+            ('g2', 'affine', True): mnt4_298_g2_affine_mont,
+            ('g2', 'jacobian', False): mnt4_298_g2_jacobian,
+            ('g2', 'jacobian', True): mnt4_298_g2_jacobian_mont,
+            ('g2', 'xyzz', False): mnt4_298_g2_xyzz,
+            ('g2', 'xyzz', True): mnt4_298_g2_xyzz_mont,
+        },
+    )
+)
 
 
 class ecinfo:  # pylint: disable=invalid-name,missing-class-docstring
@@ -105,111 +293,26 @@ class ecinfo:  # pylint: disable=invalid-name,missing-class-docstring
 
   def __init__(self, ec_type):
     ec_type = np.dtype(ec_type)
-    self.dtype = ec_type
-    self.a = _BN254_A
-
-    # G1 types (base field is bn254_sf)
-    if ec_type == _bn254_g1_affine_dtype:
-      self.base_field_dtype = _bn254_sf_dtype
-      self.storage_bits = 512  # 2 × 256 bits (x, y)
-      self.point_repr = 'affine'
-      self.curve_group = 'g1'
-      self.is_montgomery = False
-    elif ec_type == _bn254_g1_affine_mont_dtype:
-      self.base_field_dtype = _bn254_sf_mont_dtype
-      self.storage_bits = 512
-      self.point_repr = 'affine'
-      self.curve_group = 'g1'
-      self.is_montgomery = True
-    elif ec_type == _bn254_g1_jacobian_dtype:
-      self.base_field_dtype = _bn254_sf_dtype
-      self.storage_bits = 768  # 3 × 256 bits (x, y, z)
-      self.point_repr = 'jacobian'
-      self.curve_group = 'g1'
-      self.is_montgomery = False
-    elif ec_type == _bn254_g1_jacobian_mont_dtype:
-      self.base_field_dtype = _bn254_sf_mont_dtype
-      self.storage_bits = 768
-      self.point_repr = 'jacobian'
-      self.curve_group = 'g1'
-      self.is_montgomery = True
-    elif ec_type == _bn254_g1_xyzz_dtype:
-      self.base_field_dtype = _bn254_sf_dtype
-      self.storage_bits = 1024  # 4 × 256 bits (x, y, zz, zzz)
-      self.point_repr = 'xyzz'
-      self.curve_group = 'g1'
-      self.is_montgomery = False
-    elif ec_type == _bn254_g1_xyzz_mont_dtype:
-      self.base_field_dtype = _bn254_sf_mont_dtype
-      self.storage_bits = 1024
-      self.point_repr = 'xyzz'
-      self.curve_group = 'g1'
-      self.is_montgomery = True
-    # G2 types (base field is Fp2 extension field, but we use bn254_sf for now)
-    # NOTE: G2 points use extension field Fp2 as their base field.
-    # For MLIR lowering, this will require creating an ExtensionFieldType.
-    elif ec_type == _bn254_g2_affine_dtype:
-      self.base_field_dtype = _bn254_sf_dtype  # Will be Fp2 in MLIR
-      self.storage_bits = 1024  # 2 × 2 × 256 bits (Fp2 has 2 elements)
-      self.point_repr = 'affine'
-      self.curve_group = 'g2'
-      self.is_montgomery = False
-    elif ec_type == _bn254_g2_affine_mont_dtype:
-      self.base_field_dtype = _bn254_sf_mont_dtype
-      self.storage_bits = 1024
-      self.point_repr = 'affine'
-      self.curve_group = 'g2'
-      self.is_montgomery = True
-    elif ec_type == _bn254_g2_jacobian_dtype:
-      self.base_field_dtype = _bn254_sf_dtype
-      self.storage_bits = 1536  # 3 × 2 × 256 bits
-      self.point_repr = 'jacobian'
-      self.curve_group = 'g2'
-      self.is_montgomery = False
-    elif ec_type == _bn254_g2_jacobian_mont_dtype:
-      self.base_field_dtype = _bn254_sf_mont_dtype
-      self.storage_bits = 1536
-      self.point_repr = 'jacobian'
-      self.curve_group = 'g2'
-      self.is_montgomery = True
-    elif ec_type == _bn254_g2_xyzz_dtype:
-      self.base_field_dtype = _bn254_sf_dtype
-      self.storage_bits = 2048  # 4 × 2 × 256 bits
-      self.point_repr = 'xyzz'
-      self.curve_group = 'g2'
-      self.is_montgomery = False
-    elif ec_type == _bn254_g2_xyzz_mont_dtype:
-      self.base_field_dtype = _bn254_sf_mont_dtype
-      self.storage_bits = 2048
-      self.point_repr = 'xyzz'
-      self.curve_group = 'g2'
-      self.is_montgomery = True
-    else:
+    meta = _EC_DTYPE_META.get(ec_type)
+    if meta is None:
       raise ValueError(f'Unknown elliptic curve point type: {ec_type}')
+    curve, group, point_repr, is_montgomery, storage_bits, base_field_dtype = (
+        meta
+    )
 
-    # Set curve parameters based on group and Montgomery form
-    if self.curve_group == 'g1':
-      if self.is_montgomery:
-        self.b = _BN254_G1_B_MONT
-        self.gx = _BN254_G1_GX_MONT
-        self.gy = _BN254_G1_GY_MONT
-      else:
-        self.b = _BN254_B
-        self.gx = _BN254_G1_GX
-        self.gy = _BN254_G1_GY
-      self.non_residue = None
-    else:
-      self.a = [0, 0]
-      if self.is_montgomery:
-        self.b = _BN254_G2_B_MONT
-        self.gx = _BN254_G2_GX_MONT
-        self.gy = _BN254_G2_GY_MONT
-        self.non_residue = _BN254_G2_NON_RESIDUE_MONT
-      else:
-        self.b = _BN254_G2_B
-        self.gx = _BN254_G2_GX
-        self.gy = _BN254_G2_GY
-        self.non_residue = _BN254_G2_NON_RESIDUE
+    self.dtype = ec_type
+    self.curve_group = group
+    self.point_repr = point_repr
+    self.is_montgomery = is_montgomery
+    self.storage_bits = storage_bits
+    self.base_field_dtype = base_field_dtype
+
+    params = _CURVE_PARAMS[(curve, group, is_montgomery)]
+    self.a = params['a']
+    self.b = params['b']
+    self.gx = params['gx']
+    self.gy = params['gy']
+    self.non_residue = params['non_residue']
 
   def __repr__(self):
     return f'ecinfo(curve_group={self.curve_group}, point_repr={self.point_repr}, dtype={self.dtype})'

--- a/zk_dtypes/_ecinfo.py
+++ b/zk_dtypes/_ecinfo.py
@@ -43,6 +43,20 @@ from zk_dtypes._zk_dtypes_ext import mnt4_298_g2_jacobian
 from zk_dtypes._zk_dtypes_ext import mnt4_298_g2_jacobian_mont
 from zk_dtypes._zk_dtypes_ext import mnt4_298_g2_xyzz
 from zk_dtypes._zk_dtypes_ext import mnt4_298_g2_xyzz_mont
+from zk_dtypes._zk_dtypes_ext import mnt6_298_sf
+from zk_dtypes._zk_dtypes_ext import mnt6_298_sf_mont
+from zk_dtypes._zk_dtypes_ext import mnt6_298_g1_affine
+from zk_dtypes._zk_dtypes_ext import mnt6_298_g1_affine_mont
+from zk_dtypes._zk_dtypes_ext import mnt6_298_g1_jacobian
+from zk_dtypes._zk_dtypes_ext import mnt6_298_g1_jacobian_mont
+from zk_dtypes._zk_dtypes_ext import mnt6_298_g1_xyzz
+from zk_dtypes._zk_dtypes_ext import mnt6_298_g1_xyzz_mont
+from zk_dtypes._zk_dtypes_ext import mnt6_298_g2_affine
+from zk_dtypes._zk_dtypes_ext import mnt6_298_g2_affine_mont
+from zk_dtypes._zk_dtypes_ext import mnt6_298_g2_jacobian
+from zk_dtypes._zk_dtypes_ext import mnt6_298_g2_jacobian_mont
+from zk_dtypes._zk_dtypes_ext import mnt6_298_g2_xyzz
+from zk_dtypes._zk_dtypes_ext import mnt6_298_g2_xyzz_mont
 
 import numpy as np
 
@@ -50,6 +64,8 @@ _bn254_sf_dtype = np.dtype(bn254_sf)
 _bn254_sf_mont_dtype = np.dtype(bn254_sf_mont)
 _mnt4_298_sf_dtype = np.dtype(mnt4_298_sf)
 _mnt4_298_sf_mont_dtype = np.dtype(mnt4_298_sf_mont)
+_mnt6_298_sf_dtype = np.dtype(mnt6_298_sf)
+_mnt6_298_sf_mont_dtype = np.dtype(mnt6_298_sf_mont)
 
 # ---------------------------------------------------------------------------
 # bn254 curve parameters (y² = x³ + ax + b). G2 lives over Fp² = Fq[u]/(u²-β).
@@ -147,6 +163,61 @@ _MNT4_298_G2_GY_MONT = [
 ]
 _MNT4_298_G2_NON_RESIDUE_MONT = 465743018361954773686184243535452341565193593040424183030522717535393503346130123154901525
 
+# ---------------------------------------------------------------------------
+# MNT6-298 curve parameters (ark-mnt6-298). G1: y² = x³ + 11x + b over Fq.
+# G2 over Fp³ = Fq[u]/(u³-5); twist a = (0, 0, 11), b = (5·b, 0, 0). 320-bit
+# field (the MNT4 cycle: MNT6 Fq = MNT4 Fr). Montgomery form = value·R mod p.
+# ---------------------------------------------------------------------------
+_MNT6_298_G1_A = 11
+_MNT6_298_G1_B = 106700080510851735677967319632585352256454251201367587890185989362936000262606668469523074
+_MNT6_298_G1_GX = 336685752883082228109289846353937104185698209371404178342968838739115829740084426881123453
+_MNT6_298_G1_GY = 402596290139780989709332707716568920777622032073762749862342374583908837063963736098549800
+
+_MNT6_298_G1_A_MONT = 77399700742788935560072510686211067378536588283599049747225344898379629001906254049619951
+_MNT6_298_G1_B_MONT = 117863729424218755314889477576976072108240353392280102964914008159214280612609743972627259
+_MNT6_298_G1_GX_MONT = 66803446633995354443436432086785857429890759773793771766712172085558096199224671983246628
+_MNT6_298_G1_GY_MONT = 391921278559921373872478291534168668984317278471439419727775904969858842965515216515760050
+
+_MNT6_298_G2_A = [0, 0, 11]
+_MNT6_298_G2_B = [
+    57578116384997352636487348509878309737146377454014423897662211075515354005624851787652233,
+    0,
+    0,
+]
+_MNT6_298_G2_GX = [
+    421456435772811846256826561593908322288509115489119907560382401870203318738334702321297427,
+    103072927438548502463527009961344915021167584706439945404959058962657261178393635706405114,
+    143029172143731852627002926324735183809768363301149009204849580478324784395590388826052558,
+]
+_MNT6_298_G2_GY = [
+    464673596668689463130099227575639512541218133445388869383893594087634649237515554342751377,
+    100642907501977375184575075967118071807821117960152743335603284583254620685343989304941678,
+    123019855502969896026940545715841181300275180157288044663051565390506010149881373807142903,
+]
+_MNT6_298_G2_NON_RESIDUE = 5
+
+_MNT6_298_G2_A_MONT = [
+    0,
+    0,
+    77399700742788935560072510686211067378536588283599049747225344898379629001906254049619951,
+]
+_MNT6_298_G2_B_MONT = [
+    113396360951832450821098138231831908996076888408576999271302305056906755755640229303173158,
+    0,
+    0,
+]
+_MNT6_298_G2_GX_MONT = [
+    288208926410660646513785090852407832338233401063728316230268857502404730449173144485043879,
+    351381625308823176868807127486138634595116949883628439586787050017946781674344146387034416,
+    127672217964183870707978709919069290404704306329671129014740702808526116370651618768708081,
+]
+_MNT6_298_G2_GY_MONT = [
+    149587757998830678715843103866538208153562829471370761178971527424848110063377843185155167,
+    105322739714326088692821876215799163825059720357780792387795512794429173527988284429257703,
+    359945110800750513286064290068019448559925840421393865155861545034129653722834631881439455,
+]
+_MNT6_298_G2_NON_RESIDUE_MONT = 164978669292884423187310027490018244684368870643315072308720902882672007902886976538908106
+
 # Per-(curve, group, is_montgomery) curve coefficient + generator tables.
 _CURVE_PARAMS = {
     ('bn254', 'g1', False): dict(
@@ -205,24 +276,56 @@ _CURVE_PARAMS = {
         gy=_MNT4_298_G2_GY_MONT,
         non_residue=_MNT4_298_G2_NON_RESIDUE_MONT,
     ),
+    ('mnt6_298', 'g1', False): dict(
+        a=_MNT6_298_G1_A,
+        b=_MNT6_298_G1_B,
+        gx=_MNT6_298_G1_GX,
+        gy=_MNT6_298_G1_GY,
+        non_residue=None,
+    ),
+    ('mnt6_298', 'g1', True): dict(
+        a=_MNT6_298_G1_A_MONT,
+        b=_MNT6_298_G1_B_MONT,
+        gx=_MNT6_298_G1_GX_MONT,
+        gy=_MNT6_298_G1_GY_MONT,
+        non_residue=None,
+    ),
+    ('mnt6_298', 'g2', False): dict(
+        a=_MNT6_298_G2_A,
+        b=_MNT6_298_G2_B,
+        gx=_MNT6_298_G2_GX,
+        gy=_MNT6_298_G2_GY,
+        non_residue=_MNT6_298_G2_NON_RESIDUE,
+    ),
+    ('mnt6_298', 'g2', True): dict(
+        a=_MNT6_298_G2_A_MONT,
+        b=_MNT6_298_G2_B_MONT,
+        gx=_MNT6_298_G2_GX_MONT,
+        gy=_MNT6_298_G2_GY_MONT,
+        non_residue=_MNT6_298_G2_NON_RESIDUE_MONT,
+    ),
 }
 
-# (group, repr, num_coords, ext_degree): storage = num_coords * ext * field_bits.
+# (group, repr, num_coords). G1 coords are in the base field; G2 coords are in
+# the degree-`g2_ext` extension (Fp2 for bn254/mnt4, Fp3 for mnt6).
 _EC_LAYOUT = [
-    ('g1', 'affine', 2, 1),
-    ('g1', 'jacobian', 3, 1),
-    ('g1', 'xyzz', 4, 1),
-    ('g2', 'affine', 2, 2),
-    ('g2', 'jacobian', 3, 2),
-    ('g2', 'xyzz', 4, 2),
+    ('g1', 'affine', 2),
+    ('g1', 'jacobian', 3),
+    ('g1', 'xyzz', 4),
+    ('g2', 'affine', 2),
+    ('g2', 'jacobian', 3),
+    ('g2', 'xyzz', 4),
 ]
 
 
-def _build_meta(curve, field_bits, scalar_std, scalar_mont, dtype_table):
+def _build_meta(
+    curve, field_bits, g2_ext, scalar_std, scalar_mont, dtype_table
+):
   """Maps each registered point dtype -> (curve, group, repr, is_mont,
   storage_bits, base_field_dtype)."""
   meta = {}
-  for group, repr_, num_coords, ext in _EC_LAYOUT:
+  for group, repr_, num_coords in _EC_LAYOUT:
+    ext = 1 if group == 'g1' else g2_ext
     bits = num_coords * ext * field_bits
     for is_mont in (False, True):
       dt = np.dtype(dtype_table[(group, repr_, is_mont)])
@@ -236,6 +339,7 @@ _EC_DTYPE_META.update(
     _build_meta(
         'bn254',
         256,
+        2,
         _bn254_sf_dtype,
         _bn254_sf_mont_dtype,
         {
@@ -258,6 +362,7 @@ _EC_DTYPE_META.update(
     _build_meta(
         'mnt4_298',
         320,
+        2,
         _mnt4_298_sf_dtype,
         _mnt4_298_sf_mont_dtype,
         {
@@ -276,6 +381,29 @@ _EC_DTYPE_META.update(
         },
     )
 )
+_EC_DTYPE_META.update(
+    _build_meta(
+        'mnt6_298',
+        320,
+        3,
+        _mnt6_298_sf_dtype,
+        _mnt6_298_sf_mont_dtype,
+        {
+            ('g1', 'affine', False): mnt6_298_g1_affine,
+            ('g1', 'affine', True): mnt6_298_g1_affine_mont,
+            ('g1', 'jacobian', False): mnt6_298_g1_jacobian,
+            ('g1', 'jacobian', True): mnt6_298_g1_jacobian_mont,
+            ('g1', 'xyzz', False): mnt6_298_g1_xyzz,
+            ('g1', 'xyzz', True): mnt6_298_g1_xyzz_mont,
+            ('g2', 'affine', False): mnt6_298_g2_affine,
+            ('g2', 'affine', True): mnt6_298_g2_affine_mont,
+            ('g2', 'jacobian', False): mnt6_298_g2_jacobian,
+            ('g2', 'jacobian', True): mnt6_298_g2_jacobian_mont,
+            ('g2', 'xyzz', False): mnt6_298_g2_xyzz,
+            ('g2', 'xyzz', True): mnt6_298_g2_xyzz_mont,
+        },
+    )
+)
 
 
 class ecinfo:  # pylint: disable=invalid-name,missing-class-docstring
@@ -288,7 +416,7 @@ class ecinfo:  # pylint: disable=invalid-name,missing-class-docstring
   b: int | list[int]  # curve coefficient b
   gx: int | list[int]  # generator x-coordinate
   gy: int | list[int]  # generator y-coordinate
-  non_residue: int | None  # Fp² non-residue (None for G1, int for G2)
+  non_residue: int | None  # Fp²/Fp³ non-residue (None for G1, int for G2)
   dtype: np.dtype
 
   def __init__(self, ec_type):

--- a/zk_dtypes/_pfinfo.py
+++ b/zk_dtypes/_pfinfo.py
@@ -24,6 +24,8 @@ from zk_dtypes._zk_dtypes_ext import koalabear_mont
 from zk_dtypes._zk_dtypes_ext import mersenne31
 from zk_dtypes._zk_dtypes_ext import bn254_sf
 from zk_dtypes._zk_dtypes_ext import bn254_sf_mont
+from zk_dtypes._zk_dtypes_ext import mnt4_298_sf
+from zk_dtypes._zk_dtypes_ext import mnt4_298_sf_mont
 
 import numpy as np
 
@@ -36,6 +38,8 @@ _koalabear_mont_dtype = np.dtype(koalabear_mont)
 _mersenne31_dtype = np.dtype(mersenne31)
 _bn254_sf_dtype = np.dtype(bn254_sf)
 _bn254_sf_mont_dtype = np.dtype(bn254_sf_mont)
+_mnt4_298_sf_dtype = np.dtype(mnt4_298_sf)
+_mnt4_298_sf_mont_dtype = np.dtype(mnt4_298_sf_mont)
 
 
 _BN254_PARAM = 4965661367192848881
@@ -84,6 +88,12 @@ class pfinfo:  # pylint: disable=invalid-name,missing-class-docstring
       self.modulus_bits = 254
       self.modulus = _get_bn_scalar_field_modulus(_BN254_PARAM)
       self.is_montgomery = pf_type == _bn254_sf_mont_dtype
+    elif pf_type == _mnt4_298_sf_dtype or pf_type == _mnt4_298_sf_mont_dtype:
+      self.dtype = pf_type
+      self.storage_bits = 320
+      self.modulus_bits = 298
+      self.modulus = 475922286169261325753349249653048451545124878552823515553267735739164647307408490559963137
+      self.is_montgomery = pf_type == _mnt4_298_sf_mont_dtype
     else:
       raise ValueError(f"Unknown prime field type: {pf_type}")
     # Calculate the 2-adicity of `modulus - 1`, which is the number of

--- a/zk_dtypes/_pfinfo.py
+++ b/zk_dtypes/_pfinfo.py
@@ -26,6 +26,8 @@ from zk_dtypes._zk_dtypes_ext import bn254_sf
 from zk_dtypes._zk_dtypes_ext import bn254_sf_mont
 from zk_dtypes._zk_dtypes_ext import mnt4_298_sf
 from zk_dtypes._zk_dtypes_ext import mnt4_298_sf_mont
+from zk_dtypes._zk_dtypes_ext import mnt6_298_sf
+from zk_dtypes._zk_dtypes_ext import mnt6_298_sf_mont
 
 import numpy as np
 
@@ -40,6 +42,8 @@ _bn254_sf_dtype = np.dtype(bn254_sf)
 _bn254_sf_mont_dtype = np.dtype(bn254_sf_mont)
 _mnt4_298_sf_dtype = np.dtype(mnt4_298_sf)
 _mnt4_298_sf_mont_dtype = np.dtype(mnt4_298_sf_mont)
+_mnt6_298_sf_dtype = np.dtype(mnt6_298_sf)
+_mnt6_298_sf_mont_dtype = np.dtype(mnt6_298_sf_mont)
 
 
 _BN254_PARAM = 4965661367192848881
@@ -94,6 +98,12 @@ class pfinfo:  # pylint: disable=invalid-name,missing-class-docstring
       self.modulus_bits = 298
       self.modulus = 475922286169261325753349249653048451545124878552823515553267735739164647307408490559963137
       self.is_montgomery = pf_type == _mnt4_298_sf_mont_dtype
+    elif pf_type == _mnt6_298_sf_dtype or pf_type == _mnt6_298_sf_mont_dtype:
+      self.dtype = pf_type
+      self.storage_bits = 320
+      self.modulus_bits = 298
+      self.modulus = 475922286169261325753349249653048451545124879242694725395555128576210262817955800483758081
+      self.is_montgomery = pf_type == _mnt6_298_sf_mont_dtype
     else:
       raise ValueError(f"Unknown prime field type: {pf_type}")
     # Calculate the 2-adicity of `modulus - 1`, which is the number of

--- a/zk_dtypes/_src/dtypes.cc
+++ b/zk_dtypes/_src/dtypes.cc
@@ -241,6 +241,21 @@ struct TypeDescriptorBase<mnt4_298::FrMont>
   static constexpr char kNpyDescrType = 'b';
 };
 
+template <>
+struct TypeDescriptorBase<mnt6_298::Fr> : FieldTypeDescriptor<mnt6_298::Fr> {
+  static constexpr const char* kTpDoc =
+      "mnt6_298 scalar field values on standard domain";
+  static constexpr char kNpyDescrType = 'B';
+};
+
+template <>
+struct TypeDescriptorBase<mnt6_298::FrMont>
+    : FieldTypeDescriptor<mnt6_298::FrMont> {
+  static constexpr const char* kTpDoc =
+      "mnt6_298 scalar field values on montgomery domain";
+  static constexpr char kNpyDescrType = 'b';
+};
+
 //===----------------------------------------------------------------------===//
 // ExtendedField TypeDescriptorBase
 //===----------------------------------------------------------------------===//
@@ -538,6 +553,102 @@ struct TypeDescriptorBase<mnt4_298::G2PointXyzzMont>
     : EcPointTypeDescriptor<mnt4_298::G2PointXyzzMont> {
   static constexpr const char* kTpDoc =
       "mnt4_298 G2 elliptic curve xyzz point on montgomery domain";
+  static constexpr char kNpyDescrType = 'x';
+};
+
+template <>
+struct TypeDescriptorBase<mnt6_298::G1AffinePoint>
+    : EcPointTypeDescriptor<mnt6_298::G1AffinePoint> {
+  static constexpr const char* kTpDoc =
+      "mnt6_298 G1 elliptic curve affine point on standard domain";
+  static constexpr char kNpyDescrType = 'A';
+};
+
+template <>
+struct TypeDescriptorBase<mnt6_298::G1AffinePointMont>
+    : EcPointTypeDescriptor<mnt6_298::G1AffinePointMont> {
+  static constexpr const char* kTpDoc =
+      "mnt6_298 G1 elliptic curve affine point on montgomery domain";
+  static constexpr char kNpyDescrType = 'a';
+};
+
+template <>
+struct TypeDescriptorBase<mnt6_298::G1JacobianPoint>
+    : EcPointTypeDescriptor<mnt6_298::G1JacobianPoint> {
+  static constexpr const char* kTpDoc =
+      "mnt6_298 G1 elliptic curve jacobian point on standard domain";
+  static constexpr char kNpyDescrType = 'J';
+};
+
+template <>
+struct TypeDescriptorBase<mnt6_298::G1JacobianPointMont>
+    : EcPointTypeDescriptor<mnt6_298::G1JacobianPointMont> {
+  static constexpr const char* kTpDoc =
+      "mnt6_298 G1 elliptic curve jacobian point on montgomery domain";
+  static constexpr char kNpyDescrType = 'j';
+};
+
+template <>
+struct TypeDescriptorBase<mnt6_298::G1PointXyzz>
+    : EcPointTypeDescriptor<mnt6_298::G1PointXyzz> {
+  static constexpr const char* kTpDoc =
+      "mnt6_298 G1 elliptic curve xyzz point on standard domain";
+  static constexpr char kNpyDescrType = 'X';
+};
+
+template <>
+struct TypeDescriptorBase<mnt6_298::G1PointXyzzMont>
+    : EcPointTypeDescriptor<mnt6_298::G1PointXyzzMont> {
+  static constexpr const char* kTpDoc =
+      "mnt6_298 G1 elliptic curve xyzz point on montgomery domain";
+  static constexpr char kNpyDescrType = 'x';
+};
+
+template <>
+struct TypeDescriptorBase<mnt6_298::G2AffinePoint>
+    : EcPointTypeDescriptor<mnt6_298::G2AffinePoint> {
+  static constexpr const char* kTpDoc =
+      "mnt6_298 G2 elliptic curve affine point on standard domain";
+  static constexpr char kNpyDescrType = 'A';
+};
+
+template <>
+struct TypeDescriptorBase<mnt6_298::G2AffinePointMont>
+    : EcPointTypeDescriptor<mnt6_298::G2AffinePointMont> {
+  static constexpr const char* kTpDoc =
+      "mnt6_298 G2 elliptic curve affine point on montgomery domain";
+  static constexpr char kNpyDescrType = 'a';
+};
+
+template <>
+struct TypeDescriptorBase<mnt6_298::G2JacobianPoint>
+    : EcPointTypeDescriptor<mnt6_298::G2JacobianPoint> {
+  static constexpr const char* kTpDoc =
+      "mnt6_298 G2 elliptic curve jacobian point on standard domain";
+  static constexpr char kNpyDescrType = 'J';
+};
+
+template <>
+struct TypeDescriptorBase<mnt6_298::G2JacobianPointMont>
+    : EcPointTypeDescriptor<mnt6_298::G2JacobianPointMont> {
+  static constexpr const char* kTpDoc =
+      "mnt6_298 G2 elliptic curve jacobian point on montgomery domain";
+  static constexpr char kNpyDescrType = 'j';
+};
+
+template <>
+struct TypeDescriptorBase<mnt6_298::G2PointXyzz>
+    : EcPointTypeDescriptor<mnt6_298::G2PointXyzz> {
+  static constexpr const char* kTpDoc =
+      "mnt6_298 G2 elliptic curve xyzz point on standard domain";
+  static constexpr char kNpyDescrType = 'X';
+};
+
+template <>
+struct TypeDescriptorBase<mnt6_298::G2PointXyzzMont>
+    : EcPointTypeDescriptor<mnt6_298::G2PointXyzzMont> {
+  static constexpr const char* kTpDoc =
+      "mnt6_298 G2 elliptic curve xyzz point on montgomery domain";
   static constexpr char kNpyDescrType = 'x';
 };
 

--- a/zk_dtypes/_src/dtypes.cc
+++ b/zk_dtypes/_src/dtypes.cc
@@ -226,6 +226,21 @@ struct TypeDescriptorBase<bn254::FrMont> : FieldTypeDescriptor<bn254::FrMont> {
   static constexpr char kNpyDescrType = 'b';
 };
 
+template <>
+struct TypeDescriptorBase<mnt4_298::Fr> : FieldTypeDescriptor<mnt4_298::Fr> {
+  static constexpr const char* kTpDoc =
+      "mnt4_298 scalar field values on standard domain";
+  static constexpr char kNpyDescrType = 'B';
+};
+
+template <>
+struct TypeDescriptorBase<mnt4_298::FrMont>
+    : FieldTypeDescriptor<mnt4_298::FrMont> {
+  static constexpr const char* kTpDoc =
+      "mnt4_298 scalar field values on montgomery domain";
+  static constexpr char kNpyDescrType = 'b';
+};
+
 //===----------------------------------------------------------------------===//
 // ExtendedField TypeDescriptorBase
 //===----------------------------------------------------------------------===//
@@ -427,6 +442,102 @@ struct TypeDescriptorBase<bn254::G2PointXyzzMont>
     : EcPointTypeDescriptor<bn254::G2PointXyzzMont> {
   static constexpr const char* kTpDoc =
       "bn254 G2 elliptic curve xyzz point on montgomery domain";
+  static constexpr char kNpyDescrType = 'x';
+};
+
+template <>
+struct TypeDescriptorBase<mnt4_298::G1AffinePoint>
+    : EcPointTypeDescriptor<mnt4_298::G1AffinePoint> {
+  static constexpr const char* kTpDoc =
+      "mnt4_298 G1 elliptic curve affine point on standard domain";
+  static constexpr char kNpyDescrType = 'A';
+};
+
+template <>
+struct TypeDescriptorBase<mnt4_298::G1AffinePointMont>
+    : EcPointTypeDescriptor<mnt4_298::G1AffinePointMont> {
+  static constexpr const char* kTpDoc =
+      "mnt4_298 G1 elliptic curve affine point on montgomery domain";
+  static constexpr char kNpyDescrType = 'a';
+};
+
+template <>
+struct TypeDescriptorBase<mnt4_298::G1JacobianPoint>
+    : EcPointTypeDescriptor<mnt4_298::G1JacobianPoint> {
+  static constexpr const char* kTpDoc =
+      "mnt4_298 G1 elliptic curve jacobian point on standard domain";
+  static constexpr char kNpyDescrType = 'J';
+};
+
+template <>
+struct TypeDescriptorBase<mnt4_298::G1JacobianPointMont>
+    : EcPointTypeDescriptor<mnt4_298::G1JacobianPointMont> {
+  static constexpr const char* kTpDoc =
+      "mnt4_298 G1 elliptic curve jacobian point on montgomery domain";
+  static constexpr char kNpyDescrType = 'j';
+};
+
+template <>
+struct TypeDescriptorBase<mnt4_298::G1PointXyzz>
+    : EcPointTypeDescriptor<mnt4_298::G1PointXyzz> {
+  static constexpr const char* kTpDoc =
+      "mnt4_298 G1 elliptic curve xyzz point on standard domain";
+  static constexpr char kNpyDescrType = 'X';
+};
+
+template <>
+struct TypeDescriptorBase<mnt4_298::G1PointXyzzMont>
+    : EcPointTypeDescriptor<mnt4_298::G1PointXyzzMont> {
+  static constexpr const char* kTpDoc =
+      "mnt4_298 G1 elliptic curve xyzz point on montgomery domain";
+  static constexpr char kNpyDescrType = 'x';
+};
+
+template <>
+struct TypeDescriptorBase<mnt4_298::G2AffinePoint>
+    : EcPointTypeDescriptor<mnt4_298::G2AffinePoint> {
+  static constexpr const char* kTpDoc =
+      "mnt4_298 G2 elliptic curve affine point on standard domain";
+  static constexpr char kNpyDescrType = 'A';
+};
+
+template <>
+struct TypeDescriptorBase<mnt4_298::G2AffinePointMont>
+    : EcPointTypeDescriptor<mnt4_298::G2AffinePointMont> {
+  static constexpr const char* kTpDoc =
+      "mnt4_298 G2 elliptic curve affine point on montgomery domain";
+  static constexpr char kNpyDescrType = 'a';
+};
+
+template <>
+struct TypeDescriptorBase<mnt4_298::G2JacobianPoint>
+    : EcPointTypeDescriptor<mnt4_298::G2JacobianPoint> {
+  static constexpr const char* kTpDoc =
+      "mnt4_298 G2 elliptic curve jacobian point on standard domain";
+  static constexpr char kNpyDescrType = 'J';
+};
+
+template <>
+struct TypeDescriptorBase<mnt4_298::G2JacobianPointMont>
+    : EcPointTypeDescriptor<mnt4_298::G2JacobianPointMont> {
+  static constexpr const char* kTpDoc =
+      "mnt4_298 G2 elliptic curve jacobian point on montgomery domain";
+  static constexpr char kNpyDescrType = 'j';
+};
+
+template <>
+struct TypeDescriptorBase<mnt4_298::G2PointXyzz>
+    : EcPointTypeDescriptor<mnt4_298::G2PointXyzz> {
+  static constexpr const char* kTpDoc =
+      "mnt4_298 G2 elliptic curve xyzz point on standard domain";
+  static constexpr char kNpyDescrType = 'X';
+};
+
+template <>
+struct TypeDescriptorBase<mnt4_298::G2PointXyzzMont>
+    : EcPointTypeDescriptor<mnt4_298::G2PointXyzzMont> {
+  static constexpr const char* kTpDoc =
+      "mnt4_298 G2 elliptic curve xyzz point on montgomery domain";
   static constexpr char kNpyDescrType = 'x';
 };
 

--- a/zk_dtypes/_src/ec_point_numpy.h
+++ b/zk_dtypes/_src/ec_point_numpy.h
@@ -33,6 +33,8 @@ limitations under the License.
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/g2.h"
 #include "zk_dtypes/include/elliptic_curve/mnt4_298/g1.h"
 #include "zk_dtypes/include/elliptic_curve/mnt4_298/g2.h"
+#include "zk_dtypes/include/elliptic_curve/mnt6_298/g1.h"
+#include "zk_dtypes/include/elliptic_curve/mnt6_298/g2.h"
 #include "zk_dtypes/include/geometry/point_declarations.h"
 
 namespace zk_dtypes {
@@ -875,6 +877,17 @@ bool RegisterEcPointMultiplyUFunc(PyObject* numpy) {
         mnt4_298::G1JacobianPointMont, mnt4_298::G1PointXyzzMont,
         mnt4_298::G2AffinePointMont, mnt4_298::G2JacobianPointMont,
         mnt4_298::G2PointXyzzMont>(numpy);
+  } else if constexpr (std::is_same_v<ScalarField, mnt6_298::Fr>) {
+    return RegisterEcPointMul_Impl<
+        mnt6_298::Fr, mnt6_298::G1AffinePoint, mnt6_298::G1JacobianPoint,
+        mnt6_298::G1PointXyzz, mnt6_298::G2AffinePoint,
+        mnt6_298::G2JacobianPoint, mnt6_298::G2PointXyzz>(numpy);
+  } else if constexpr (std::is_same_v<ScalarField, mnt6_298::FrMont>) {
+    return RegisterEcPointMul_Impl<
+        mnt6_298::FrMont, mnt6_298::G1AffinePointMont,
+        mnt6_298::G1JacobianPointMont, mnt6_298::G1PointXyzzMont,
+        mnt6_298::G2AffinePointMont, mnt6_298::G2JacobianPointMont,
+        mnt6_298::G2PointXyzzMont>(numpy);
   } else {
     return false;
   }

--- a/zk_dtypes/_src/ec_point_numpy.h
+++ b/zk_dtypes/_src/ec_point_numpy.h
@@ -31,6 +31,8 @@ limitations under the License.
 #include "zk_dtypes/_src/ufuncs.h"
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/g1.h"
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/g2.h"
+#include "zk_dtypes/include/elliptic_curve/mnt4_298/g1.h"
+#include "zk_dtypes/include/elliptic_curve/mnt4_298/g2.h"
 #include "zk_dtypes/include/geometry/point_declarations.h"
 
 namespace zk_dtypes {
@@ -862,6 +864,17 @@ bool RegisterEcPointMultiplyUFunc(PyObject* numpy) {
         bn254::FrMont, bn254::G1AffinePointMont, bn254::G1JacobianPointMont,
         bn254::G1PointXyzzMont, bn254::G2AffinePointMont,
         bn254::G2JacobianPointMont, bn254::G2PointXyzzMont>(numpy);
+  } else if constexpr (std::is_same_v<ScalarField, mnt4_298::Fr>) {
+    return RegisterEcPointMul_Impl<
+        mnt4_298::Fr, mnt4_298::G1AffinePoint, mnt4_298::G1JacobianPoint,
+        mnt4_298::G1PointXyzz, mnt4_298::G2AffinePoint,
+        mnt4_298::G2JacobianPoint, mnt4_298::G2PointXyzz>(numpy);
+  } else if constexpr (std::is_same_v<ScalarField, mnt4_298::FrMont>) {
+    return RegisterEcPointMul_Impl<
+        mnt4_298::FrMont, mnt4_298::G1AffinePointMont,
+        mnt4_298::G1JacobianPointMont, mnt4_298::G1PointXyzzMont,
+        mnt4_298::G2AffinePointMont, mnt4_298::G2JacobianPointMont,
+        mnt4_298::G2PointXyzzMont>(numpy);
   } else {
     return false;
   }

--- a/zk_dtypes/_src/field_numpy.h
+++ b/zk_dtypes/_src/field_numpy.h
@@ -33,6 +33,9 @@ limitations under the License.
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/fr.h"
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/g1.h"
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/g2.h"
+#include "zk_dtypes/include/elliptic_curve/mnt4_298/fr.h"
+#include "zk_dtypes/include/elliptic_curve/mnt4_298/g1.h"
+#include "zk_dtypes/include/elliptic_curve/mnt4_298/g2.h"
 #include "zk_dtypes/include/field/extension_field.h"
 #include "zk_dtypes/include/field/prime_field.h"
 
@@ -495,6 +498,17 @@ PyObject* PyField_nb_multiply(PyObject* a, PyObject* b) {
           bn254::FrMont, bn254::G1AffinePointMont, bn254::G1JacobianPointMont,
           bn254::G1PointXyzzMont, bn254::G2AffinePointMont,
           bn254::G2JacobianPointMont, bn254::G2PointXyzzMont>(x, b);
+    } else if constexpr (std::is_same_v<T, mnt4_298::Fr>) {
+      return PyField_nb_ec_multiply<
+          mnt4_298::Fr, mnt4_298::G1AffinePoint, mnt4_298::G1JacobianPoint,
+          mnt4_298::G1PointXyzz, mnt4_298::G2AffinePoint,
+          mnt4_298::G2JacobianPoint, mnt4_298::G2PointXyzz>(x, b);
+    } else if constexpr (std::is_same_v<T, mnt4_298::FrMont>) {
+      return PyField_nb_ec_multiply<
+          mnt4_298::FrMont, mnt4_298::G1AffinePointMont,
+          mnt4_298::G1JacobianPointMont, mnt4_298::G1PointXyzzMont,
+          mnt4_298::G2AffinePointMont, mnt4_298::G2JacobianPointMont,
+          mnt4_298::G2PointXyzzMont>(x, b);
     }
   }
 

--- a/zk_dtypes/_src/field_numpy.h
+++ b/zk_dtypes/_src/field_numpy.h
@@ -36,6 +36,9 @@ limitations under the License.
 #include "zk_dtypes/include/elliptic_curve/mnt4_298/fr.h"
 #include "zk_dtypes/include/elliptic_curve/mnt4_298/g1.h"
 #include "zk_dtypes/include/elliptic_curve/mnt4_298/g2.h"
+#include "zk_dtypes/include/elliptic_curve/mnt6_298/fr.h"
+#include "zk_dtypes/include/elliptic_curve/mnt6_298/g1.h"
+#include "zk_dtypes/include/elliptic_curve/mnt6_298/g2.h"
 #include "zk_dtypes/include/field/extension_field.h"
 #include "zk_dtypes/include/field/prime_field.h"
 
@@ -509,6 +512,17 @@ PyObject* PyField_nb_multiply(PyObject* a, PyObject* b) {
           mnt4_298::G1JacobianPointMont, mnt4_298::G1PointXyzzMont,
           mnt4_298::G2AffinePointMont, mnt4_298::G2JacobianPointMont,
           mnt4_298::G2PointXyzzMont>(x, b);
+    } else if constexpr (std::is_same_v<T, mnt6_298::Fr>) {
+      return PyField_nb_ec_multiply<
+          mnt6_298::Fr, mnt6_298::G1AffinePoint, mnt6_298::G1JacobianPoint,
+          mnt6_298::G1PointXyzz, mnt6_298::G2AffinePoint,
+          mnt6_298::G2JacobianPoint, mnt6_298::G2PointXyzz>(x, b);
+    } else if constexpr (std::is_same_v<T, mnt6_298::FrMont>) {
+      return PyField_nb_ec_multiply<
+          mnt6_298::FrMont, mnt6_298::G1AffinePointMont,
+          mnt6_298::G1JacobianPointMont, mnt6_298::G1PointXyzzMont,
+          mnt6_298::G2AffinePointMont, mnt6_298::G2JacobianPointMont,
+          mnt6_298::G2PointXyzzMont>(x, b);
     }
   }
 

--- a/zk_dtypes/include/all_types.h
+++ b/zk_dtypes/include/all_types.h
@@ -25,6 +25,9 @@ limitations under the License.
 #include "zk_dtypes/include/elliptic_curve/mnt4_298/fr.h"
 #include "zk_dtypes/include/elliptic_curve/mnt4_298/g1.h"
 #include "zk_dtypes/include/elliptic_curve/mnt4_298/g2.h"
+#include "zk_dtypes/include/elliptic_curve/mnt6_298/fr.h"
+#include "zk_dtypes/include/elliptic_curve/mnt6_298/g1.h"
+#include "zk_dtypes/include/elliptic_curve/mnt6_298/g2.h"
 #include "zk_dtypes/include/elliptic_curve/secp256k1/g1.h"
 #include "zk_dtypes/include/field/babybear/babybear.h"
 #include "zk_dtypes/include/field/babybear/babybearx4.h"
@@ -77,12 +80,14 @@ V(::zk_dtypes::Mersenne31, Mersenne31, MERSENNE31, mersenne31)            \
 WITH_MONT(V, ::zk_dtypes::Goldilocks, Goldilocks, GOLDILOCKS, goldilocks) \
 WITH_MONT(V, ::zk_dtypes::Koalabear, Koalabear, KOALABEAR, koalabear)     \
 WITH_MONT(V, ::zk_dtypes::bn254::Fr, Bn254Sf, BN254_SF, bn254_sf)         \
-WITH_MONT(V, ::zk_dtypes::mnt4_298::Fr, Mnt4298Sf, MNT4_298_SF, mnt4_298_sf)
+WITH_MONT(V, ::zk_dtypes::mnt4_298::Fr, Mnt4298Sf, MNT4_298_SF, mnt4_298_sf) \
+WITH_MONT(V, ::zk_dtypes::mnt6_298::Fr, Mnt6298Sf, MNT6_298_SF, mnt6_298_sf)
 
 #define ZK_DTYPES_ALL_PRIME_FIELD_TYPE_LIST(V)                                        \
 ZK_DTYPES_PUBLIC_PRIME_FIELD_TYPE_LIST(V)                                             \
 WITH_MONT(V, ::zk_dtypes::bn254::Fq, Bn254Bf, BN254_BF, bn254_bf)                     \
 WITH_MONT(V, ::zk_dtypes::mnt4_298::Fq, Mnt4298Bf, MNT4_298_BF, mnt4_298_bf)          \
+WITH_MONT(V, ::zk_dtypes::mnt6_298::Fq, Mnt6298Bf, MNT6_298_BF, mnt6_298_bf)          \
 WITH_MONT(V, ::zk_dtypes::secp256k1::Fq, Secp256k1Bf, SECP256K1_BF, secp256k1_bf)     \
 WITH_MONT(V, ::zk_dtypes::secp256k1::Fr, Secp256k1Sf, SECP256K1_SF, secp256k1_sf)     \
 WITH_MONT(V, ::zk_dtypes::bls12_381::Fq, Bls12381Bf, BLS12_381_BF, bls12_381_bf)      \
@@ -105,6 +110,7 @@ WITH_MONT(V, ::zk_dtypes::GoldilocksX3, GoldilocksX3, GOLDILOCKSX3, goldilocksx3
 ZK_DTYPES_PUBLIC_EXT_FIELD_TYPE_LIST(V)                                   \
 WITH_MONT(V, ::zk_dtypes::bn254::FqX2, Bn254BfX2, BN254_BFX2, bn254_bfx2) \
 WITH_MONT(V, ::zk_dtypes::mnt4_298::FqX2, Mnt4298BfX2, MNT4_298_BFX2, mnt4_298_bfx2) \
+WITH_MONT(V, ::zk_dtypes::mnt6_298::FqX3, Mnt6298BfX3, MNT6_298_BFX3, mnt6_298_bfx3) \
 WITH_MONT(V, ::zk_dtypes::bls12_381::FqX2, Bls12381BfX2, BLS12_381_BFX2, bls12_381_bfx2)
 
 //===----------------------------------------------------------------------===//
@@ -127,7 +133,8 @@ ZK_DTYPES_ALL_BINARY_FIELD_TYPE_LIST(V)
 
 #define ZK_DTYPES_SCALAR_FIELD_TYPE_LIST(V) \
 WITH_MONT(V, ::zk_dtypes::bn254::Fr, Bn254Sf, BN254_SF, bn254_sf) \
-WITH_MONT(V, ::zk_dtypes::mnt4_298::Fr, Mnt4298Sf, MNT4_298_SF, mnt4_298_sf)
+WITH_MONT(V, ::zk_dtypes::mnt4_298::Fr, Mnt4298Sf, MNT4_298_SF, mnt4_298_sf) \
+WITH_MONT(V, ::zk_dtypes::mnt6_298::Fr, Mnt6298Sf, MNT6_298_SF, mnt6_298_sf)
 
 //===----------------------------------------------------------------------===//
 // AffinePoint Types
@@ -135,11 +142,13 @@ WITH_MONT(V, ::zk_dtypes::mnt4_298::Fr, Mnt4298Sf, MNT4_298_SF, mnt4_298_sf)
 
 #define ZK_DTYPES_PUBLIC_R1_AFFINE_POINT_TYPE_LIST(V) \
 WITH_MONT(V, ::zk_dtypes::bn254::G1AffinePoint, Bn254G1Affine, BN254_G1_AFFINE, bn254_g1_affine) \
-WITH_MONT(V, ::zk_dtypes::mnt4_298::G1AffinePoint, Mnt4298G1Affine, MNT4_298_G1_AFFINE, mnt4_298_g1_affine)
+WITH_MONT(V, ::zk_dtypes::mnt4_298::G1AffinePoint, Mnt4298G1Affine, MNT4_298_G1_AFFINE, mnt4_298_g1_affine) \
+WITH_MONT(V, ::zk_dtypes::mnt6_298::G1AffinePoint, Mnt6298G1Affine, MNT6_298_G1_AFFINE, mnt6_298_g1_affine)
 
 #define ZK_DTYPES_PUBLIC_R2_AFFINE_POINT_TYPE_LIST(V) \
 WITH_MONT(V, ::zk_dtypes::bn254::G2AffinePoint, Bn254G2Affine, BN254_G2_AFFINE, bn254_g2_affine) \
-WITH_MONT(V, ::zk_dtypes::mnt4_298::G2AffinePoint, Mnt4298G2Affine, MNT4_298_G2_AFFINE, mnt4_298_g2_affine)
+WITH_MONT(V, ::zk_dtypes::mnt4_298::G2AffinePoint, Mnt4298G2Affine, MNT4_298_G2_AFFINE, mnt4_298_g2_affine) \
+WITH_MONT(V, ::zk_dtypes::mnt6_298::G2AffinePoint, Mnt6298G2Affine, MNT6_298_G2_AFFINE, mnt6_298_g2_affine)
 
 #define ZK_DTYPES_PUBLIC_AFFINE_POINT_TYPE_LIST(V) \
 ZK_DTYPES_PUBLIC_R1_AFFINE_POINT_TYPE_LIST(V)      \
@@ -164,11 +173,13 @@ ZK_DTYPES_ALL_R2_AFFINE_POINT_TYPE_LIST(V)
 
 #define ZK_DTYPES_PUBLIC_R1_JACOBIAN_POINT_TYPE_LIST(V) \
 WITH_MONT(V, ::zk_dtypes::bn254::G1JacobianPoint, Bn254G1Jacobian, BN254_G1_JACOBIAN, bn254_g1_jacobian) \
-WITH_MONT(V, ::zk_dtypes::mnt4_298::G1JacobianPoint, Mnt4298G1Jacobian, MNT4_298_G1_JACOBIAN, mnt4_298_g1_jacobian)
+WITH_MONT(V, ::zk_dtypes::mnt4_298::G1JacobianPoint, Mnt4298G1Jacobian, MNT4_298_G1_JACOBIAN, mnt4_298_g1_jacobian) \
+WITH_MONT(V, ::zk_dtypes::mnt6_298::G1JacobianPoint, Mnt6298G1Jacobian, MNT6_298_G1_JACOBIAN, mnt6_298_g1_jacobian)
 
 #define ZK_DTYPES_PUBLIC_R2_JACOBIAN_POINT_TYPE_LIST(V) \
 WITH_MONT(V, ::zk_dtypes::bn254::G2JacobianPoint, Bn254G2Jacobian, BN254_G2_JACOBIAN, bn254_g2_jacobian) \
-WITH_MONT(V, ::zk_dtypes::mnt4_298::G2JacobianPoint, Mnt4298G2Jacobian, MNT4_298_G2_JACOBIAN, mnt4_298_g2_jacobian)
+WITH_MONT(V, ::zk_dtypes::mnt4_298::G2JacobianPoint, Mnt4298G2Jacobian, MNT4_298_G2_JACOBIAN, mnt4_298_g2_jacobian) \
+WITH_MONT(V, ::zk_dtypes::mnt6_298::G2JacobianPoint, Mnt6298G2Jacobian, MNT6_298_G2_JACOBIAN, mnt6_298_g2_jacobian)
 
 #define ZK_DTYPES_PUBLIC_JACOBIAN_POINT_TYPE_LIST(V) \
 ZK_DTYPES_PUBLIC_R1_JACOBIAN_POINT_TYPE_LIST(V)      \
@@ -192,11 +203,13 @@ ZK_DTYPES_ALL_R2_JACOBIAN_POINT_TYPE_LIST(V)
 
 #define ZK_DTYPES_PUBLIC_R1_XYZZ_POINT_TYPE_LIST(V) \
 WITH_MONT(V, ::zk_dtypes::bn254::G1PointXyzz, Bn254G1Xyzz, BN254_G1_XYZZ, bn254_g1_xyzz) \
-WITH_MONT(V, ::zk_dtypes::mnt4_298::G1PointXyzz, Mnt4298G1Xyzz, MNT4_298_G1_XYZZ, mnt4_298_g1_xyzz)
+WITH_MONT(V, ::zk_dtypes::mnt4_298::G1PointXyzz, Mnt4298G1Xyzz, MNT4_298_G1_XYZZ, mnt4_298_g1_xyzz) \
+WITH_MONT(V, ::zk_dtypes::mnt6_298::G1PointXyzz, Mnt6298G1Xyzz, MNT6_298_G1_XYZZ, mnt6_298_g1_xyzz)
 
 #define ZK_DTYPES_PUBLIC_R2_XYZZ_POINT_TYPE_LIST(V) \
 WITH_MONT(V, ::zk_dtypes::bn254::G2PointXyzz, Bn254G2Xyzz, BN254_G2_XYZZ, bn254_g2_xyzz) \
-WITH_MONT(V, ::zk_dtypes::mnt4_298::G2PointXyzz, Mnt4298G2Xyzz, MNT4_298_G2_XYZZ, mnt4_298_g2_xyzz)
+WITH_MONT(V, ::zk_dtypes::mnt4_298::G2PointXyzz, Mnt4298G2Xyzz, MNT4_298_G2_XYZZ, mnt4_298_g2_xyzz) \
+WITH_MONT(V, ::zk_dtypes::mnt6_298::G2PointXyzz, Mnt6298G2Xyzz, MNT6_298_G2_XYZZ, mnt6_298_g2_xyzz)
 
 #define ZK_DTYPES_PUBLIC_XYZZ_POINT_TYPE_LIST(V) \
 ZK_DTYPES_PUBLIC_R1_XYZZ_POINT_TYPE_LIST(V)      \

--- a/zk_dtypes/include/all_types.h
+++ b/zk_dtypes/include/all_types.h
@@ -22,6 +22,9 @@ limitations under the License.
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/g1.h"
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/g2.h"
 #include "zk_dtypes/include/elliptic_curve/curve25519/ed25519/g1.h"
+#include "zk_dtypes/include/elliptic_curve/mnt4_298/fr.h"
+#include "zk_dtypes/include/elliptic_curve/mnt4_298/g1.h"
+#include "zk_dtypes/include/elliptic_curve/mnt4_298/g2.h"
 #include "zk_dtypes/include/elliptic_curve/secp256k1/g1.h"
 #include "zk_dtypes/include/field/babybear/babybear.h"
 #include "zk_dtypes/include/field/babybear/babybearx4.h"
@@ -73,11 +76,13 @@ WITH_MONT(V, ::zk_dtypes::Babybear, Babybear, BABYBEAR, babybear)         \
 V(::zk_dtypes::Mersenne31, Mersenne31, MERSENNE31, mersenne31)            \
 WITH_MONT(V, ::zk_dtypes::Goldilocks, Goldilocks, GOLDILOCKS, goldilocks) \
 WITH_MONT(V, ::zk_dtypes::Koalabear, Koalabear, KOALABEAR, koalabear)     \
-WITH_MONT(V, ::zk_dtypes::bn254::Fr, Bn254Sf, BN254_SF, bn254_sf)
+WITH_MONT(V, ::zk_dtypes::bn254::Fr, Bn254Sf, BN254_SF, bn254_sf)         \
+WITH_MONT(V, ::zk_dtypes::mnt4_298::Fr, Mnt4298Sf, MNT4_298_SF, mnt4_298_sf)
 
 #define ZK_DTYPES_ALL_PRIME_FIELD_TYPE_LIST(V)                                        \
 ZK_DTYPES_PUBLIC_PRIME_FIELD_TYPE_LIST(V)                                             \
 WITH_MONT(V, ::zk_dtypes::bn254::Fq, Bn254Bf, BN254_BF, bn254_bf)                     \
+WITH_MONT(V, ::zk_dtypes::mnt4_298::Fq, Mnt4298Bf, MNT4_298_BF, mnt4_298_bf)          \
 WITH_MONT(V, ::zk_dtypes::secp256k1::Fq, Secp256k1Bf, SECP256K1_BF, secp256k1_bf)     \
 WITH_MONT(V, ::zk_dtypes::secp256k1::Fr, Secp256k1Sf, SECP256K1_SF, secp256k1_sf)     \
 WITH_MONT(V, ::zk_dtypes::bls12_381::Fq, Bls12381Bf, BLS12_381_BF, bls12_381_bf)      \
@@ -99,6 +104,7 @@ WITH_MONT(V, ::zk_dtypes::GoldilocksX3, GoldilocksX3, GOLDILOCKSX3, goldilocksx3
 #define ZK_DTYPES_ALL_EXT_FIELD_TYPE_LIST(V)                              \
 ZK_DTYPES_PUBLIC_EXT_FIELD_TYPE_LIST(V)                                   \
 WITH_MONT(V, ::zk_dtypes::bn254::FqX2, Bn254BfX2, BN254_BFX2, bn254_bfx2) \
+WITH_MONT(V, ::zk_dtypes::mnt4_298::FqX2, Mnt4298BfX2, MNT4_298_BFX2, mnt4_298_bfx2) \
 WITH_MONT(V, ::zk_dtypes::bls12_381::FqX2, Bls12381BfX2, BLS12_381_BFX2, bls12_381_bfx2)
 
 //===----------------------------------------------------------------------===//
@@ -120,17 +126,20 @@ ZK_DTYPES_ALL_BINARY_FIELD_TYPE_LIST(V)
 //===----------------------------------------------------------------------===//
 
 #define ZK_DTYPES_SCALAR_FIELD_TYPE_LIST(V) \
-WITH_MONT(V, ::zk_dtypes::bn254::Fr, Bn254Sf, BN254_SF, bn254_sf)
+WITH_MONT(V, ::zk_dtypes::bn254::Fr, Bn254Sf, BN254_SF, bn254_sf) \
+WITH_MONT(V, ::zk_dtypes::mnt4_298::Fr, Mnt4298Sf, MNT4_298_SF, mnt4_298_sf)
 
 //===----------------------------------------------------------------------===//
 // AffinePoint Types
 //===----------------------------------------------------------------------===//
 
 #define ZK_DTYPES_PUBLIC_R1_AFFINE_POINT_TYPE_LIST(V) \
-WITH_MONT(V, ::zk_dtypes::bn254::G1AffinePoint, Bn254G1Affine, BN254_G1_AFFINE, bn254_g1_affine)
+WITH_MONT(V, ::zk_dtypes::bn254::G1AffinePoint, Bn254G1Affine, BN254_G1_AFFINE, bn254_g1_affine) \
+WITH_MONT(V, ::zk_dtypes::mnt4_298::G1AffinePoint, Mnt4298G1Affine, MNT4_298_G1_AFFINE, mnt4_298_g1_affine)
 
 #define ZK_DTYPES_PUBLIC_R2_AFFINE_POINT_TYPE_LIST(V) \
-WITH_MONT(V, ::zk_dtypes::bn254::G2AffinePoint, Bn254G2Affine, BN254_G2_AFFINE, bn254_g2_affine)
+WITH_MONT(V, ::zk_dtypes::bn254::G2AffinePoint, Bn254G2Affine, BN254_G2_AFFINE, bn254_g2_affine) \
+WITH_MONT(V, ::zk_dtypes::mnt4_298::G2AffinePoint, Mnt4298G2Affine, MNT4_298_G2_AFFINE, mnt4_298_g2_affine)
 
 #define ZK_DTYPES_PUBLIC_AFFINE_POINT_TYPE_LIST(V) \
 ZK_DTYPES_PUBLIC_R1_AFFINE_POINT_TYPE_LIST(V)      \
@@ -154,10 +163,12 @@ ZK_DTYPES_ALL_R2_AFFINE_POINT_TYPE_LIST(V)
 //===----------------------------------------------------------------------===//
 
 #define ZK_DTYPES_PUBLIC_R1_JACOBIAN_POINT_TYPE_LIST(V) \
-WITH_MONT(V, ::zk_dtypes::bn254::G1JacobianPoint, Bn254G1Jacobian, BN254_G1_JACOBIAN, bn254_g1_jacobian)
+WITH_MONT(V, ::zk_dtypes::bn254::G1JacobianPoint, Bn254G1Jacobian, BN254_G1_JACOBIAN, bn254_g1_jacobian) \
+WITH_MONT(V, ::zk_dtypes::mnt4_298::G1JacobianPoint, Mnt4298G1Jacobian, MNT4_298_G1_JACOBIAN, mnt4_298_g1_jacobian)
 
 #define ZK_DTYPES_PUBLIC_R2_JACOBIAN_POINT_TYPE_LIST(V) \
-WITH_MONT(V, ::zk_dtypes::bn254::G2JacobianPoint, Bn254G2Jacobian, BN254_G2_JACOBIAN, bn254_g2_jacobian)
+WITH_MONT(V, ::zk_dtypes::bn254::G2JacobianPoint, Bn254G2Jacobian, BN254_G2_JACOBIAN, bn254_g2_jacobian) \
+WITH_MONT(V, ::zk_dtypes::mnt4_298::G2JacobianPoint, Mnt4298G2Jacobian, MNT4_298_G2_JACOBIAN, mnt4_298_g2_jacobian)
 
 #define ZK_DTYPES_PUBLIC_JACOBIAN_POINT_TYPE_LIST(V) \
 ZK_DTYPES_PUBLIC_R1_JACOBIAN_POINT_TYPE_LIST(V)      \
@@ -180,10 +191,12 @@ ZK_DTYPES_ALL_R2_JACOBIAN_POINT_TYPE_LIST(V)
 //===----------------------------------------------------------------------===//
 
 #define ZK_DTYPES_PUBLIC_R1_XYZZ_POINT_TYPE_LIST(V) \
-WITH_MONT(V, ::zk_dtypes::bn254::G1PointXyzz, Bn254G1Xyzz, BN254_G1_XYZZ, bn254_g1_xyzz)
+WITH_MONT(V, ::zk_dtypes::bn254::G1PointXyzz, Bn254G1Xyzz, BN254_G1_XYZZ, bn254_g1_xyzz) \
+WITH_MONT(V, ::zk_dtypes::mnt4_298::G1PointXyzz, Mnt4298G1Xyzz, MNT4_298_G1_XYZZ, mnt4_298_g1_xyzz)
 
 #define ZK_DTYPES_PUBLIC_R2_XYZZ_POINT_TYPE_LIST(V) \
-WITH_MONT(V, ::zk_dtypes::bn254::G2PointXyzz, Bn254G2Xyzz, BN254_G2_XYZZ, bn254_g2_xyzz)
+WITH_MONT(V, ::zk_dtypes::bn254::G2PointXyzz, Bn254G2Xyzz, BN254_G2_XYZZ, bn254_g2_xyzz) \
+WITH_MONT(V, ::zk_dtypes::mnt4_298::G2PointXyzz, Mnt4298G2Xyzz, MNT4_298_G2_XYZZ, mnt4_298_g2_xyzz)
 
 #define ZK_DTYPES_PUBLIC_XYZZ_POINT_TYPE_LIST(V) \
 ZK_DTYPES_PUBLIC_R1_XYZZ_POINT_TYPE_LIST(V)      \

--- a/zk_dtypes/include/elliptic_curve/mnt4_298/fq.h
+++ b/zk_dtypes/include/elliptic_curve/mnt4_298/fq.h
@@ -1,0 +1,109 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT4_298_FQ_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT4_298_FQ_H_
+
+#include "zk_dtypes/include/field/big_prime_field.h"
+
+namespace zk_dtypes::mnt4_298 {
+
+// MNT4-298 base field. p =
+// 475922286169261325753349249653048451545124879242694725395555128576210262817955800483758081
+// Constants mirror ark-mnt4-298 (generator 17, small subgroup 7^2). MNT4's Fq
+// is the MNT6 cycle's Fr, hence the small-subgroup root lives on the base
+// field.
+struct FqBaseConfig {
+  constexpr static size_t kStorageBits = 320;
+  constexpr static size_t kModulusBits = 298;
+  constexpr static BigInt<5> kModulus = {
+      UINT64_C(14487189785281953793), UINT64_C(4731562877756902930),
+      UINT64_C(14622846468719063274), UINT64_C(11702080941310629006),
+      UINT64_C(4110145082483),
+  };
+
+  constexpr static uint32_t kTwoAdicity = 17;
+  constexpr static uint32_t kSmallSubgroupBase = 7;
+  constexpr static uint32_t kSmallSubgroupAdicity = 2;
+
+  constexpr static BigInt<5> kTrace = {
+      UINT64_C(507046961542412467),
+      UINT64_C(10985722965000136848),
+      UINT64_C(3046515236404309641),
+      UINT64_C(7654379058973561816),
+      UINT64_C(31357918),
+  };
+
+  constexpr static bool kHasTwoAdicRootOfUnity = true;
+  constexpr static bool kHasLargeSubgroupRootOfUnity = true;
+};
+
+struct FqConfig : public FqBaseConfig {
+  constexpr static bool kUseMontgomery = false;
+
+  using StdConfig = FqConfig;
+
+  constexpr static BigInt<5> kOne = 1;
+
+  constexpr static BigInt<5> kTwoAdicRootOfUnity = {
+      UINT64_C(6851414208322399299), UINT64_C(12862850025448111381),
+      UINT64_C(5069430316273791837), UINT64_C(2411171371820257181),
+      UINT64_C(2286047797525),
+  };
+
+  constexpr static BigInt<5> kLargeSubgroupRootOfUnity = {
+      UINT64_C(10971634350113958758), UINT64_C(11768941864355092521),
+      UINT64_C(6183902089951039463),  UINT64_C(8757983921245469509),
+      UINT64_C(3297388348686),
+  };
+};
+
+struct FqMontConfig : public FqBaseConfig {
+  constexpr static bool kUseMontgomery = true;
+
+  using StdConfig = FqConfig;
+
+  constexpr static BigInt<5> kRSquared = {
+      UINT64_C(28619103704175136),   UINT64_C(11702218449377544339),
+      UINT64_C(7403203599591297249), UINT64_C(2248105543421449339),
+      UINT64_C(2357678148148),
+  };
+  constexpr static uint64_t kNPrime = UINT64_C(12714121028002250751);
+
+  constexpr static BigInt<5> kOne = {
+      UINT64_C(1784298994435064924),  UINT64_C(16852041090100268533),
+      UINT64_C(14258261760832875328), UINT64_C(2961187778261111191),
+      UINT64_C(1929014752195),
+  };
+
+  constexpr static BigInt<5> kTwoAdicRootOfUnity = {
+      UINT64_C(9821480371597472441), UINT64_C(9468346035609379175),
+      UINT64_C(9963748368231707135), UINT64_C(14865337659602750405),
+      UINT64_C(3984815592673),
+  };
+
+  constexpr static BigInt<5> kLargeSubgroupRootOfUnity = {
+      UINT64_C(7711798843682337706), UINT64_C(16456007754393011187),
+      UINT64_C(7470854640069402569), UINT64_C(10767969225751706229),
+      UINT64_C(2250015743691),
+  };
+};
+
+using Fq = PrimeField<FqConfig>;
+using FqMont = PrimeField<FqMontConfig>;
+
+}  // namespace zk_dtypes::mnt4_298
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT4_298_FQ_H_

--- a/zk_dtypes/include/elliptic_curve/mnt4_298/fqx2.h
+++ b/zk_dtypes/include/elliptic_curve/mnt4_298/fqx2.h
@@ -1,0 +1,30 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT4_298_FQX2_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT4_298_FQX2_H_
+
+#include "zk_dtypes/include/elliptic_curve/mnt4_298/fq.h"
+#include "zk_dtypes/include/field/extension_field.h"
+
+namespace zk_dtypes::mnt4_298 {
+
+// Fq2 = Fq[u] / (u^2 - 17). The quadratic non-residue 17 matches ark-mnt4-298
+// (and libff mnt4_init).
+REGISTER_EXTENSION_FIELD_WITH_MONT(FqX2, Fq, 2, 17);
+
+}  // namespace zk_dtypes::mnt4_298
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT4_298_FQX2_H_

--- a/zk_dtypes/include/elliptic_curve/mnt4_298/fqx4.h
+++ b/zk_dtypes/include/elliptic_curve/mnt4_298/fqx4.h
@@ -1,0 +1,32 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT4_298_FQX4_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT4_298_FQX4_H_
+
+#include "zk_dtypes/include/elliptic_curve/mnt4_298/fqx2.h"
+#include "zk_dtypes/include/field/extension_field.h"
+
+namespace zk_dtypes::mnt4_298 {
+
+// Fq4 = Fq2[v] / (v^2 - u), where u is the non-residue of Fq2 (u^2 = 17).
+// Non-residue for the quadratic tower is the Fq2 element (0, 1) = u, matching
+// ark-mnt4-298 (Fq4 NONRESIDUE = Fq2::new(Fq::ZERO, Fq::ONE)). GT of the MNT4
+// pairing lives here.
+REGISTER_EXTENSION_FIELD_TOWER_WITH_MONT(FqX4, FqX2, Fq, 2, {0, 1});
+
+}  // namespace zk_dtypes::mnt4_298
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT4_298_FQX4_H_

--- a/zk_dtypes/include/elliptic_curve/mnt4_298/fr.h
+++ b/zk_dtypes/include/elliptic_curve/mnt4_298/fr.h
@@ -1,0 +1,94 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT4_298_FR_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT4_298_FR_H_
+
+#include "zk_dtypes/include/field/big_prime_field.h"
+
+namespace zk_dtypes::mnt4_298 {
+
+// MNT4-298 scalar field. r =
+// 475922286169261325753349249653048451545124878552823515553267735739164647307408490559963137
+// Constants mirror ark-mnt4-298 (generator 10). Two-adicity 34 gives ample
+// room for NTT-based proving. No small subgroup on the scalar field.
+struct FrBaseConfig {
+  constexpr static size_t kStorageBits = 320;
+  constexpr static size_t kModulusBits = 298;
+  constexpr static BigInt<5> kModulus = {
+      UINT64_C(13493686787511418881), UINT64_C(18107087372223867603),
+      UINT64_C(14622846468717035924), UINT64_C(11702080941310629006),
+      UINT64_C(4110145082483),
+  };
+
+  constexpr static uint32_t kTwoAdicity = 34;
+
+  constexpr static BigInt<5> kTrace = {
+      UINT64_C(16471733895278153001),
+      UINT64_C(15509570718765568769),
+      UINT64_C(7632498711552832088),
+      UINT64_C(4462844154025183527),
+      UINT64_C(239),
+  };
+
+  constexpr static bool kHasTwoAdicRootOfUnity = true;
+  constexpr static bool kHasLargeSubgroupRootOfUnity = false;
+};
+
+struct FrConfig : public FrBaseConfig {
+  constexpr static bool kUseMontgomery = false;
+
+  using StdConfig = FrConfig;
+
+  constexpr static BigInt<5> kOne = 1;
+
+  constexpr static BigInt<5> kTwoAdicRootOfUnity = {
+      UINT64_C(3610488132116382585),  UINT64_C(326696323574833339),
+      UINT64_C(16343429254519383513), UINT64_C(10231842559834597716),
+      UINT64_C(1041857165040),
+  };
+};
+
+struct FrMontConfig : public FrBaseConfig {
+  constexpr static bool kUseMontgomery = true;
+
+  using StdConfig = FrConfig;
+
+  constexpr static BigInt<5> kRSquared = {
+      UINT64_C(5069492133365307755), UINT64_C(238568745964307313),
+      UINT64_C(5457639059775718278), UINT64_C(215892256015403885),
+      UINT64_C(1416186078018),
+  };
+  constexpr static uint64_t kNPrime = UINT64_C(13493686787511418879);
+
+  constexpr static BigInt<5> kOne = {
+      UINT64_C(14057839933066544220), UINT64_C(11205174688489019272),
+      UINT64_C(14258270859779156058), UINT64_C(2961187778261111191),
+      UINT64_C(1929014752195),
+  };
+
+  constexpr static BigInt<5> kTwoAdicRootOfUnity = {
+      UINT64_C(9334614154892245988), UINT64_C(3090160994209839447),
+      UINT64_C(6306351189133647754), UINT64_C(17995603186291776438),
+      UINT64_C(455881062568),
+  };
+};
+
+using Fr = PrimeField<FrConfig>;
+using FrMont = PrimeField<FrMontConfig>;
+
+}  // namespace zk_dtypes::mnt4_298
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT4_298_FR_H_

--- a/zk_dtypes/include/elliptic_curve/mnt4_298/g1.h
+++ b/zk_dtypes/include/elliptic_curve/mnt4_298/g1.h
@@ -1,0 +1,103 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT4_298_G1_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT4_298_G1_H_
+
+#include "zk_dtypes/include/elliptic_curve/mnt4_298/fq.h"
+#include "zk_dtypes/include/elliptic_curve/mnt4_298/fr.h"
+#include "zk_dtypes/include/elliptic_curve/short_weierstrass/affine_point.h"
+#include "zk_dtypes/include/elliptic_curve/short_weierstrass/jacobian_point.h"
+#include "zk_dtypes/include/elliptic_curve/short_weierstrass/point_xyzz.h"
+#include "zk_dtypes/include/elliptic_curve/short_weierstrass/sw_curve.h"
+
+namespace zk_dtypes::mnt4_298 {
+
+// MNT4-298 G1: y² = x³ + 2x + b over Fq (a = 2, unlike BN curves).
+// b, generator (G1_GENERATOR_X, G1_GENERATOR_Y) from ark-mnt4-298.
+class G1SwCurveConfig {
+ public:
+  constexpr static bool kUseMontgomery = false;
+  using StdConfig = G1SwCurveConfig;
+  using BaseField = Fq;
+  using ScalarField = Fr;
+
+  constexpr static BaseField kA = 2;
+  constexpr static BaseField kB = {
+      UINT64_C(6722483314896932821),  UINT64_C(8905885093438036561),
+      UINT64_C(14118172000221005916), UINT64_C(1538083334790521679),
+      UINT64_C(3660824667028),
+  };
+  constexpr static BaseField kX = {
+      UINT64_C(11679722493174787910), UINT64_C(6972706457774541022),
+      UINT64_C(12603440906699527824), UINT64_C(13440185221295782005),
+      UINT64_C(524735709857),
+  };
+  constexpr static BaseField kY = {
+      UINT64_C(11293419172838804146), UINT64_C(7455922144122925538),
+      UINT64_C(9930459777607426771),  UINT64_C(9396531370401983534),
+      UINT64_C(3141258207692),
+  };
+};
+
+class G1SwCurveMontConfig {
+ public:
+  constexpr static bool kUseMontgomery = true;
+  using StdConfig = G1SwCurveConfig;
+  using BaseField = FqMont;
+  using ScalarField = FrMont;
+
+  constexpr static BaseField kA = BaseField::FromUnchecked({
+      UINT64_C(3568597988870129848),
+      UINT64_C(15257338106490985450),
+      UINT64_C(10069779447956199041),
+      UINT64_C(5922375556522222383),
+      UINT64_C(3858029504390),
+  });
+  constexpr static BaseField kB = BaseField::FromUnchecked({
+      UINT64_C(7842808090366692145),
+      UINT64_C(288200302308193399),
+      UINT64_C(4162060950790347941),
+      UINT64_C(5488589108190218591),
+      UINT64_C(1553456013645),
+  });
+  constexpr static BaseField kX = BaseField::FromUnchecked({
+      UINT64_C(6046301378120906932),
+      UINT64_C(15105298306031900263),
+      UINT64_C(15757949605695610691),
+      UINT64_C(6113949277267426050),
+      UINT64_C(3063081829217),
+  });
+  constexpr static BaseField kY = BaseField::FromUnchecked({
+      UINT64_C(8798367863963590781),
+      UINT64_C(9770379341721339603),
+      UINT64_C(17697354471293810920),
+      UINT64_C(15252694996423733496),
+      UINT64_C(3845520398052),
+  });
+};
+
+using G1Curve = SwCurve<G1SwCurveConfig>;
+using G1CurveMont = SwCurve<G1SwCurveMontConfig>;
+using G1AffinePoint = AffinePoint<G1Curve>;
+using G1AffinePointMont = AffinePoint<G1CurveMont>;
+using G1JacobianPoint = JacobianPoint<G1Curve>;
+using G1JacobianPointMont = JacobianPoint<G1CurveMont>;
+using G1PointXyzz = PointXyzz<G1Curve>;
+using G1PointXyzzMont = PointXyzz<G1CurveMont>;
+
+}  // namespace zk_dtypes::mnt4_298
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT4_298_G1_H_

--- a/zk_dtypes/include/elliptic_curve/mnt4_298/g2.h
+++ b/zk_dtypes/include/elliptic_curve/mnt4_298/g2.h
@@ -1,0 +1,148 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT4_298_G2_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT4_298_G2_H_
+
+#include "zk_dtypes/include/elliptic_curve/mnt4_298/fqx2.h"
+#include "zk_dtypes/include/elliptic_curve/mnt4_298/fr.h"
+#include "zk_dtypes/include/elliptic_curve/short_weierstrass/affine_point.h"
+#include "zk_dtypes/include/elliptic_curve/short_weierstrass/jacobian_point.h"
+#include "zk_dtypes/include/elliptic_curve/short_weierstrass/point_xyzz.h"
+#include "zk_dtypes/include/elliptic_curve/short_weierstrass/sw_curve.h"
+
+namespace zk_dtypes::mnt4_298 {
+
+// MNT4-298 G2 over FqX2 (the quadratic twist): y² = x³ + a'x + b' with
+// a' = (34, 0) = (COEFF_A · non_residue, 0) and b' = (0, b·non_residue).
+// Values (twist coeffs, generator) from ark-mnt4-298.
+class G2SwCurveConfig {
+ public:
+  constexpr static bool kUseMontgomery = false;
+  using StdConfig = G2SwCurveConfig;
+  using BaseField = FqX2;
+  using ScalarField = Fr;
+
+  constexpr static BaseField kA = {{
+                                       UINT64_C(34),
+                                       UINT64_C(0),
+                                       UINT64_C(0),
+                                       UINT64_C(0),
+                                       UINT64_C(0),
+                                   },
+                                   {
+                                       UINT64_C(0),
+                                       UINT64_C(0),
+                                       UINT64_C(0),
+                                       UINT64_C(0),
+                                       UINT64_C(0),
+                                   }};
+  constexpr static BaseField kB = {{
+                                       UINT64_C(0),
+                                       UINT64_C(0),
+                                       UINT64_C(0),
+                                       UINT64_C(0),
+                                       UINT64_C(0),
+                                   },
+                                   {
+                                       UINT64_C(7654834016275860758),
+                                       UINT64_C(6639627127254871117),
+                                       UINT64_C(2219482899261599850),
+                                       UINT64_C(16636899235165397998),
+                                       UINT64_C(581843102222),
+                                   }};
+  constexpr static BaseField kX = {{
+                                       UINT64_C(13436775221361748388),
+                                       UINT64_C(3220442077098796845),
+                                       UINT64_C(10376841120081384103),
+                                       UINT64_C(7351407308195180280),
+                                       UINT64_C(3785879753157),
+                                   },
+                                   {
+                                       UINT64_C(10848013905752533385),
+                                       UINT64_C(229731644904075564),
+                                       UINT64_C(7601096639288137571),
+                                       UINT64_C(15714851233040728495),
+                                       UINT64_C(324900896626),
+                                   }};
+  constexpr static BaseField kY = {{
+                                       UINT64_C(978726687638789922),
+                                       UINT64_C(17048641329042926333),
+                                       UINT64_C(15212698069489290080),
+                                       UINT64_C(12310704625412826629),
+                                       UINT64_C(323315774463),
+                                   },
+                                   {
+                                       UINT64_C(9582359988289986801),
+                                       UINT64_C(4274312890841155524),
+                                       UINT64_C(14663043291447860476),
+                                       UINT64_C(11890381798806765824),
+                                       UINT64_C(3667102669929),
+                                   }};
+};
+
+class G2SwCurveMontConfig {
+ public:
+  constexpr static bool kUseMontgomery = true;
+  using StdConfig = G2SwCurveConfig;
+  using BaseField = FqX2Mont;
+  using ScalarField = FrMont;
+
+  constexpr static BaseField kA = {
+      FqMont::FromUnchecked(
+          {UINT64_C(9379015694948865065), UINT64_C(3933863906897692531),
+           UINT64_C(7183785805598089445), UINT64_C(17382890709766103498),
+           UINT64_C(3934325337380)}),
+      FqMont::FromUnchecked(
+          {UINT64_C(0), UINT64_C(0), UINT64_C(0), UINT64_C(0), UINT64_C(0)})};
+  constexpr static BaseField kB = {
+      FqMont::FromUnchecked(
+          {UINT64_C(0), UINT64_C(0), UINT64_C(0), UINT64_C(0), UINT64_C(0)}),
+      FqMont::FromUnchecked(
+          {UINT64_C(9511110677122940475), UINT64_C(13403516020116973437),
+           UINT64_C(1464701424831086967), UINT64_C(4646785117660390394),
+           UINT64_C(1747881737068)})};
+  constexpr static BaseField kX = {
+      FqMont::FromUnchecked(
+          {UINT64_C(5356671649366391794), UINT64_C(2684151262065976452),
+           UINT64_C(4683110650642896126), UINT64_C(10421299515941681582),
+           UINT64_C(1618695480960)}),
+      FqMont::FromUnchecked(
+          {UINT64_C(133394645290266480), UINT64_C(15395232932057272770),
+           UINT64_C(18271324022738539173), UINT64_C(9095178119640120034),
+           UINT64_C(2303787573609)})};
+  constexpr static BaseField kY = {
+      FqMont::FromUnchecked(
+          {UINT64_C(16920448081812496532), UINT64_C(15580160192086626100),
+           UINT64_C(3974467672100342742), UINT64_C(8216505962266760277),
+           UINT64_C(2643162835232)}),
+      FqMont::FromUnchecked(
+          {UINT64_C(73816197493558356), UINT64_C(8663991890578965996),
+           UINT64_C(11575903875707445958), UINT64_C(17953546933481201011),
+           UINT64_C(2167465829200)})};
+};
+
+using G2Curve = SwCurve<G2SwCurveConfig>;
+using G2CurveMont = SwCurve<G2SwCurveMontConfig>;
+using G2AffinePoint = AffinePoint<G2Curve>;
+using G2AffinePointMont = AffinePoint<G2CurveMont>;
+using G2JacobianPoint = JacobianPoint<G2Curve>;
+using G2JacobianPointMont = JacobianPoint<G2CurveMont>;
+using G2PointXyzz = PointXyzz<G2Curve>;
+using G2PointXyzzMont = PointXyzz<G2CurveMont>;
+
+}  // namespace zk_dtypes::mnt4_298
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT4_298_G2_H_

--- a/zk_dtypes/include/elliptic_curve/mnt6_298/fq.h
+++ b/zk_dtypes/include/elliptic_curve/mnt6_298/fq.h
@@ -1,0 +1,94 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT6_298_FQ_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT6_298_FQ_H_
+
+#include "zk_dtypes/include/field/big_prime_field.h"
+
+namespace zk_dtypes::mnt6_298 {
+
+// MNT6-298 base field. p =
+// 475922286169261325753349249653048451545124878552823515553267735739164647307408490559963137
+// This is the MNT4/MNT6 cycle: MNT6's Fq equals MNT4's Fr (ark-mnt6-298 defines
+// it as `ark_mnt4_298::Fr`). Generator 10, two-adicity 34, no small subgroup.
+struct FqBaseConfig {
+  constexpr static size_t kStorageBits = 320;
+  constexpr static size_t kModulusBits = 298;
+  constexpr static BigInt<5> kModulus = {
+      UINT64_C(13493686787511418881), UINT64_C(18107087372223867603),
+      UINT64_C(14622846468717035924), UINT64_C(11702080941310629006),
+      UINT64_C(4110145082483),
+  };
+
+  constexpr static uint32_t kTwoAdicity = 34;
+
+  constexpr static BigInt<5> kTrace = {
+      UINT64_C(16471733895278153001),
+      UINT64_C(15509570718765568769),
+      UINT64_C(7632498711552832088),
+      UINT64_C(4462844154025183527),
+      UINT64_C(239),
+  };
+
+  constexpr static bool kHasTwoAdicRootOfUnity = true;
+  constexpr static bool kHasLargeSubgroupRootOfUnity = false;
+};
+
+struct FqConfig : public FqBaseConfig {
+  constexpr static bool kUseMontgomery = false;
+
+  using StdConfig = FqConfig;
+
+  constexpr static BigInt<5> kOne = 1;
+
+  constexpr static BigInt<5> kTwoAdicRootOfUnity = {
+      UINT64_C(3610488132116382585),  UINT64_C(326696323574833339),
+      UINT64_C(16343429254519383513), UINT64_C(10231842559834597716),
+      UINT64_C(1041857165040),
+  };
+};
+
+struct FqMontConfig : public FqBaseConfig {
+  constexpr static bool kUseMontgomery = true;
+
+  using StdConfig = FqConfig;
+
+  constexpr static BigInt<5> kRSquared = {
+      UINT64_C(5069492133365307755), UINT64_C(238568745964307313),
+      UINT64_C(5457639059775718278), UINT64_C(215892256015403885),
+      UINT64_C(1416186078018),
+  };
+  constexpr static uint64_t kNPrime = UINT64_C(13493686787511418879);
+
+  constexpr static BigInt<5> kOne = {
+      UINT64_C(14057839933066544220), UINT64_C(11205174688489019272),
+      UINT64_C(14258270859779156058), UINT64_C(2961187778261111191),
+      UINT64_C(1929014752195),
+  };
+
+  constexpr static BigInt<5> kTwoAdicRootOfUnity = {
+      UINT64_C(9334614154892245988), UINT64_C(3090160994209839447),
+      UINT64_C(6306351189133647754), UINT64_C(17995603186291776438),
+      UINT64_C(455881062568),
+  };
+};
+
+using Fq = PrimeField<FqConfig>;
+using FqMont = PrimeField<FqMontConfig>;
+
+}  // namespace zk_dtypes::mnt6_298
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT6_298_FQ_H_

--- a/zk_dtypes/include/elliptic_curve/mnt6_298/fqx3.h
+++ b/zk_dtypes/include/elliptic_curve/mnt6_298/fqx3.h
@@ -1,0 +1,29 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT6_298_FQX3_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT6_298_FQX3_H_
+
+#include "zk_dtypes/include/elliptic_curve/mnt6_298/fq.h"
+#include "zk_dtypes/include/field/extension_field.h"
+
+namespace zk_dtypes::mnt6_298 {
+
+// Fq3 = Fq[u] / (u^3 - 5). The cubic non-residue 5 matches ark-mnt6-298.
+REGISTER_EXTENSION_FIELD_WITH_MONT(FqX3, Fq, 3, 5);
+
+}  // namespace zk_dtypes::mnt6_298
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT6_298_FQX3_H_

--- a/zk_dtypes/include/elliptic_curve/mnt6_298/fqx6.h
+++ b/zk_dtypes/include/elliptic_curve/mnt6_298/fqx6.h
@@ -1,0 +1,32 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT6_298_FQX6_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT6_298_FQX6_H_
+
+#include "zk_dtypes/include/elliptic_curve/mnt6_298/fqx3.h"
+#include "zk_dtypes/include/field/extension_field.h"
+
+namespace zk_dtypes::mnt6_298 {
+
+// Fq6 = Fq3[v] / (v^2 - u), where u is the non-residue of Fq3 (u^3 = 5).
+// Non-residue for the quadratic tower is the Fq3 element (0, 1, 0) = u,
+// matching ark-mnt6-298 (Fp6 = Fp6_2over3, NONRESIDUE = Fq3::new(0, 1, 0)). GT
+// of the MNT6 pairing lives here.
+REGISTER_EXTENSION_FIELD_TOWER_WITH_MONT(FqX6, FqX3, Fq, 2, {0, 1, 0});
+
+}  // namespace zk_dtypes::mnt6_298
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT6_298_FQX6_H_

--- a/zk_dtypes/include/elliptic_curve/mnt6_298/fr.h
+++ b/zk_dtypes/include/elliptic_curve/mnt6_298/fr.h
@@ -1,0 +1,108 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT6_298_FR_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT6_298_FR_H_
+
+#include "zk_dtypes/include/field/big_prime_field.h"
+
+namespace zk_dtypes::mnt6_298 {
+
+// MNT6-298 scalar field. r =
+// 475922286169261325753349249653048451545124879242694725395555128576210262817955800483758081
+// The MNT4/MNT6 cycle: MNT6's Fr equals MNT4's Fq (ark-mnt6-298 defines it as
+// `ark_mnt4_298::Fq`). Generator 17, two-adicity 17, small subgroup 7^2.
+struct FrBaseConfig {
+  constexpr static size_t kStorageBits = 320;
+  constexpr static size_t kModulusBits = 298;
+  constexpr static BigInt<5> kModulus = {
+      UINT64_C(14487189785281953793), UINT64_C(4731562877756902930),
+      UINT64_C(14622846468719063274), UINT64_C(11702080941310629006),
+      UINT64_C(4110145082483),
+  };
+
+  constexpr static uint32_t kTwoAdicity = 17;
+  constexpr static uint32_t kSmallSubgroupBase = 7;
+  constexpr static uint32_t kSmallSubgroupAdicity = 2;
+
+  constexpr static BigInt<5> kTrace = {
+      UINT64_C(507046961542412467),
+      UINT64_C(10985722965000136848),
+      UINT64_C(3046515236404309641),
+      UINT64_C(7654379058973561816),
+      UINT64_C(31357918),
+  };
+
+  constexpr static bool kHasTwoAdicRootOfUnity = true;
+  constexpr static bool kHasLargeSubgroupRootOfUnity = true;
+};
+
+struct FrConfig : public FrBaseConfig {
+  constexpr static bool kUseMontgomery = false;
+
+  using StdConfig = FrConfig;
+
+  constexpr static BigInt<5> kOne = 1;
+
+  constexpr static BigInt<5> kTwoAdicRootOfUnity = {
+      UINT64_C(6851414208322399299), UINT64_C(12862850025448111381),
+      UINT64_C(5069430316273791837), UINT64_C(2411171371820257181),
+      UINT64_C(2286047797525),
+  };
+
+  constexpr static BigInt<5> kLargeSubgroupRootOfUnity = {
+      UINT64_C(10971634350113958758), UINT64_C(11768941864355092521),
+      UINT64_C(6183902089951039463),  UINT64_C(8757983921245469509),
+      UINT64_C(3297388348686),
+  };
+};
+
+struct FrMontConfig : public FrBaseConfig {
+  constexpr static bool kUseMontgomery = true;
+
+  using StdConfig = FrConfig;
+
+  constexpr static BigInt<5> kRSquared = {
+      UINT64_C(28619103704175136),   UINT64_C(11702218449377544339),
+      UINT64_C(7403203599591297249), UINT64_C(2248105543421449339),
+      UINT64_C(2357678148148),
+  };
+  constexpr static uint64_t kNPrime = UINT64_C(12714121028002250751);
+
+  constexpr static BigInt<5> kOne = {
+      UINT64_C(1784298994435064924),  UINT64_C(16852041090100268533),
+      UINT64_C(14258261760832875328), UINT64_C(2961187778261111191),
+      UINT64_C(1929014752195),
+  };
+
+  constexpr static BigInt<5> kTwoAdicRootOfUnity = {
+      UINT64_C(9821480371597472441), UINT64_C(9468346035609379175),
+      UINT64_C(9963748368231707135), UINT64_C(14865337659602750405),
+      UINT64_C(3984815592673),
+  };
+
+  constexpr static BigInt<5> kLargeSubgroupRootOfUnity = {
+      UINT64_C(7711798843682337706), UINT64_C(16456007754393011187),
+      UINT64_C(7470854640069402569), UINT64_C(10767969225751706229),
+      UINT64_C(2250015743691),
+  };
+};
+
+using Fr = PrimeField<FrConfig>;
+using FrMont = PrimeField<FrMontConfig>;
+
+}  // namespace zk_dtypes::mnt6_298
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT6_298_FR_H_

--- a/zk_dtypes/include/elliptic_curve/mnt6_298/g1.h
+++ b/zk_dtypes/include/elliptic_curve/mnt6_298/g1.h
@@ -1,0 +1,103 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT6_298_G1_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT6_298_G1_H_
+
+#include "zk_dtypes/include/elliptic_curve/mnt6_298/fq.h"
+#include "zk_dtypes/include/elliptic_curve/mnt6_298/fr.h"
+#include "zk_dtypes/include/elliptic_curve/short_weierstrass/affine_point.h"
+#include "zk_dtypes/include/elliptic_curve/short_weierstrass/jacobian_point.h"
+#include "zk_dtypes/include/elliptic_curve/short_weierstrass/point_xyzz.h"
+#include "zk_dtypes/include/elliptic_curve/short_weierstrass/sw_curve.h"
+
+namespace zk_dtypes::mnt6_298 {
+
+// MNT6-298 G1: y² = x³ + 11x + b over Fq (a = 11).
+// b, generator from ark-mnt6-298.
+class G1SwCurveConfig {
+ public:
+  constexpr static bool kUseMontgomery = false;
+  using StdConfig = G1SwCurveConfig;
+  using BaseField = Fq;
+  using ScalarField = Fr;
+
+  constexpr static BaseField kA = 11;
+  constexpr static BaseField kB = {
+      UINT64_C(15827219621888807554), UINT64_C(2355843104595895421),
+      UINT64_C(4425953106273765812),  UINT64_C(15925905401844974669),
+      UINT64_C(921479880133),
+  };
+  constexpr static BaseField kX = {
+      UINT64_C(12532321609140159613), UINT64_C(16191784749896139965),
+      UINT64_C(7056391821740972887),  UINT64_C(3200319740236116666),
+      UINT64_C(2907674911997),
+  };
+  constexpr static BaseField kY = {
+      UINT64_C(9958370768819400744),  UINT64_C(6733419960382232352),
+      UINT64_C(18260350450562793410), UINT64_C(15793986406456999802),
+      UINT64_C(3476889421302),
+  };
+};
+
+class G1SwCurveMontConfig {
+ public:
+  constexpr static bool kUseMontgomery = true;
+  using StdConfig = G1SwCurveConfig;
+  using BaseField = FqMont;
+  using ScalarField = FrMont;
+
+  constexpr static BaseField kA = BaseField::FromUnchecked({
+      UINT64_C(13380829031336685551),
+      UINT64_C(14274740638550322365),
+      UINT64_C(9939770819147330555),
+      UINT64_C(10956149001738181307),
+      UINT64_C(668436861728),
+  });
+  constexpr static BaseField kB = BaseField::FromUnchecked({
+      UINT64_C(762457536267711291),
+      UINT64_C(1017480769655388902),
+      UINT64_C(12579245979485372705),
+      UINT64_C(11028678579857772437),
+      UINT64_C(1017891033839),
+  });
+  constexpr static BaseField kX = BaseField::FromUnchecked({
+      UINT64_C(1902266591782772004),
+      UINT64_C(13966178682311351161),
+      UINT64_C(15710654711326981618),
+      UINT64_C(8125800953529631193),
+      UINT64_C(576925825192),
+  });
+  constexpr static BaseField kY = BaseField::FromUnchecked({
+      UINT64_C(8851191548877995954),
+      UINT64_C(9862165831291588720),
+      UINT64_C(4895755467660702521),
+      UINT64_C(11132806403512354364),
+      UINT64_C(3384698221971),
+  });
+};
+
+using G1Curve = SwCurve<G1SwCurveConfig>;
+using G1CurveMont = SwCurve<G1SwCurveMontConfig>;
+using G1AffinePoint = AffinePoint<G1Curve>;
+using G1AffinePointMont = AffinePoint<G1CurveMont>;
+using G1JacobianPoint = JacobianPoint<G1Curve>;
+using G1JacobianPointMont = JacobianPoint<G1CurveMont>;
+using G1PointXyzz = PointXyzz<G1Curve>;
+using G1PointXyzzMont = PointXyzz<G1CurveMont>;
+
+}  // namespace zk_dtypes::mnt6_298
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT6_298_G1_H_

--- a/zk_dtypes/include/elliptic_curve/mnt6_298/g2.h
+++ b/zk_dtypes/include/elliptic_curve/mnt6_298/g2.h
@@ -1,0 +1,135 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT6_298_G2_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT6_298_G2_H_
+
+#include "zk_dtypes/include/elliptic_curve/mnt6_298/fqx3.h"
+#include "zk_dtypes/include/elliptic_curve/mnt6_298/fr.h"
+#include "zk_dtypes/include/elliptic_curve/short_weierstrass/affine_point.h"
+#include "zk_dtypes/include/elliptic_curve/short_weierstrass/jacobian_point.h"
+#include "zk_dtypes/include/elliptic_curve/short_weierstrass/point_xyzz.h"
+#include "zk_dtypes/include/elliptic_curve/short_weierstrass/sw_curve.h"
+
+namespace zk_dtypes::mnt6_298 {
+
+// MNT6-298 G2 over FqX3 (the cubic twist): y² = x³ + a'x + b' with
+// a' = (0, 0, 11) = (0, 0, COEFF_A) and b' = (5·b, 0, 0).
+// Values (twist coeffs, generator) from ark-mnt6-298. Each FqX3 coordinate is
+// (c0, c1, c2) with c0 + c1·u + c2·u² and u³ = 5.
+class G2SwCurveConfig {
+ public:
+  constexpr static bool kUseMontgomery = false;
+  using StdConfig = G2SwCurveConfig;
+  using BaseField = FqX3;
+  using ScalarField = Fr;
+
+  constexpr static BaseField kA = {
+      {UINT64_C(0), UINT64_C(0), UINT64_C(0), UINT64_C(0), UINT64_C(0)},
+      {UINT64_C(0), UINT64_C(0), UINT64_C(0), UINT64_C(0), UINT64_C(0)},
+      {UINT64_C(11), UINT64_C(0), UINT64_C(0), UINT64_C(0), UINT64_C(0)}};
+  constexpr static BaseField kB = {
+      {UINT64_C(10302179100803964041), UINT64_C(12118872224465161121),
+       UINT64_C(7506919062651793135), UINT64_C(12587213846785589491),
+       UINT64_C(497254318185)},
+      {UINT64_C(0), UINT64_C(0), UINT64_C(0), UINT64_C(0), UINT64_C(0)},
+      {UINT64_C(0), UINT64_C(0), UINT64_C(0), UINT64_C(0), UINT64_C(0)}};
+  constexpr static BaseField kX = {
+      {UINT64_C(4948741468954847251), UINT64_C(12513040782488949478),
+       UINT64_C(201442015971770421), UINT64_C(6255028380047225929),
+       UINT64_C(3639768817963)},
+      {UINT64_C(12227656358602506490), UINT64_C(4683400904595509419),
+       UINT64_C(12997221507588427923), UINT64_C(5975930421125778101),
+       UINT64_C(890155174826)},
+      {UINT64_C(82616830145402830), UINT64_C(17517601131757822667),
+       UINT64_C(13006404289022529628), UINT64_C(16367843824136356655),
+       UINT64_C(1235224038928)}};
+  constexpr static BaseField kY = {
+      {UINT64_C(8815844766680796305), UINT64_C(9442157791365292401),
+       UINT64_C(6775643458208415428), UINT64_C(14289185687982283841),
+       UINT64_C(4012999503932)},
+      {UINT64_C(3434657911289699438), UINT64_C(3299744831849133120),
+       UINT64_C(4979489892731608504), UINT64_C(15786531497538547650),
+       UINT64_C(869169113061)},
+      {UINT64_C(8912474332398151671), UINT64_C(13506681642645607842),
+       UINT64_C(11104537585227651130), UINT64_C(200873007283111778),
+       UINT64_C(1062420207747)}};
+};
+
+class G2SwCurveMontConfig {
+ public:
+  constexpr static bool kUseMontgomery = true;
+  using StdConfig = G2SwCurveConfig;
+  using BaseField = FqX3Mont;
+  using ScalarField = FrMont;
+
+  constexpr static BaseField kA = {
+      FqMont::FromUnchecked(
+          {UINT64_C(0), UINT64_C(0), UINT64_C(0), UINT64_C(0), UINT64_C(0)}),
+      FqMont::FromUnchecked(
+          {UINT64_C(0), UINT64_C(0), UINT64_C(0), UINT64_C(0), UINT64_C(0)}),
+      FqMont::FromUnchecked(
+          {UINT64_C(13380829031336685551), UINT64_C(14274740638550322365),
+           UINT64_C(9939770819147330555), UINT64_C(10956149001738181307),
+           UINT64_C(668436861728)})};
+  constexpr static BaseField kB = {
+      FqMont::FromUnchecked(
+          {UINT64_C(8765344967536689190), UINT64_C(5427060549762628522),
+           UINT64_C(11379895281290724368), UINT64_C(6547823810559129949),
+           UINT64_C(979310086714)}),
+      FqMont::FromUnchecked(
+          {UINT64_C(0), UINT64_C(0), UINT64_C(0), UINT64_C(0), UINT64_C(0)}),
+      FqMont::FromUnchecked(
+          {UINT64_C(0), UINT64_C(0), UINT64_C(0), UINT64_C(0), UINT64_C(0)})};
+  constexpr static BaseField kX = {
+      FqMont::FromUnchecked(
+          {UINT64_C(1570088295198957223), UINT64_C(11388243547153545593),
+           UINT64_C(16638094191055501418), UINT64_C(5096397944772901895),
+           UINT64_C(2489020867565)}),
+      FqMont::FromUnchecked(
+          {UINT64_C(3174542784159244592), UINT64_C(2855666475624403019),
+           UINT64_C(8007133152924412546), UINT64_C(682346899378287834),
+           UINT64_C(3034590943330)}),
+      FqMont::FromUnchecked(
+          {UINT64_C(17574722413557572081), UINT64_C(456974755699165048),
+           UINT64_C(3254619369127186675), UINT64_C(8279179948042967436),
+           UINT64_C(1102598794141)})};
+  constexpr static BaseField kY = {
+      FqMont::FromUnchecked(
+          {UINT64_C(12812139972553768031), UINT64_C(11537818555351683770),
+           UINT64_C(260815648150822609), UINT64_C(10680555275562460751),
+           UINT64_C(1291865091856)}),
+      FqMont::FromUnchecked(
+          {UINT64_C(11624524503831104487), UINT64_C(2433606431341056774),
+           UINT64_C(11186207532538858274), UINT64_C(4792775529631887891),
+           UINT64_C(909584932857)}),
+      FqMont::FromUnchecked(
+          {UINT64_C(6991090668950567135), UINT64_C(5882326072780932593),
+           UINT64_C(11371546271046018568), UINT64_C(7882928134413989632),
+           UINT64_C(3108546647457)})};
+};
+
+using G2Curve = SwCurve<G2SwCurveConfig>;
+using G2CurveMont = SwCurve<G2SwCurveMontConfig>;
+using G2AffinePoint = AffinePoint<G2Curve>;
+using G2AffinePointMont = AffinePoint<G2CurveMont>;
+using G2JacobianPoint = JacobianPoint<G2Curve>;
+using G2JacobianPointMont = JacobianPoint<G2CurveMont>;
+using G2PointXyzz = PointXyzz<G2Curve>;
+using G2PointXyzzMont = PointXyzz<G2CurveMont>;
+
+}  // namespace zk_dtypes::mnt6_298
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_MNT6_298_G2_H_

--- a/zk_dtypes/tests/elliptic_curve/constexpr_curve_config_unittest.cc
+++ b/zk_dtypes/tests/elliptic_curve/constexpr_curve_config_unittest.cc
@@ -26,6 +26,9 @@ limitations under the License.
 #include "zk_dtypes/include/elliptic_curve/bls12_381/g1.h"
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/g1.h"
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/g2.h"
+#include "zk_dtypes/include/elliptic_curve/mnt4_298/fqx4.h"
+#include "zk_dtypes/include/elliptic_curve/mnt4_298/g1.h"
+#include "zk_dtypes/include/elliptic_curve/mnt4_298/g2.h"
 #include "zk_dtypes/include/elliptic_curve/secp256k1/g1.h"
 #include "zk_dtypes/include/elliptic_curve/secp256r1/fq.h"
 #include "zk_dtypes/include/elliptic_curve/secp256r1/g1.h"
@@ -49,6 +52,8 @@ constexpr bool VerifyConstexpr() {
 // Montgomery configs.
 static_assert(VerifyConstexpr<bn254::G1SwCurveMontConfig>());
 static_assert(VerifyConstexpr<bn254::G2SwCurveMontConfig>());
+static_assert(VerifyConstexpr<mnt4_298::G1SwCurveMontConfig>());
+static_assert(VerifyConstexpr<mnt4_298::G2SwCurveMontConfig>());
 static_assert(VerifyConstexpr<secp256k1::G1SwCurveMontConfig>());
 static_assert(VerifyConstexpr<secp256r1::G1SwCurveMontConfig>());
 static_assert(VerifyConstexpr<bls12_381::G1SwCurveMontConfig>());
@@ -57,11 +62,11 @@ static_assert(VerifyConstexpr<bls12_381::G1SwCurveMontConfig>());
 // Runtime correctness via TYPED_TEST on MontConfig.
 // =========================================================================
 
-using MontConfigs =
-    ::testing::Types<bn254::G1SwCurveMontConfig, bn254::G2SwCurveMontConfig,
-                     secp256k1::G1SwCurveMontConfig,
-                     secp256r1::G1SwCurveMontConfig,
-                     bls12_381::G1SwCurveMontConfig>;
+using MontConfigs = ::testing::Types<
+    bn254::G1SwCurveMontConfig, bn254::G2SwCurveMontConfig,
+    mnt4_298::G1SwCurveMontConfig, mnt4_298::G2SwCurveMontConfig,
+    secp256k1::G1SwCurveMontConfig, secp256r1::G1SwCurveMontConfig,
+    bls12_381::G1SwCurveMontConfig>;
 
 template <typename T>
 class CurveConfigTest : public ::testing::Test {};
@@ -89,6 +94,14 @@ TYPED_TEST(CurveConfigTest, MontReduceMatchesStandard) {
   EXPECT_EQ(Mont::kB.MontReduce(), Std::kB) << "kB MontReduce mismatch";
   EXPECT_EQ(Mont::kX.MontReduce(), Std::kX) << "kX MontReduce mismatch";
   EXPECT_EQ(Mont::kY.MontReduce(), Std::kY) << "kY MontReduce mismatch";
+}
+
+// Smoke-test the MNT4-298 Fq4 tower (Fq -> Fq2 -> Fq4) compiles and supports
+// basic arithmetic. GT of the MNT4 pairing lives in Fq4.
+TEST(Mnt4Fq4Test, BasicTowerOps) {
+  using mnt4_298::FqX4;
+  EXPECT_EQ(FqX4::One() * FqX4::One(), FqX4::One());
+  EXPECT_EQ(FqX4::Zero() + FqX4::One(), FqX4::One());
 }
 
 }  // namespace

--- a/zk_dtypes/tests/elliptic_curve/constexpr_curve_config_unittest.cc
+++ b/zk_dtypes/tests/elliptic_curve/constexpr_curve_config_unittest.cc
@@ -29,6 +29,9 @@ limitations under the License.
 #include "zk_dtypes/include/elliptic_curve/mnt4_298/fqx4.h"
 #include "zk_dtypes/include/elliptic_curve/mnt4_298/g1.h"
 #include "zk_dtypes/include/elliptic_curve/mnt4_298/g2.h"
+#include "zk_dtypes/include/elliptic_curve/mnt6_298/fqx6.h"
+#include "zk_dtypes/include/elliptic_curve/mnt6_298/g1.h"
+#include "zk_dtypes/include/elliptic_curve/mnt6_298/g2.h"
 #include "zk_dtypes/include/elliptic_curve/secp256k1/g1.h"
 #include "zk_dtypes/include/elliptic_curve/secp256r1/fq.h"
 #include "zk_dtypes/include/elliptic_curve/secp256r1/g1.h"
@@ -54,6 +57,8 @@ static_assert(VerifyConstexpr<bn254::G1SwCurveMontConfig>());
 static_assert(VerifyConstexpr<bn254::G2SwCurveMontConfig>());
 static_assert(VerifyConstexpr<mnt4_298::G1SwCurveMontConfig>());
 static_assert(VerifyConstexpr<mnt4_298::G2SwCurveMontConfig>());
+static_assert(VerifyConstexpr<mnt6_298::G1SwCurveMontConfig>());
+static_assert(VerifyConstexpr<mnt6_298::G2SwCurveMontConfig>());
 static_assert(VerifyConstexpr<secp256k1::G1SwCurveMontConfig>());
 static_assert(VerifyConstexpr<secp256r1::G1SwCurveMontConfig>());
 static_assert(VerifyConstexpr<bls12_381::G1SwCurveMontConfig>());
@@ -65,6 +70,7 @@ static_assert(VerifyConstexpr<bls12_381::G1SwCurveMontConfig>());
 using MontConfigs = ::testing::Types<
     bn254::G1SwCurveMontConfig, bn254::G2SwCurveMontConfig,
     mnt4_298::G1SwCurveMontConfig, mnt4_298::G2SwCurveMontConfig,
+    mnt6_298::G1SwCurveMontConfig, mnt6_298::G2SwCurveMontConfig,
     secp256k1::G1SwCurveMontConfig, secp256r1::G1SwCurveMontConfig,
     bls12_381::G1SwCurveMontConfig>;
 
@@ -102,6 +108,14 @@ TEST(Mnt4Fq4Test, BasicTowerOps) {
   using mnt4_298::FqX4;
   EXPECT_EQ(FqX4::One() * FqX4::One(), FqX4::One());
   EXPECT_EQ(FqX4::Zero() + FqX4::One(), FqX4::One());
+}
+
+// Smoke-test the MNT6-298 Fq6 tower (Fq -> Fq3 -> Fq6) compiles and supports
+// basic arithmetic. GT of the MNT6 pairing lives in Fq6.
+TEST(Mnt6Fq6Test, BasicTowerOps) {
+  using mnt6_298::FqX6;
+  EXPECT_EQ(FqX6::One() * FqX6::One(), FqX6::One());
+  EXPECT_EQ(FqX6::Zero() + FqX6::One(), FqX6::One());
 }
 
 }  // namespace

--- a/zk_dtypes/tests/mnt4_298_test.py
+++ b/zk_dtypes/tests/mnt4_298_test.py
@@ -1,0 +1,144 @@
+# Copyright 2026 The zk_dtypes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for the MNT4-298 numpy dtypes registered in zk_dtypes.
+
+Reference constants are the standard-form values from ark-mnt4-298.
+"""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import zk_dtypes
+
+import numpy as np
+
+_FR_MODULUS = 475922286169261325753349249653048451545124878552823515553267735739164647307408490559963137
+_G1_A = 2
+_G1_B = 423894536526684178289416011533888240029318103673896002803341544124054745019340795360841685
+_G1_GX = 60760244141852568949126569781626075788424196370144486719385562369396875346601926534016838
+_G1_GY = 363732850702582978263902770815145784459747722357071843971107674179038674942891694705904306
+_G2_A = [34, 0]
+_G2_B = [
+    0,
+    67372828414711144619833451280373307321534573815811166723479321465776723059456513877937430,
+]
+_G2_NON_RESIDUE = 17
+_G2_GX = [
+    438374926219350099854919100077809681842783509163790991847867546339851681564223481322252708,
+    37620953615500480110935514360923278605464476459712393277679280819942849043649216370485641,
+]
+_G2_GY = [
+    37437409008528968268352521034936931842973546441370663118543015118291998305624025037512482,
+    424621479598893882672393190337420680597584695892317197646113820787463109735345923009077489,
+]
+
+# MNT4-298 base field Fq modulus and Montgomery radix R = 2^320, used to check
+# that ecinfo's Montgomery-form coefficients equal value·R mod p.
+_FQ_MODULUS = 475922286169261325753349249653048451545124879242694725395555128576210262817955800483758081
+_R = 1 << 320
+
+
+class Mnt4298DtypeTest(parameterized.TestCase):
+
+  @parameterized.parameters(
+      "mnt4_298_sf",
+      "mnt4_298_sf_mont",
+      "mnt4_298_g1_affine",
+      "mnt4_298_g1_affine_mont",
+      "mnt4_298_g1_jacobian",
+      "mnt4_298_g1_jacobian_mont",
+      "mnt4_298_g1_xyzz",
+      "mnt4_298_g1_xyzz_mont",
+      "mnt4_298_g2_affine",
+      "mnt4_298_g2_affine_mont",
+      "mnt4_298_g2_jacobian",
+      "mnt4_298_g2_jacobian_mont",
+      "mnt4_298_g2_xyzz",
+      "mnt4_298_g2_xyzz_mont",
+  )
+  def test_dtype_registered_and_allocatable(self, name):
+    dt = np.dtype(getattr(zk_dtypes, name))
+    arr = np.zeros(4, dtype=dt)
+    self.assertEqual(arr.dtype, dt)
+    self.assertLen(arr, 4)
+
+  def test_pfinfo_scalar_field(self):
+    for t in (zk_dtypes.mnt4_298_sf, zk_dtypes.mnt4_298_sf_mont):
+      info = zk_dtypes.pfinfo(t)
+      self.assertEqual(info.modulus, _FR_MODULUS)
+      self.assertEqual(info.storage_bits, 320)
+      self.assertEqual(info.modulus_bits, 298)
+      self.assertEqual(info.two_adicity, 34)
+    self.assertFalse(zk_dtypes.pfinfo(zk_dtypes.mnt4_298_sf).is_montgomery)
+    self.assertTrue(zk_dtypes.pfinfo(zk_dtypes.mnt4_298_sf_mont).is_montgomery)
+
+  @parameterized.parameters(
+      ("mnt4_298_g1_affine", "affine", 640),
+      ("mnt4_298_g1_jacobian", "jacobian", 960),
+      ("mnt4_298_g1_xyzz", "xyzz", 1280),
+  )
+  def test_g1_ecinfo(self, name, point_repr, bits):
+    info = zk_dtypes.ecinfo(getattr(zk_dtypes, name))
+    self.assertEqual(info.curve_group, "g1")
+    self.assertEqual(info.point_repr, point_repr)
+    self.assertEqual(info.storage_bits, bits)
+    self.assertFalse(info.is_montgomery)
+    self.assertEqual(info.a, _G1_A)
+    self.assertEqual(info.b, _G1_B)
+    self.assertEqual(info.gx, _G1_GX)
+    self.assertEqual(info.gy, _G1_GY)
+    self.assertIsNone(info.non_residue)
+
+  @parameterized.parameters(
+      ("mnt4_298_g2_affine", "affine", 1280),
+      ("mnt4_298_g2_jacobian", "jacobian", 1920),
+      ("mnt4_298_g2_xyzz", "xyzz", 2560),
+  )
+  def test_g2_ecinfo(self, name, point_repr, bits):
+    info = zk_dtypes.ecinfo(getattr(zk_dtypes, name))
+    self.assertEqual(info.curve_group, "g2")
+    self.assertEqual(info.point_repr, point_repr)
+    self.assertEqual(info.storage_bits, bits)
+    self.assertEqual(info.a, _G2_A)
+    self.assertEqual(info.b, _G2_B)
+    self.assertEqual(info.non_residue, _G2_NON_RESIDUE)
+
+  def _mont(self, value):
+    return (value * _R) % _FQ_MODULUS
+
+  def test_g1_montgomery_coefficients(self):
+    # ecinfo's Montgomery constants must equal value·R mod p. MNT4 G1 a=2 is
+    # non-zero, so this genuinely exercises the Montgomery path (bn254 a=0 would
+    # pass trivially). Also the only check of _ecinfo.py's mont decimals, which
+    # are transcribed independently of the C++ limb constants.
+    info = zk_dtypes.ecinfo(zk_dtypes.mnt4_298_g1_affine_mont)
+    self.assertTrue(info.is_montgomery)
+    self.assertEqual(info.a, self._mont(_G1_A))
+    self.assertEqual(info.b, self._mont(_G1_B))
+    self.assertEqual(info.gx, self._mont(_G1_GX))
+    self.assertEqual(info.gy, self._mont(_G1_GY))
+
+  def test_g2_montgomery_coefficients(self):
+    info = zk_dtypes.ecinfo(zk_dtypes.mnt4_298_g2_affine_mont)
+    self.assertTrue(info.is_montgomery)
+    self.assertEqual(info.a, [self._mont(_G2_A[0]), self._mont(_G2_A[1])])
+    self.assertEqual(info.b, [self._mont(_G2_B[0]), self._mont(_G2_B[1])])
+    self.assertEqual(info.gx, [self._mont(_G2_GX[0]), self._mont(_G2_GX[1])])
+    self.assertEqual(info.gy, [self._mont(_G2_GY[0]), self._mont(_G2_GY[1])])
+    self.assertEqual(info.non_residue, self._mont(_G2_NON_RESIDUE))
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/zk_dtypes/tests/mnt6_298_test.py
+++ b/zk_dtypes/tests/mnt6_298_test.py
@@ -1,0 +1,146 @@
+# Copyright 2026 The zk_dtypes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for the MNT6-298 numpy dtypes registered in zk_dtypes.
+
+Reference constants are the standard-form values from ark-mnt6-298. MNT6 G2 is
+defined over Fp3 (the cubic twist), so its coordinates are 3-element lists and
+its point storage is 3x wider than G1.
+"""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import zk_dtypes
+
+import numpy as np
+
+# MNT6-298 is the MNT4 cycle: its scalar field is MNT4's Fq, its base field is
+# MNT4's Fr.
+_FR_MODULUS = 475922286169261325753349249653048451545124879242694725395555128576210262817955800483758081
+_FQ_MODULUS = 475922286169261325753349249653048451545124878552823515553267735739164647307408490559963137
+_R = 1 << 320
+
+_G1_A = 11
+_G1_B = 106700080510851735677967319632585352256454251201367587890185989362936000262606668469523074
+_G1_GX = 336685752883082228109289846353937104185698209371404178342968838739115829740084426881123453
+_G1_GY = 402596290139780989709332707716568920777622032073762749862342374583908837063963736098549800
+_G2_A = [0, 0, 11]
+_G2_B = [
+    57578116384997352636487348509878309737146377454014423897662211075515354005624851787652233,
+    0,
+    0,
+]
+_G2_GX = [
+    421456435772811846256826561593908322288509115489119907560382401870203318738334702321297427,
+    103072927438548502463527009961344915021167584706439945404959058962657261178393635706405114,
+    143029172143731852627002926324735183809768363301149009204849580478324784395590388826052558,
+]
+_G2_GY = [
+    464673596668689463130099227575639512541218133445388869383893594087634649237515554342751377,
+    100642907501977375184575075967118071807821117960152743335603284583254620685343989304941678,
+    123019855502969896026940545715841181300275180157288044663051565390506010149881373807142903,
+]
+_G2_NON_RESIDUE = 5
+
+
+class Mnt6298DtypeTest(parameterized.TestCase):
+
+  @parameterized.parameters(
+      "mnt6_298_sf",
+      "mnt6_298_sf_mont",
+      "mnt6_298_g1_affine",
+      "mnt6_298_g1_affine_mont",
+      "mnt6_298_g1_jacobian",
+      "mnt6_298_g1_jacobian_mont",
+      "mnt6_298_g1_xyzz",
+      "mnt6_298_g1_xyzz_mont",
+      "mnt6_298_g2_affine",
+      "mnt6_298_g2_affine_mont",
+      "mnt6_298_g2_jacobian",
+      "mnt6_298_g2_jacobian_mont",
+      "mnt6_298_g2_xyzz",
+      "mnt6_298_g2_xyzz_mont",
+  )
+  def test_dtype_registered_and_allocatable(self, name):
+    dt = np.dtype(getattr(zk_dtypes, name))
+    arr = np.zeros(4, dtype=dt)
+    self.assertEqual(arr.dtype, dt)
+    self.assertLen(arr, 4)
+
+  def test_pfinfo_scalar_field(self):
+    for t in (zk_dtypes.mnt6_298_sf, zk_dtypes.mnt6_298_sf_mont):
+      info = zk_dtypes.pfinfo(t)
+      self.assertEqual(info.modulus, _FR_MODULUS)
+      self.assertEqual(info.storage_bits, 320)
+      self.assertEqual(info.modulus_bits, 298)
+      self.assertEqual(info.two_adicity, 17)
+    self.assertFalse(zk_dtypes.pfinfo(zk_dtypes.mnt6_298_sf).is_montgomery)
+    self.assertTrue(zk_dtypes.pfinfo(zk_dtypes.mnt6_298_sf_mont).is_montgomery)
+
+  @parameterized.parameters(
+      ("mnt6_298_g1_affine", "affine", 640),
+      ("mnt6_298_g1_jacobian", "jacobian", 960),
+      ("mnt6_298_g1_xyzz", "xyzz", 1280),
+  )
+  def test_g1_ecinfo(self, name, point_repr, bits):
+    info = zk_dtypes.ecinfo(getattr(zk_dtypes, name))
+    self.assertEqual(info.curve_group, "g1")
+    self.assertEqual(info.point_repr, point_repr)
+    self.assertEqual(info.storage_bits, bits)
+    self.assertFalse(info.is_montgomery)
+    self.assertEqual(info.a, _G1_A)
+    self.assertEqual(info.b, _G1_B)
+    self.assertEqual(info.gx, _G1_GX)
+    self.assertEqual(info.gy, _G1_GY)
+    self.assertIsNone(info.non_residue)
+
+  @parameterized.parameters(
+      # G2 over Fp3: storage is num_coords * 3 * 320 bits.
+      ("mnt6_298_g2_affine", "affine", 1920),
+      ("mnt6_298_g2_jacobian", "jacobian", 2880),
+      ("mnt6_298_g2_xyzz", "xyzz", 3840),
+  )
+  def test_g2_ecinfo(self, name, point_repr, bits):
+    info = zk_dtypes.ecinfo(getattr(zk_dtypes, name))
+    self.assertEqual(info.curve_group, "g2")
+    self.assertEqual(info.point_repr, point_repr)
+    self.assertEqual(info.storage_bits, bits)
+    self.assertEqual(info.a, _G2_A)
+    self.assertEqual(info.b, _G2_B)
+    self.assertEqual(info.non_residue, _G2_NON_RESIDUE)
+
+  def _mont(self, value):
+    return (value * _R) % _FQ_MODULUS
+
+  def test_g1_montgomery_coefficients(self):
+    info = zk_dtypes.ecinfo(zk_dtypes.mnt6_298_g1_affine_mont)
+    self.assertTrue(info.is_montgomery)
+    self.assertEqual(info.a, self._mont(_G1_A))
+    self.assertEqual(info.b, self._mont(_G1_B))
+    self.assertEqual(info.gx, self._mont(_G1_GX))
+    self.assertEqual(info.gy, self._mont(_G1_GY))
+
+  def test_g2_montgomery_coefficients(self):
+    info = zk_dtypes.ecinfo(zk_dtypes.mnt6_298_g2_affine_mont)
+    self.assertTrue(info.is_montgomery)
+    self.assertEqual(info.a, [self._mont(c) for c in _G2_A])
+    self.assertEqual(info.b, [self._mont(c) for c in _G2_B])
+    self.assertEqual(info.gx, [self._mont(c) for c in _G2_GX])
+    self.assertEqual(info.gy, [self._mont(c) for c in _G2_GY])
+    self.assertEqual(info.non_residue, self._mont(_G2_NON_RESIDUE))
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
## Description

MNT4-298 and MNT6-298 form the pairing-friendly cycle used for proof-carrying
data (PCD) recursion (arkworks `ark-mnt4-298`/`ark-mnt6-298`) — the next curves
needed beyond bn254. This adds their fields, curves (G1/G2), and numpy dtypes.

Two things a reviewer won't see from the diff:

- These are the first 320-bit (`BigInt<5>`) fields and the first
  short-Weierstrass curves with a non-zero `a` (MNT4 G1 `a=2`, MNT6 G1 `a=11`).
  The non-zero `a` is why the Python `ecinfo` registry now carries a
  Montgomery-form `a` per domain — the prior code stored a single `a`, correct
  only because every existing curve had `a=0`.
- MNT6's G2 lives over a cubic extension Fp3 (vs Fp2) — the first such case;
  the `ecinfo` G2 extension-degree is now a per-curve parameter to size it. By
  the MNT cycle, MNT6's Fq/Fr equal MNT4's Fr/Fq, so those field configs carry
  identical constants but are kept as separate per-curve definitions (matching
  arkworks) rather than aliased, to avoid conflating two curve identities.

All field and curve constants are sourced from `ark-mnt4-298`/`ark-mnt6-298`.

Follow-up (out of scope, noted for later): the per-scalar-field `if constexpr`
dispatches in `_src/ec_point_numpy.h` and `_src/field_numpy.h` grow one arm per
curve across two files; a `ScalarField -> point-types` trait could retire that
lockstep-edit (documented as a gotcha in `CLAUDE.md`).

## Related Issues/PRs

None — standalone curve addition.

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline
