### PR TITLE
feat(elliptic_curve): add Pasta curves (Pallas + Vesta) to zk_dtypes

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -94,6 +94,15 @@ using curve25519::FqMont;
 - SW infra: `sw_curve`, `sw_affine_point`, `sw_jacobian_point`, `sw_point_xyzz`
 - TE infra: `te_curve`, `te_affine_point`, `te_extended_point`
 
+### BUILD Target Ordering
+
+- Within the `# Elliptic Curve #` section of `zk_dtypes/BUILD.bazel`, the
+  per-curve `cc_library` groups are ordered **alphabetically by curve name**
+  (`bls12_381`, `bn254`, `pallas`, `secp256k1`, `secp256r1`, `vesta`).
+- Keep each curve's own targets in dependency order within its group (`fq` →
+  `fqx*` → `fr` → `curve` → `g1` → `g2`), not alphabetical.
+- `deps` lists are sorted by buildifier; don't hand-order them.
+
 ### Test Convention
 
 - Small-prime test config in `<curve_type>/test/<type>_curve_config.h` (e.g.
@@ -110,10 +119,17 @@ using curve25519::FqMont;
 1. **Curve config** (`g1.h`): Define `G1<Sw|Te>CurveConfig` with `kA`/`kB`/`kD`,
    generator coords, and Mont variant with `FromUnchecked`. Verify generator is
    on curve in a unittest.
-1. **BUILD.bazel**: Add `cc_library` targets. Add to `all_types` deps and the
-   appropriate type list macros in `all_types.h`.
+1. **BUILD.bazel**: Add `cc_library` targets in alphabetical position (see BUILD
+   Target Ordering). Add to `all_types` deps and the appropriate type list
+   macros in `all_types.h`.
+1. **numpy surface** (if the curve is exposed to numpy): add the curve to the
+   `_CURVE_PARAMS` / `_build_meta` tables in `_ecinfo.py` and a modulus branch
+   in `_pfinfo.py`. These are curve-list-driven, so no per-curve dispatch code
+   is needed.
 1. **Tests**: On-curve check, identity addition, inverse, double=add(self),
-   Mont/non-Mont consistency.
+   Mont/non-Mont consistency. numpy EC point types are covered by adding the
+   curve name to `_CURVES` in `tests/ec_point_test.py` (curve-list-driven — no
+   per-curve test file).
 
 ## Downstream Integration
 

--- a/zk_dtypes/BUILD.bazel
+++ b/zk_dtypes/BUILD.bazel
@@ -46,8 +46,10 @@ cc_library(
         ":mersenne31",
         ":mersenne31x2",
         ":mersenne31x2x2",
+        ":pallas_g1",
         ":secp256k1_g1",
         ":secp256r1_g1",
+        ":vesta_g1",
     ],
 )
 
@@ -638,6 +640,40 @@ cc_library(
 ##################
 
 cc_library(
+    name = "bls12_381_fq",
+    hdrs = ["include/elliptic_curve/bls12_381/fq.h"],
+    deps = [":big_prime_field"],
+)
+
+cc_library(
+    name = "bls12_381_fqx2",
+    hdrs = ["include/elliptic_curve/bls12_381/fqx2.h"],
+    deps = [
+        ":bls12_381_fq",
+        ":extension_field",
+    ],
+)
+
+cc_library(
+    name = "bls12_381_fr",
+    hdrs = ["include/elliptic_curve/bls12_381/fr.h"],
+    deps = [":big_prime_field"],
+)
+
+cc_library(
+    name = "bls12_381_g1",
+    hdrs = ["include/elliptic_curve/bls12_381/g1.h"],
+    deps = [
+        ":bls12_381_fq",
+        ":bls12_381_fr",
+        ":sw_affine_point",
+        ":sw_curve",
+        ":sw_jacobian_point",
+        ":sw_point_xyzz",
+    ],
+)
+
+cc_library(
     name = "bn254_fq",
     hdrs = ["include/elliptic_curve/bn/bn254/fq.h"],
     deps = [":big_prime_field"],
@@ -712,6 +748,31 @@ cc_library(
 )
 
 cc_library(
+    name = "pallas_fq",
+    hdrs = ["include/elliptic_curve/pallas/fq.h"],
+    deps = [":big_prime_field"],
+)
+
+cc_library(
+    name = "pallas_fr",
+    hdrs = ["include/elliptic_curve/pallas/fr.h"],
+    deps = [":big_prime_field"],
+)
+
+cc_library(
+    name = "pallas_g1",
+    hdrs = ["include/elliptic_curve/pallas/g1.h"],
+    deps = [
+        ":pallas_fq",
+        ":pallas_fr",
+        ":sw_affine_point",
+        ":sw_curve",
+        ":sw_jacobian_point",
+        ":sw_point_xyzz",
+    ],
+)
+
+cc_library(
     name = "secp256k1_fq",
     hdrs = ["include/elliptic_curve/secp256k1/fq.h"],
     deps = [":big_prime_field"],
@@ -762,36 +823,27 @@ cc_library(
 )
 
 cc_library(
-    name = "bls12_381_fq",
-    hdrs = ["include/elliptic_curve/bls12_381/fq.h"],
+    name = "vesta_fq",
+    hdrs = ["include/elliptic_curve/vesta/fq.h"],
     deps = [":big_prime_field"],
 )
 
 cc_library(
-    name = "bls12_381_fqx2",
-    hdrs = ["include/elliptic_curve/bls12_381/fqx2.h"],
-    deps = [
-        ":bls12_381_fq",
-        ":extension_field",
-    ],
-)
-
-cc_library(
-    name = "bls12_381_fr",
-    hdrs = ["include/elliptic_curve/bls12_381/fr.h"],
+    name = "vesta_fr",
+    hdrs = ["include/elliptic_curve/vesta/fr.h"],
     deps = [":big_prime_field"],
 )
 
 cc_library(
-    name = "bls12_381_g1",
-    hdrs = ["include/elliptic_curve/bls12_381/g1.h"],
+    name = "vesta_g1",
+    hdrs = ["include/elliptic_curve/vesta/g1.h"],
     deps = [
-        ":bls12_381_fq",
-        ":bls12_381_fr",
         ":sw_affine_point",
         ":sw_curve",
         ":sw_jacobian_point",
         ":sw_point_xyzz",
+        ":vesta_fq",
+        ":vesta_fr",
     ],
 )
 
@@ -1083,11 +1135,13 @@ cc_test(
         ":bls12_381_g1",
         ":bn254_g1",
         ":bn254_g2",
+        ":pallas_g1",
         ":secp256k1_g1",
         ":secp256r1_fq",
         ":secp256r1_g1",
         ":sw_test_curve_config",
         ":te_test_curve_config",
+        ":vesta_g1",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],

--- a/zk_dtypes/__init__.py
+++ b/zk_dtypes/__init__.py
@@ -40,6 +40,10 @@ __all__ = [
     # Big prime field types
     "bn254_sf",
     "bn254_sf_mont",
+    "pallas_sf",
+    "pallas_sf_mont",
+    "vesta_sf",
+    "vesta_sf_mont",
     # Extension field types
     "babybearx4",
     "babybearx4_mont",
@@ -70,6 +74,18 @@ __all__ = [
     "bn254_g2_jacobian_mont",
     "bn254_g2_xyzz",
     "bn254_g2_xyzz_mont",
+    "pallas_g1_affine",
+    "pallas_g1_affine_mont",
+    "pallas_g1_jacobian",
+    "pallas_g1_jacobian_mont",
+    "pallas_g1_xyzz",
+    "pallas_g1_xyzz_mont",
+    "vesta_g1_affine",
+    "vesta_g1_affine_mont",
+    "vesta_g1_jacobian",
+    "vesta_g1_jacobian_mont",
+    "vesta_g1_xyzz",
+    "vesta_g1_xyzz_mont",
 ]
 
 from typing import Type
@@ -95,6 +111,10 @@ from zk_dtypes._zk_dtypes_ext import koalabear_mont
 from zk_dtypes._zk_dtypes_ext import mersenne31
 from zk_dtypes._zk_dtypes_ext import bn254_sf
 from zk_dtypes._zk_dtypes_ext import bn254_sf_mont
+from zk_dtypes._zk_dtypes_ext import pallas_sf
+from zk_dtypes._zk_dtypes_ext import pallas_sf_mont
+from zk_dtypes._zk_dtypes_ext import vesta_sf
+from zk_dtypes._zk_dtypes_ext import vesta_sf_mont
 from zk_dtypes._zk_dtypes_ext import babybearx4
 from zk_dtypes._zk_dtypes_ext import babybearx4_mont
 from zk_dtypes._zk_dtypes_ext import goldilocksx3
@@ -122,6 +142,18 @@ from zk_dtypes._zk_dtypes_ext import bn254_g2_jacobian
 from zk_dtypes._zk_dtypes_ext import bn254_g2_jacobian_mont
 from zk_dtypes._zk_dtypes_ext import bn254_g2_xyzz
 from zk_dtypes._zk_dtypes_ext import bn254_g2_xyzz_mont
+from zk_dtypes._zk_dtypes_ext import pallas_g1_affine
+from zk_dtypes._zk_dtypes_ext import pallas_g1_affine_mont
+from zk_dtypes._zk_dtypes_ext import pallas_g1_jacobian
+from zk_dtypes._zk_dtypes_ext import pallas_g1_jacobian_mont
+from zk_dtypes._zk_dtypes_ext import pallas_g1_xyzz
+from zk_dtypes._zk_dtypes_ext import pallas_g1_xyzz_mont
+from zk_dtypes._zk_dtypes_ext import vesta_g1_affine
+from zk_dtypes._zk_dtypes_ext import vesta_g1_affine_mont
+from zk_dtypes._zk_dtypes_ext import vesta_g1_jacobian
+from zk_dtypes._zk_dtypes_ext import vesta_g1_jacobian_mont
+from zk_dtypes._zk_dtypes_ext import vesta_g1_xyzz
+from zk_dtypes._zk_dtypes_ext import vesta_g1_xyzz_mont
 
 import numpy as np
 
@@ -142,6 +174,10 @@ koalabear_mont: Type[np.generic]
 mersenne31: Type[np.generic]
 bn254_sf: Type[np.generic]
 bn254_sf_mont: Type[np.generic]
+pallas_sf: Type[np.generic]
+pallas_sf_mont: Type[np.generic]
+vesta_sf: Type[np.generic]
+vesta_sf_mont: Type[np.generic]
 babybearx4: Type[np.generic]
 babybearx4_mont: Type[np.generic]
 goldilocksx3: Type[np.generic]
@@ -169,5 +205,17 @@ bn254_g2_jacobian: Type[np.generic]
 bn254_g2_jacobian_mont: Type[np.generic]
 bn254_g2_xyzz: Type[np.generic]
 bn254_g2_xyzz_mont: Type[np.generic]
+pallas_g1_affine: Type[np.generic]
+pallas_g1_affine_mont: Type[np.generic]
+pallas_g1_jacobian: Type[np.generic]
+pallas_g1_jacobian_mont: Type[np.generic]
+pallas_g1_xyzz: Type[np.generic]
+pallas_g1_xyzz_mont: Type[np.generic]
+vesta_g1_affine: Type[np.generic]
+vesta_g1_affine_mont: Type[np.generic]
+vesta_g1_jacobian: Type[np.generic]
+vesta_g1_jacobian_mont: Type[np.generic]
+vesta_g1_xyzz: Type[np.generic]
+vesta_g1_xyzz_mont: Type[np.generic]
 
 del np, Type

--- a/zk_dtypes/_ecinfo.py
+++ b/zk_dtypes/_ecinfo.py
@@ -29,11 +29,31 @@ from zk_dtypes._zk_dtypes_ext import bn254_g2_jacobian
 from zk_dtypes._zk_dtypes_ext import bn254_g2_jacobian_mont
 from zk_dtypes._zk_dtypes_ext import bn254_g2_xyzz
 from zk_dtypes._zk_dtypes_ext import bn254_g2_xyzz_mont
+from zk_dtypes._zk_dtypes_ext import pallas_sf
+from zk_dtypes._zk_dtypes_ext import pallas_sf_mont
+from zk_dtypes._zk_dtypes_ext import pallas_g1_affine
+from zk_dtypes._zk_dtypes_ext import pallas_g1_affine_mont
+from zk_dtypes._zk_dtypes_ext import pallas_g1_jacobian
+from zk_dtypes._zk_dtypes_ext import pallas_g1_jacobian_mont
+from zk_dtypes._zk_dtypes_ext import pallas_g1_xyzz
+from zk_dtypes._zk_dtypes_ext import pallas_g1_xyzz_mont
+from zk_dtypes._zk_dtypes_ext import vesta_sf
+from zk_dtypes._zk_dtypes_ext import vesta_sf_mont
+from zk_dtypes._zk_dtypes_ext import vesta_g1_affine
+from zk_dtypes._zk_dtypes_ext import vesta_g1_affine_mont
+from zk_dtypes._zk_dtypes_ext import vesta_g1_jacobian
+from zk_dtypes._zk_dtypes_ext import vesta_g1_jacobian_mont
+from zk_dtypes._zk_dtypes_ext import vesta_g1_xyzz
+from zk_dtypes._zk_dtypes_ext import vesta_g1_xyzz_mont
 
 import numpy as np
 
 _bn254_sf_dtype = np.dtype(bn254_sf)
 _bn254_sf_mont_dtype = np.dtype(bn254_sf_mont)
+_pallas_sf_dtype = np.dtype(pallas_sf)
+_pallas_sf_mont_dtype = np.dtype(pallas_sf_mont)
+_vesta_sf_dtype = np.dtype(vesta_sf)
+_vesta_sf_mont_dtype = np.dtype(vesta_sf_mont)
 _bn254_g1_affine_dtype = np.dtype(bn254_g1_affine)
 _bn254_g1_affine_mont_dtype = np.dtype(bn254_g1_affine_mont)
 _bn254_g1_jacobian_dtype = np.dtype(bn254_g1_jacobian)
@@ -89,6 +109,25 @@ _BN254_G2_GY_MONT = [
 ]
 _BN254_G2_NON_RESIDUE_MONT = 15537367993719455909907449462855742678907882278146377936676643359958227611562
 
+# Pasta G1: y² = x³ + 5, generator (-1, 2). Standard gx is `modulus - 1`;
+# Montgomery forms are `value * R mod base-field modulus` (arkworks ark-pallas /
+# ark-vesta). See docs/development.md for the constant-derivation method.
+_PALLAS_A = 0
+_PALLAS_B = 5
+_PALLAS_G1_GX = 28948022309329048855892746252171976963363056481941560715954676764349967630336
+_PALLAS_G1_GY = 2
+_PALLAS_G1_B_MONT = 28948022309329048855892746252171976962451850171313166594149061516916263223277
+_PALLAS_G1_GX_MONT = 182241262125678824361123049486740881412
+_PALLAS_G1_GY_MONT = 28948022309329048855892746252171976962998573957690203067232430665376485867513
+
+_VESTA_A = 0
+_VESTA_B = 5
+_VESTA_G1_GX = 28948022309329048855892746252171976963363056481941647379679742748393362948096
+_VESTA_G1_GY = 2
+_VESTA_G1_B_MONT = 28948022309329048855892746252171976962451850171311519983372807820091752185837
+_VESTA_G1_GX_MONT = 182241262126025479261386985660322152452
+_VESTA_G1_GY_MONT = 28948022309329048855892746252171976962998573957689596421156968777072718643193
+
 
 # Curve parameters keyed by (curve, group, is_montgomery). Each entry holds the
 # curve coefficients and generator for that group/representation. Adding a new
@@ -121,6 +160,34 @@ _CURVE_PARAMS = {
         gx=_BN254_G2_GX_MONT,
         gy=_BN254_G2_GY_MONT,
         non_residue=_BN254_G2_NON_RESIDUE_MONT,
+    ),
+    ('pallas', 'g1', False): dict(
+        a=_PALLAS_A,
+        b=_PALLAS_B,
+        gx=_PALLAS_G1_GX,
+        gy=_PALLAS_G1_GY,
+        non_residue=None,
+    ),
+    ('pallas', 'g1', True): dict(
+        a=_PALLAS_A,
+        b=_PALLAS_G1_B_MONT,
+        gx=_PALLAS_G1_GX_MONT,
+        gy=_PALLAS_G1_GY_MONT,
+        non_residue=None,
+    ),
+    ('vesta', 'g1', False): dict(
+        a=_VESTA_A,
+        b=_VESTA_B,
+        gx=_VESTA_G1_GX,
+        gy=_VESTA_G1_GY,
+        non_residue=None,
+    ),
+    ('vesta', 'g1', True): dict(
+        a=_VESTA_A,
+        b=_VESTA_G1_B_MONT,
+        gx=_VESTA_G1_GX_MONT,
+        gy=_VESTA_G1_GY_MONT,
+        non_residue=None,
     ),
 }
 
@@ -174,26 +241,58 @@ def _build_meta(
 
 
 # Curve-list-driven dtype metadata. Each curve contributes one _build_meta call.
-_EC_DTYPE_META = _build_meta(
-    'bn254',
-    256,
-    _bn254_sf_dtype,
-    _bn254_sf_mont_dtype,
-    {
-        ('g1', 'affine', False): bn254_g1_affine,
-        ('g1', 'affine', True): bn254_g1_affine_mont,
-        ('g1', 'jacobian', False): bn254_g1_jacobian,
-        ('g1', 'jacobian', True): bn254_g1_jacobian_mont,
-        ('g1', 'xyzz', False): bn254_g1_xyzz,
-        ('g1', 'xyzz', True): bn254_g1_xyzz_mont,
-        ('g2', 'affine', False): bn254_g2_affine,
-        ('g2', 'affine', True): bn254_g2_affine_mont,
-        ('g2', 'jacobian', False): bn254_g2_jacobian,
-        ('g2', 'jacobian', True): bn254_g2_jacobian_mont,
-        ('g2', 'xyzz', False): bn254_g2_xyzz,
-        ('g2', 'xyzz', True): bn254_g2_xyzz_mont,
-    },
-)
+# Pasta (Pallas/Vesta) is non-pairing, so its table carries only g1 entries;
+# _build_meta skips the absent g2 layout rows.
+_EC_DTYPE_META = {
+    **_build_meta(
+        'bn254',
+        256,
+        _bn254_sf_dtype,
+        _bn254_sf_mont_dtype,
+        {
+            ('g1', 'affine', False): bn254_g1_affine,
+            ('g1', 'affine', True): bn254_g1_affine_mont,
+            ('g1', 'jacobian', False): bn254_g1_jacobian,
+            ('g1', 'jacobian', True): bn254_g1_jacobian_mont,
+            ('g1', 'xyzz', False): bn254_g1_xyzz,
+            ('g1', 'xyzz', True): bn254_g1_xyzz_mont,
+            ('g2', 'affine', False): bn254_g2_affine,
+            ('g2', 'affine', True): bn254_g2_affine_mont,
+            ('g2', 'jacobian', False): bn254_g2_jacobian,
+            ('g2', 'jacobian', True): bn254_g2_jacobian_mont,
+            ('g2', 'xyzz', False): bn254_g2_xyzz,
+            ('g2', 'xyzz', True): bn254_g2_xyzz_mont,
+        },
+    ),
+    **_build_meta(
+        'pallas',
+        256,
+        _pallas_sf_dtype,
+        _pallas_sf_mont_dtype,
+        {
+            ('g1', 'affine', False): pallas_g1_affine,
+            ('g1', 'affine', True): pallas_g1_affine_mont,
+            ('g1', 'jacobian', False): pallas_g1_jacobian,
+            ('g1', 'jacobian', True): pallas_g1_jacobian_mont,
+            ('g1', 'xyzz', False): pallas_g1_xyzz,
+            ('g1', 'xyzz', True): pallas_g1_xyzz_mont,
+        },
+    ),
+    **_build_meta(
+        'vesta',
+        256,
+        _vesta_sf_dtype,
+        _vesta_sf_mont_dtype,
+        {
+            ('g1', 'affine', False): vesta_g1_affine,
+            ('g1', 'affine', True): vesta_g1_affine_mont,
+            ('g1', 'jacobian', False): vesta_g1_jacobian,
+            ('g1', 'jacobian', True): vesta_g1_jacobian_mont,
+            ('g1', 'xyzz', False): vesta_g1_xyzz,
+            ('g1', 'xyzz', True): vesta_g1_xyzz_mont,
+        },
+    ),
+}
 
 
 class ecinfo:  # pylint: disable=invalid-name,missing-class-docstring

--- a/zk_dtypes/_pfinfo.py
+++ b/zk_dtypes/_pfinfo.py
@@ -24,6 +24,10 @@ from zk_dtypes._zk_dtypes_ext import koalabear_mont
 from zk_dtypes._zk_dtypes_ext import mersenne31
 from zk_dtypes._zk_dtypes_ext import bn254_sf
 from zk_dtypes._zk_dtypes_ext import bn254_sf_mont
+from zk_dtypes._zk_dtypes_ext import pallas_sf
+from zk_dtypes._zk_dtypes_ext import pallas_sf_mont
+from zk_dtypes._zk_dtypes_ext import vesta_sf
+from zk_dtypes._zk_dtypes_ext import vesta_sf_mont
 
 import numpy as np
 
@@ -36,9 +40,22 @@ _koalabear_mont_dtype = np.dtype(koalabear_mont)
 _mersenne31_dtype = np.dtype(mersenne31)
 _bn254_sf_dtype = np.dtype(bn254_sf)
 _bn254_sf_mont_dtype = np.dtype(bn254_sf_mont)
+_pallas_sf_dtype = np.dtype(pallas_sf)
+_pallas_sf_mont_dtype = np.dtype(pallas_sf_mont)
+_vesta_sf_dtype = np.dtype(vesta_sf)
+_vesta_sf_mont_dtype = np.dtype(vesta_sf_mont)
 
 
 _BN254_PARAM = 4965661367192848881
+
+# Pasta scalar field moduli (arkworks ark-pallas / ark-vesta). The Pallas
+# scalar field equals the Vesta base field (q) and vice versa (p).
+_PALLAS_SF_MODULUS = (
+    0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000001
+)
+_VESTA_SF_MODULUS = (
+    0x40000000000000000000000000000000224698FC094CF91B992D30ED00000001
+)
 
 
 def _get_bn_scalar_field_modulus(x):
@@ -84,6 +101,18 @@ class pfinfo:  # pylint: disable=invalid-name,missing-class-docstring
       self.modulus_bits = 254
       self.modulus = _get_bn_scalar_field_modulus(_BN254_PARAM)
       self.is_montgomery = pf_type == _bn254_sf_mont_dtype
+    elif pf_type == _pallas_sf_dtype or pf_type == _pallas_sf_mont_dtype:
+      self.dtype = pf_type
+      self.storage_bits = 256
+      self.modulus_bits = 255
+      self.modulus = _PALLAS_SF_MODULUS
+      self.is_montgomery = pf_type == _pallas_sf_mont_dtype
+    elif pf_type == _vesta_sf_dtype or pf_type == _vesta_sf_mont_dtype:
+      self.dtype = pf_type
+      self.storage_bits = 256
+      self.modulus_bits = 255
+      self.modulus = _VESTA_SF_MODULUS
+      self.is_montgomery = pf_type == _vesta_sf_mont_dtype
     else:
       raise ValueError(f"Unknown prime field type: {pf_type}")
     # Calculate the 2-adicity of `modulus - 1`, which is the number of

--- a/zk_dtypes/_src/dtypes.cc
+++ b/zk_dtypes/_src/dtypes.cc
@@ -226,6 +226,37 @@ struct TypeDescriptorBase<bn254::FrMont> : FieldTypeDescriptor<bn254::FrMont> {
   static constexpr char kNpyDescrType = 'b';
 };
 
+template <>
+struct TypeDescriptorBase<pallas::Fr> : FieldTypeDescriptor<pallas::Fr> {
+  static constexpr const char* kTpDoc =
+      "pallas scalar field values on standard domain";
+  static constexpr char kNpyDescrType = 'P';
+};
+
+template <>
+struct TypeDescriptorBase<pallas::FrMont>
+    : FieldTypeDescriptor<pallas::FrMont> {
+  static constexpr const char* kTpDoc =
+      "pallas scalar field values on montgomery domain";
+  static constexpr char kNpyDescrType = 'p';
+};
+
+template <>
+struct TypeDescriptorBase<vesta::Fr> : FieldTypeDescriptor<vesta::Fr> {
+  static constexpr const char* kTpDoc =
+      "vesta scalar field values on standard domain";
+  // 'Y'/'y' rather than 'V'/'v': 'V' is the void kind char these user dtypes
+  // register under, so reusing it as the type char is needlessly confusing.
+  static constexpr char kNpyDescrType = 'Y';
+};
+
+template <>
+struct TypeDescriptorBase<vesta::FrMont> : FieldTypeDescriptor<vesta::FrMont> {
+  static constexpr const char* kTpDoc =
+      "vesta scalar field values on montgomery domain";
+  static constexpr char kNpyDescrType = 'y';
+};
+
 //===----------------------------------------------------------------------===//
 // ExtendedField TypeDescriptorBase
 //===----------------------------------------------------------------------===//
@@ -427,6 +458,102 @@ struct TypeDescriptorBase<bn254::G2PointXyzzMont>
     : EcPointTypeDescriptor<bn254::G2PointXyzzMont> {
   static constexpr const char* kTpDoc =
       "bn254 G2 elliptic curve xyzz point on montgomery domain";
+  static constexpr char kNpyDescrType = 'x';
+};
+
+template <>
+struct TypeDescriptorBase<pallas::G1AffinePoint>
+    : EcPointTypeDescriptor<pallas::G1AffinePoint> {
+  static constexpr const char* kTpDoc =
+      "pallas G1 elliptic curve affine point on standard domain";
+  static constexpr char kNpyDescrType = 'A';
+};
+
+template <>
+struct TypeDescriptorBase<pallas::G1AffinePointMont>
+    : EcPointTypeDescriptor<pallas::G1AffinePointMont> {
+  static constexpr const char* kTpDoc =
+      "pallas G1 elliptic curve affine point on montgomery domain";
+  static constexpr char kNpyDescrType = 'a';
+};
+
+template <>
+struct TypeDescriptorBase<pallas::G1JacobianPoint>
+    : EcPointTypeDescriptor<pallas::G1JacobianPoint> {
+  static constexpr const char* kTpDoc =
+      "pallas G1 elliptic curve jacobian point on standard domain";
+  static constexpr char kNpyDescrType = 'J';
+};
+
+template <>
+struct TypeDescriptorBase<pallas::G1JacobianPointMont>
+    : EcPointTypeDescriptor<pallas::G1JacobianPointMont> {
+  static constexpr const char* kTpDoc =
+      "pallas G1 elliptic curve jacobian point on montgomery domain";
+  static constexpr char kNpyDescrType = 'j';
+};
+
+template <>
+struct TypeDescriptorBase<pallas::G1PointXyzz>
+    : EcPointTypeDescriptor<pallas::G1PointXyzz> {
+  static constexpr const char* kTpDoc =
+      "pallas G1 elliptic curve xyzz point on standard domain";
+  static constexpr char kNpyDescrType = 'X';
+};
+
+template <>
+struct TypeDescriptorBase<pallas::G1PointXyzzMont>
+    : EcPointTypeDescriptor<pallas::G1PointXyzzMont> {
+  static constexpr const char* kTpDoc =
+      "pallas G1 elliptic curve xyzz point on montgomery domain";
+  static constexpr char kNpyDescrType = 'x';
+};
+
+template <>
+struct TypeDescriptorBase<vesta::G1AffinePoint>
+    : EcPointTypeDescriptor<vesta::G1AffinePoint> {
+  static constexpr const char* kTpDoc =
+      "vesta G1 elliptic curve affine point on standard domain";
+  static constexpr char kNpyDescrType = 'A';
+};
+
+template <>
+struct TypeDescriptorBase<vesta::G1AffinePointMont>
+    : EcPointTypeDescriptor<vesta::G1AffinePointMont> {
+  static constexpr const char* kTpDoc =
+      "vesta G1 elliptic curve affine point on montgomery domain";
+  static constexpr char kNpyDescrType = 'a';
+};
+
+template <>
+struct TypeDescriptorBase<vesta::G1JacobianPoint>
+    : EcPointTypeDescriptor<vesta::G1JacobianPoint> {
+  static constexpr const char* kTpDoc =
+      "vesta G1 elliptic curve jacobian point on standard domain";
+  static constexpr char kNpyDescrType = 'J';
+};
+
+template <>
+struct TypeDescriptorBase<vesta::G1JacobianPointMont>
+    : EcPointTypeDescriptor<vesta::G1JacobianPointMont> {
+  static constexpr const char* kTpDoc =
+      "vesta G1 elliptic curve jacobian point on montgomery domain";
+  static constexpr char kNpyDescrType = 'j';
+};
+
+template <>
+struct TypeDescriptorBase<vesta::G1PointXyzz>
+    : EcPointTypeDescriptor<vesta::G1PointXyzz> {
+  static constexpr const char* kTpDoc =
+      "vesta G1 elliptic curve xyzz point on standard domain";
+  static constexpr char kNpyDescrType = 'X';
+};
+
+template <>
+struct TypeDescriptorBase<vesta::G1PointXyzzMont>
+    : EcPointTypeDescriptor<vesta::G1PointXyzzMont> {
+  static constexpr const char* kTpDoc =
+      "vesta G1 elliptic curve xyzz point on montgomery domain";
   static constexpr char kNpyDescrType = 'x';
 };
 

--- a/zk_dtypes/_src/ec_point_numpy.h
+++ b/zk_dtypes/_src/ec_point_numpy.h
@@ -31,6 +31,8 @@ limitations under the License.
 #include "zk_dtypes/_src/ufuncs.h"
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/g1.h"
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/g2.h"
+#include "zk_dtypes/include/elliptic_curve/pallas/g1.h"
+#include "zk_dtypes/include/elliptic_curve/vesta/g1.h"
 #include "zk_dtypes/include/geometry/point_declarations.h"
 
 namespace zk_dtypes {
@@ -862,6 +864,22 @@ bool RegisterEcPointMultiplyUFunc(PyObject* numpy) {
         bn254::FrMont, bn254::G1AffinePointMont, bn254::G1JacobianPointMont,
         bn254::G1PointXyzzMont, bn254::G2AffinePointMont,
         bn254::G2JacobianPointMont, bn254::G2PointXyzzMont>(numpy);
+  } else if constexpr (std::is_same_v<ScalarField, pallas::Fr>) {
+    return RegisterEcPointMul_Impl<pallas::Fr, pallas::G1AffinePoint,
+                                   pallas::G1JacobianPoint,
+                                   pallas::G1PointXyzz>(numpy);
+  } else if constexpr (std::is_same_v<ScalarField, pallas::FrMont>) {
+    return RegisterEcPointMul_Impl<pallas::FrMont, pallas::G1AffinePointMont,
+                                   pallas::G1JacobianPointMont,
+                                   pallas::G1PointXyzzMont>(numpy);
+  } else if constexpr (std::is_same_v<ScalarField, vesta::Fr>) {
+    return RegisterEcPointMul_Impl<vesta::Fr, vesta::G1AffinePoint,
+                                   vesta::G1JacobianPoint, vesta::G1PointXyzz>(
+        numpy);
+  } else if constexpr (std::is_same_v<ScalarField, vesta::FrMont>) {
+    return RegisterEcPointMul_Impl<vesta::FrMont, vesta::G1AffinePointMont,
+                                   vesta::G1JacobianPointMont,
+                                   vesta::G1PointXyzzMont>(numpy);
   } else {
     return false;
   }

--- a/zk_dtypes/_src/field_numpy.h
+++ b/zk_dtypes/_src/field_numpy.h
@@ -33,6 +33,8 @@ limitations under the License.
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/fr.h"
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/g1.h"
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/g2.h"
+#include "zk_dtypes/include/elliptic_curve/pallas/g1.h"
+#include "zk_dtypes/include/elliptic_curve/vesta/g1.h"
 #include "zk_dtypes/include/field/extension_field.h"
 #include "zk_dtypes/include/field/prime_field.h"
 
@@ -495,6 +497,22 @@ PyObject* PyField_nb_multiply(PyObject* a, PyObject* b) {
           bn254::FrMont, bn254::G1AffinePointMont, bn254::G1JacobianPointMont,
           bn254::G1PointXyzzMont, bn254::G2AffinePointMont,
           bn254::G2JacobianPointMont, bn254::G2PointXyzzMont>(x, b);
+    } else if constexpr (std::is_same_v<T, pallas::Fr>) {
+      return PyField_nb_ec_multiply<pallas::Fr, pallas::G1AffinePoint,
+                                    pallas::G1JacobianPoint,
+                                    pallas::G1PointXyzz>(x, b);
+    } else if constexpr (std::is_same_v<T, pallas::FrMont>) {
+      return PyField_nb_ec_multiply<pallas::FrMont, pallas::G1AffinePointMont,
+                                    pallas::G1JacobianPointMont,
+                                    pallas::G1PointXyzzMont>(x, b);
+    } else if constexpr (std::is_same_v<T, vesta::Fr>) {
+      return PyField_nb_ec_multiply<vesta::Fr, vesta::G1AffinePoint,
+                                    vesta::G1JacobianPoint, vesta::G1PointXyzz>(
+          x, b);
+    } else if constexpr (std::is_same_v<T, vesta::FrMont>) {
+      return PyField_nb_ec_multiply<vesta::FrMont, vesta::G1AffinePointMont,
+                                    vesta::G1JacobianPointMont,
+                                    vesta::G1PointXyzzMont>(x, b);
     }
   }
 

--- a/zk_dtypes/include/all_types.h
+++ b/zk_dtypes/include/all_types.h
@@ -22,7 +22,9 @@ limitations under the License.
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/g1.h"
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/g2.h"
 #include "zk_dtypes/include/elliptic_curve/curve25519/ed25519/g1.h"
+#include "zk_dtypes/include/elliptic_curve/pallas/g1.h"
 #include "zk_dtypes/include/elliptic_curve/secp256k1/g1.h"
+#include "zk_dtypes/include/elliptic_curve/vesta/g1.h"
 #include "zk_dtypes/include/field/babybear/babybear.h"
 #include "zk_dtypes/include/field/babybear/babybearx4.h"
 #include "zk_dtypes/include/field/binary_field.h"
@@ -73,7 +75,9 @@ WITH_MONT(V, ::zk_dtypes::Babybear, Babybear, BABYBEAR, babybear)         \
 V(::zk_dtypes::Mersenne31, Mersenne31, MERSENNE31, mersenne31)            \
 WITH_MONT(V, ::zk_dtypes::Goldilocks, Goldilocks, GOLDILOCKS, goldilocks) \
 WITH_MONT(V, ::zk_dtypes::Koalabear, Koalabear, KOALABEAR, koalabear)     \
-WITH_MONT(V, ::zk_dtypes::bn254::Fr, Bn254Sf, BN254_SF, bn254_sf)
+WITH_MONT(V, ::zk_dtypes::bn254::Fr, Bn254Sf, BN254_SF, bn254_sf)         \
+WITH_MONT(V, ::zk_dtypes::pallas::Fr, PallasSf, PALLAS_SF, pallas_sf)     \
+WITH_MONT(V, ::zk_dtypes::vesta::Fr, VestaSf, VESTA_SF, vesta_sf)
 
 #define ZK_DTYPES_ALL_PRIME_FIELD_TYPE_LIST(V)                                        \
 ZK_DTYPES_PUBLIC_PRIME_FIELD_TYPE_LIST(V)                                             \
@@ -83,7 +87,9 @@ WITH_MONT(V, ::zk_dtypes::secp256k1::Fr, Secp256k1Sf, SECP256K1_SF, secp256k1_sf
 WITH_MONT(V, ::zk_dtypes::bls12_381::Fq, Bls12381Bf, BLS12_381_BF, bls12_381_bf)      \
 WITH_MONT(V, ::zk_dtypes::bls12_381::Fr, Bls12381Sf, BLS12_381_SF, bls12_381_sf)      \
 WITH_MONT(V, ::zk_dtypes::curve25519::Fq, Curve25519Bf, CURVE25519_BF, curve25519_bf) \
-WITH_MONT(V, ::zk_dtypes::curve25519::Fr, Curve25519Sf, CURVE25519_SF, curve25519_sf)
+WITH_MONT(V, ::zk_dtypes::curve25519::Fr, Curve25519Sf, CURVE25519_SF, curve25519_sf) \
+WITH_MONT(V, ::zk_dtypes::pallas::Fq, PallasBf, PALLAS_BF, pallas_bf)                 \
+WITH_MONT(V, ::zk_dtypes::vesta::Fq, VestaBf, VESTA_BF, vesta_bf)
 
 //===----------------------------------------------------------------------===//
 // ExtendedField Types
@@ -119,15 +125,19 @@ ZK_DTYPES_ALL_BINARY_FIELD_TYPE_LIST(V)
 // ScalarField Types
 //===----------------------------------------------------------------------===//
 
-#define ZK_DTYPES_SCALAR_FIELD_TYPE_LIST(V) \
-WITH_MONT(V, ::zk_dtypes::bn254::Fr, Bn254Sf, BN254_SF, bn254_sf)
+#define ZK_DTYPES_SCALAR_FIELD_TYPE_LIST(V)                          \
+WITH_MONT(V, ::zk_dtypes::bn254::Fr, Bn254Sf, BN254_SF, bn254_sf)    \
+WITH_MONT(V, ::zk_dtypes::pallas::Fr, PallasSf, PALLAS_SF, pallas_sf) \
+WITH_MONT(V, ::zk_dtypes::vesta::Fr, VestaSf, VESTA_SF, vesta_sf)
 
 //===----------------------------------------------------------------------===//
 // AffinePoint Types
 //===----------------------------------------------------------------------===//
 
-#define ZK_DTYPES_PUBLIC_R1_AFFINE_POINT_TYPE_LIST(V) \
-WITH_MONT(V, ::zk_dtypes::bn254::G1AffinePoint, Bn254G1Affine, BN254_G1_AFFINE, bn254_g1_affine)
+#define ZK_DTYPES_PUBLIC_R1_AFFINE_POINT_TYPE_LIST(V)                                              \
+WITH_MONT(V, ::zk_dtypes::bn254::G1AffinePoint, Bn254G1Affine, BN254_G1_AFFINE, bn254_g1_affine)    \
+WITH_MONT(V, ::zk_dtypes::pallas::G1AffinePoint, PallasG1Affine, PALLAS_G1_AFFINE, pallas_g1_affine) \
+WITH_MONT(V, ::zk_dtypes::vesta::G1AffinePoint, VestaG1Affine, VESTA_G1_AFFINE, vesta_g1_affine)
 
 #define ZK_DTYPES_PUBLIC_R2_AFFINE_POINT_TYPE_LIST(V) \
 WITH_MONT(V, ::zk_dtypes::bn254::G2AffinePoint, Bn254G2Affine, BN254_G2_AFFINE, bn254_g2_affine)
@@ -153,8 +163,10 @@ ZK_DTYPES_ALL_R2_AFFINE_POINT_TYPE_LIST(V)
 // JacobianPoint Types
 //===----------------------------------------------------------------------===//
 
-#define ZK_DTYPES_PUBLIC_R1_JACOBIAN_POINT_TYPE_LIST(V) \
-WITH_MONT(V, ::zk_dtypes::bn254::G1JacobianPoint, Bn254G1Jacobian, BN254_G1_JACOBIAN, bn254_g1_jacobian)
+#define ZK_DTYPES_PUBLIC_R1_JACOBIAN_POINT_TYPE_LIST(V)                                                        \
+WITH_MONT(V, ::zk_dtypes::bn254::G1JacobianPoint, Bn254G1Jacobian, BN254_G1_JACOBIAN, bn254_g1_jacobian)        \
+WITH_MONT(V, ::zk_dtypes::pallas::G1JacobianPoint, PallasG1Jacobian, PALLAS_G1_JACOBIAN, pallas_g1_jacobian)     \
+WITH_MONT(V, ::zk_dtypes::vesta::G1JacobianPoint, VestaG1Jacobian, VESTA_G1_JACOBIAN, vesta_g1_jacobian)
 
 #define ZK_DTYPES_PUBLIC_R2_JACOBIAN_POINT_TYPE_LIST(V) \
 WITH_MONT(V, ::zk_dtypes::bn254::G2JacobianPoint, Bn254G2Jacobian, BN254_G2_JACOBIAN, bn254_g2_jacobian)
@@ -179,8 +191,10 @@ ZK_DTYPES_ALL_R2_JACOBIAN_POINT_TYPE_LIST(V)
 // PointXyzz Types
 //===----------------------------------------------------------------------===//
 
-#define ZK_DTYPES_PUBLIC_R1_XYZZ_POINT_TYPE_LIST(V) \
-WITH_MONT(V, ::zk_dtypes::bn254::G1PointXyzz, Bn254G1Xyzz, BN254_G1_XYZZ, bn254_g1_xyzz)
+#define ZK_DTYPES_PUBLIC_R1_XYZZ_POINT_TYPE_LIST(V)                                        \
+WITH_MONT(V, ::zk_dtypes::bn254::G1PointXyzz, Bn254G1Xyzz, BN254_G1_XYZZ, bn254_g1_xyzz)    \
+WITH_MONT(V, ::zk_dtypes::pallas::G1PointXyzz, PallasG1Xyzz, PALLAS_G1_XYZZ, pallas_g1_xyzz) \
+WITH_MONT(V, ::zk_dtypes::vesta::G1PointXyzz, VestaG1Xyzz, VESTA_G1_XYZZ, vesta_g1_xyzz)
 
 #define ZK_DTYPES_PUBLIC_R2_XYZZ_POINT_TYPE_LIST(V) \
 WITH_MONT(V, ::zk_dtypes::bn254::G2PointXyzz, Bn254G2Xyzz, BN254_G2_XYZZ, bn254_g2_xyzz)

--- a/zk_dtypes/include/elliptic_curve/pallas/fq.h
+++ b/zk_dtypes/include/elliptic_curve/pallas/fq.h
@@ -1,0 +1,99 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_PALLAS_FQ_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_PALLAS_FQ_H_
+
+#include "zk_dtypes/include/field/big_prime_field.h"
+
+namespace zk_dtypes::pallas {
+
+// Pallas base field (= Vesta scalar field):
+// p = 0x40000000000000000000000000000000224698fc094cf91b992d30ed00000001
+// A 255-bit prime with 2-adicity 32. Constants derived (never hand-typed) from
+// arkworks ark-pallas (multiplicative generator 5); see docs/development.md
+// for the derivation method.
+struct FqBaseConfig {
+  constexpr static size_t kStorageBits = 256;
+  constexpr static size_t kModulusBits = 255;
+  constexpr static BigInt<4> kModulus = {
+      UINT64_C(11037532056220336129),
+      UINT64_C(2469829653914515739),
+      UINT64_C(0),
+      UINT64_C(4611686018427387904),
+  };
+
+  constexpr static uint32_t kTwoAdicity = 32;
+
+  constexpr static BigInt<4> kTrace = {
+      UINT64_C(670184341500670189),
+      UINT64_C(575052028),
+      UINT64_C(0),
+      UINT64_C(1073741824),
+  };
+
+  constexpr static bool kHasTwoAdicRootOfUnity = true;
+  constexpr static bool kHasLargeSubgroupRootOfUnity = false;
+};
+
+struct FqConfig : public FqBaseConfig {
+  constexpr static bool kUseMontgomery = false;
+
+  using StdConfig = FqConfig;
+
+  constexpr static BigInt<4> kOne = 1;
+
+  constexpr static BigInt<4> kTwoAdicRootOfUnity = {
+      UINT64_C(13667703228001592111),
+      UINT64_C(16875599075175265668),
+      UINT64_C(3900434499382671386),
+      UINT64_C(3156588888553745370),
+  };
+};
+
+struct FqMontConfig : public FqBaseConfig {
+  constexpr static bool kUseMontgomery = true;
+
+  using StdConfig = FqConfig;
+
+  constexpr static BigInt<4> kRSquared = {
+      UINT64_C(10122100416058490895),
+      UINT64_C(15551789045973377255),
+      UINT64_C(8617542898466512152),
+      UINT64_C(679271340751763220),
+  };
+  constexpr static uint64_t kNPrime = UINT64_C(11037532056220336127);
+
+  constexpr static BigInt<4> kOne = {
+      UINT64_C(3780891978758094845),
+      UINT64_C(11037255111966004397),
+      UINT64_C(18446744073709551615),
+      UINT64_C(4611686018427387903),
+  };
+
+  constexpr static BigInt<4> kTwoAdicRootOfUnity = {
+      UINT64_C(11713220832667294704),
+      UINT64_C(10413392179731184095),
+      UINT64_C(18133385229535560846),
+      UINT64_C(4524191781424318170),
+  };
+};
+
+using Fq = PrimeField<FqConfig>;
+using FqMont = PrimeField<FqMontConfig>;
+
+}  // namespace zk_dtypes::pallas
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_PALLAS_FQ_H_

--- a/zk_dtypes/include/elliptic_curve/pallas/fr.h
+++ b/zk_dtypes/include/elliptic_curve/pallas/fr.h
@@ -1,0 +1,99 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_PALLAS_FR_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_PALLAS_FR_H_
+
+#include "zk_dtypes/include/field/big_prime_field.h"
+
+namespace zk_dtypes::pallas {
+
+// Pallas scalar field (= Vesta base field):
+// q = 0x40000000000000000000000000000000224698fc0994a8dd8c46eb2100000001
+// A 255-bit prime with 2-adicity 32. Constants derived (never hand-typed) from
+// arkworks ark-pallas (multiplicative generator 5); see docs/development.md
+// for the derivation method.
+struct FrBaseConfig {
+  constexpr static size_t kStorageBits = 256;
+  constexpr static size_t kModulusBits = 255;
+  constexpr static BigInt<4> kModulus = {
+      UINT64_C(10108024940646105089),
+      UINT64_C(2469829653919213789),
+      UINT64_C(0),
+      UINT64_C(4611686018427387904),
+  };
+
+  constexpr static uint32_t kTwoAdicity = 32;
+
+  constexpr static BigInt<4> kTrace = {
+      UINT64_C(690362312389225249),
+      UINT64_C(575052028),
+      UINT64_C(0),
+      UINT64_C(1073741824),
+  };
+
+  constexpr static bool kHasTwoAdicRootOfUnity = true;
+  constexpr static bool kHasLargeSubgroupRootOfUnity = false;
+};
+
+struct FrConfig : public FrBaseConfig {
+  constexpr static bool kUseMontgomery = false;
+
+  using StdConfig = FrConfig;
+
+  constexpr static BigInt<4> kOne = 1;
+
+  constexpr static BigInt<4> kTwoAdicRootOfUnity = {
+      UINT64_C(12037607305579515999),
+      UINT64_C(11221139188353527881),
+      UINT64_C(11411081306099606126),
+      UINT64_C(3307517586042601304),
+  };
+};
+
+struct FrMontConfig : public FrBaseConfig {
+  constexpr static bool kUseMontgomery = true;
+
+  using StdConfig = FrConfig;
+
+  constexpr static BigInt<4> kRSquared = {
+      UINT64_C(18200867980676431887),
+      UINT64_C(7474641938123724515),
+      UINT64_C(9200329640471491984),
+      UINT64_C(679271340771891881),
+  };
+  constexpr static uint64_t kNPrime = UINT64_C(10108024940646105087);
+
+  constexpr static BigInt<4> kOne = {
+      UINT64_C(6569413325480787965),
+      UINT64_C(11037255111951910247),
+      UINT64_C(18446744073709551615),
+      UINT64_C(4611686018427387903),
+  };
+
+  constexpr static BigInt<4> kTwoAdicRootOfUnity = {
+      UINT64_C(2414060527980987102),
+      UINT64_C(14720393103524889748),
+      UINT64_C(12406956448539459298),
+      UINT64_C(826967475050360918),
+  };
+};
+
+using Fr = PrimeField<FrConfig>;
+using FrMont = PrimeField<FrMontConfig>;
+
+}  // namespace zk_dtypes::pallas
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_PALLAS_FR_H_

--- a/zk_dtypes/include/elliptic_curve/pallas/g1.h
+++ b/zk_dtypes/include/elliptic_curve/pallas/g1.h
@@ -1,0 +1,77 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_PALLAS_G1_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_PALLAS_G1_H_
+
+#include "zk_dtypes/include/elliptic_curve/pallas/fq.h"
+#include "zk_dtypes/include/elliptic_curve/pallas/fr.h"
+#include "zk_dtypes/include/elliptic_curve/short_weierstrass/affine_point.h"
+#include "zk_dtypes/include/elliptic_curve/short_weierstrass/jacobian_point.h"
+#include "zk_dtypes/include/elliptic_curve/short_weierstrass/point_xyzz.h"
+#include "zk_dtypes/include/elliptic_curve/short_weierstrass/sw_curve.h"
+
+namespace zk_dtypes::pallas {
+
+// Pallas: y² = x³ + 5, generator (-1, 2). Constants derived from arkworks
+// ark-pallas (kX = p - 1); see docs/development.md for the derivation method.
+class G1SwCurveConfig {
+ public:
+  constexpr static bool kUseMontgomery = false;
+  using StdConfig = G1SwCurveConfig;
+  using BaseField = Fq;
+  using ScalarField = Fr;
+
+  constexpr static BaseField kA = 0;
+  constexpr static BaseField kB = 5;
+  constexpr static BaseField kX = {UINT64_C(11037532056220336128),
+                                   UINT64_C(2469829653914515739), UINT64_C(0),
+                                   UINT64_C(4611686018427387904)};
+  constexpr static BaseField kY = {UINT64_C(2), UINT64_C(0), UINT64_C(0),
+                                   UINT64_C(0)};
+};
+
+class G1SwCurveMontConfig {
+ public:
+  constexpr static bool kUseMontgomery = true;
+  using StdConfig = G1SwCurveConfig;
+  using BaseField = FqMont;
+  using ScalarField = FrMont;
+
+  constexpr static BaseField kA = BaseField::FromUnchecked(
+      {UINT64_C(0), UINT64_C(0), UINT64_C(0), UINT64_C(0)});
+  constexpr static BaseField kB = BaseField::FromUnchecked(
+      {UINT64_C(11647819816328232941), UINT64_C(8413468796752855795),
+       UINT64_C(18446744073709551613), UINT64_C(4611686018427387903)});
+  constexpr static BaseField kX = BaseField::FromUnchecked(
+      {UINT64_C(7256640077462241284), UINT64_C(9879318615658062958),
+       UINT64_C(0), UINT64_C(0)});
+  constexpr static BaseField kY = BaseField::FromUnchecked(
+      {UINT64_C(14970995975005405177), UINT64_C(1157936496307941438),
+       UINT64_C(18446744073709551615), UINT64_C(4611686018427387903)});
+};
+
+using G1Curve = SwCurve<G1SwCurveConfig>;
+using G1CurveMont = SwCurve<G1SwCurveMontConfig>;
+using G1AffinePoint = AffinePoint<G1Curve>;
+using G1AffinePointMont = AffinePoint<G1CurveMont>;
+using G1JacobianPoint = JacobianPoint<G1Curve>;
+using G1JacobianPointMont = JacobianPoint<G1CurveMont>;
+using G1PointXyzz = PointXyzz<G1Curve>;
+using G1PointXyzzMont = PointXyzz<G1CurveMont>;
+
+}  // namespace zk_dtypes::pallas
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_PALLAS_G1_H_

--- a/zk_dtypes/include/elliptic_curve/vesta/fq.h
+++ b/zk_dtypes/include/elliptic_curve/vesta/fq.h
@@ -1,0 +1,99 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_VESTA_FQ_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_VESTA_FQ_H_
+
+#include "zk_dtypes/include/field/big_prime_field.h"
+
+namespace zk_dtypes::vesta {
+
+// Vesta base field (= Pallas scalar field):
+// q = 0x40000000000000000000000000000000224698fc0994a8dd8c46eb2100000001
+// A 255-bit prime with 2-adicity 32. Constants derived (never hand-typed) from
+// arkworks ark-vesta (multiplicative generator 5); see docs/development.md
+// for the derivation method.
+struct FqBaseConfig {
+  constexpr static size_t kStorageBits = 256;
+  constexpr static size_t kModulusBits = 255;
+  constexpr static BigInt<4> kModulus = {
+      UINT64_C(10108024940646105089),
+      UINT64_C(2469829653919213789),
+      UINT64_C(0),
+      UINT64_C(4611686018427387904),
+  };
+
+  constexpr static uint32_t kTwoAdicity = 32;
+
+  constexpr static BigInt<4> kTrace = {
+      UINT64_C(690362312389225249),
+      UINT64_C(575052028),
+      UINT64_C(0),
+      UINT64_C(1073741824),
+  };
+
+  constexpr static bool kHasTwoAdicRootOfUnity = true;
+  constexpr static bool kHasLargeSubgroupRootOfUnity = false;
+};
+
+struct FqConfig : public FqBaseConfig {
+  constexpr static bool kUseMontgomery = false;
+
+  using StdConfig = FqConfig;
+
+  constexpr static BigInt<4> kOne = 1;
+
+  constexpr static BigInt<4> kTwoAdicRootOfUnity = {
+      UINT64_C(12037607305579515999),
+      UINT64_C(11221139188353527881),
+      UINT64_C(11411081306099606126),
+      UINT64_C(3307517586042601304),
+  };
+};
+
+struct FqMontConfig : public FqBaseConfig {
+  constexpr static bool kUseMontgomery = true;
+
+  using StdConfig = FqConfig;
+
+  constexpr static BigInt<4> kRSquared = {
+      UINT64_C(18200867980676431887),
+      UINT64_C(7474641938123724515),
+      UINT64_C(9200329640471491984),
+      UINT64_C(679271340771891881),
+  };
+  constexpr static uint64_t kNPrime = UINT64_C(10108024940646105087);
+
+  constexpr static BigInt<4> kOne = {
+      UINT64_C(6569413325480787965),
+      UINT64_C(11037255111951910247),
+      UINT64_C(18446744073709551615),
+      UINT64_C(4611686018427387903),
+  };
+
+  constexpr static BigInt<4> kTwoAdicRootOfUnity = {
+      UINT64_C(2414060527980987102),
+      UINT64_C(14720393103524889748),
+      UINT64_C(12406956448539459298),
+      UINT64_C(826967475050360918),
+  };
+};
+
+using Fq = PrimeField<FqConfig>;
+using FqMont = PrimeField<FqMontConfig>;
+
+}  // namespace zk_dtypes::vesta
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_VESTA_FQ_H_

--- a/zk_dtypes/include/elliptic_curve/vesta/fr.h
+++ b/zk_dtypes/include/elliptic_curve/vesta/fr.h
@@ -1,0 +1,99 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_VESTA_FR_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_VESTA_FR_H_
+
+#include "zk_dtypes/include/field/big_prime_field.h"
+
+namespace zk_dtypes::vesta {
+
+// Vesta scalar field (= Pallas base field):
+// p = 0x40000000000000000000000000000000224698fc094cf91b992d30ed00000001
+// A 255-bit prime with 2-adicity 32. Constants derived (never hand-typed) from
+// arkworks ark-vesta (multiplicative generator 5); see docs/development.md
+// for the derivation method.
+struct FrBaseConfig {
+  constexpr static size_t kStorageBits = 256;
+  constexpr static size_t kModulusBits = 255;
+  constexpr static BigInt<4> kModulus = {
+      UINT64_C(11037532056220336129),
+      UINT64_C(2469829653914515739),
+      UINT64_C(0),
+      UINT64_C(4611686018427387904),
+  };
+
+  constexpr static uint32_t kTwoAdicity = 32;
+
+  constexpr static BigInt<4> kTrace = {
+      UINT64_C(670184341500670189),
+      UINT64_C(575052028),
+      UINT64_C(0),
+      UINT64_C(1073741824),
+  };
+
+  constexpr static bool kHasTwoAdicRootOfUnity = true;
+  constexpr static bool kHasLargeSubgroupRootOfUnity = false;
+};
+
+struct FrConfig : public FrBaseConfig {
+  constexpr static bool kUseMontgomery = false;
+
+  using StdConfig = FrConfig;
+
+  constexpr static BigInt<4> kOne = 1;
+
+  constexpr static BigInt<4> kTwoAdicRootOfUnity = {
+      UINT64_C(13667703228001592111),
+      UINT64_C(16875599075175265668),
+      UINT64_C(3900434499382671386),
+      UINT64_C(3156588888553745370),
+  };
+};
+
+struct FrMontConfig : public FrBaseConfig {
+  constexpr static bool kUseMontgomery = true;
+
+  using StdConfig = FrConfig;
+
+  constexpr static BigInt<4> kRSquared = {
+      UINT64_C(10122100416058490895),
+      UINT64_C(15551789045973377255),
+      UINT64_C(8617542898466512152),
+      UINT64_C(679271340751763220),
+  };
+  constexpr static uint64_t kNPrime = UINT64_C(11037532056220336127);
+
+  constexpr static BigInt<4> kOne = {
+      UINT64_C(3780891978758094845),
+      UINT64_C(11037255111966004397),
+      UINT64_C(18446744073709551615),
+      UINT64_C(4611686018427387903),
+  };
+
+  constexpr static BigInt<4> kTwoAdicRootOfUnity = {
+      UINT64_C(11713220832667294704),
+      UINT64_C(10413392179731184095),
+      UINT64_C(18133385229535560846),
+      UINT64_C(4524191781424318170),
+  };
+};
+
+using Fr = PrimeField<FrConfig>;
+using FrMont = PrimeField<FrMontConfig>;
+
+}  // namespace zk_dtypes::vesta
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_VESTA_FR_H_

--- a/zk_dtypes/include/elliptic_curve/vesta/g1.h
+++ b/zk_dtypes/include/elliptic_curve/vesta/g1.h
@@ -1,0 +1,77 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_VESTA_G1_H_
+#define ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_VESTA_G1_H_
+
+#include "zk_dtypes/include/elliptic_curve/short_weierstrass/affine_point.h"
+#include "zk_dtypes/include/elliptic_curve/short_weierstrass/jacobian_point.h"
+#include "zk_dtypes/include/elliptic_curve/short_weierstrass/point_xyzz.h"
+#include "zk_dtypes/include/elliptic_curve/short_weierstrass/sw_curve.h"
+#include "zk_dtypes/include/elliptic_curve/vesta/fq.h"
+#include "zk_dtypes/include/elliptic_curve/vesta/fr.h"
+
+namespace zk_dtypes::vesta {
+
+// Vesta: y² = x³ + 5, generator (-1, 2). Constants derived from arkworks
+// ark-vesta (kX = q - 1); see docs/development.md for the derivation method.
+class G1SwCurveConfig {
+ public:
+  constexpr static bool kUseMontgomery = false;
+  using StdConfig = G1SwCurveConfig;
+  using BaseField = Fq;
+  using ScalarField = Fr;
+
+  constexpr static BaseField kA = 0;
+  constexpr static BaseField kB = 5;
+  constexpr static BaseField kX = {UINT64_C(10108024940646105088),
+                                   UINT64_C(2469829653919213789), UINT64_C(0),
+                                   UINT64_C(4611686018427387904)};
+  constexpr static BaseField kY = {UINT64_C(2), UINT64_C(0), UINT64_C(0),
+                                   UINT64_C(0)};
+};
+
+class G1SwCurveMontConfig {
+ public:
+  constexpr static bool kUseMontgomery = true;
+  using StdConfig = G1SwCurveConfig;
+  using BaseField = FqMont;
+  using ScalarField = FrMont;
+
+  constexpr static BaseField kA = BaseField::FromUnchecked(
+      {UINT64_C(0), UINT64_C(0), UINT64_C(0), UINT64_C(0)});
+  constexpr static BaseField kB = BaseField::FromUnchecked(
+      {UINT64_C(10861710938529071085), UINT64_C(8413468796663592846),
+       UINT64_C(18446744073709551613), UINT64_C(4611686018427387903)});
+  constexpr static BaseField kX = BaseField::FromUnchecked(
+      {UINT64_C(3538611615165317124), UINT64_C(9879318615676855158),
+       UINT64_C(0), UINT64_C(0)});
+  constexpr static BaseField kY = BaseField::FromUnchecked(
+      {UINT64_C(3030801710315470841), UINT64_C(1157936496275055089),
+       UINT64_C(18446744073709551615), UINT64_C(4611686018427387903)});
+};
+
+using G1Curve = SwCurve<G1SwCurveConfig>;
+using G1CurveMont = SwCurve<G1SwCurveMontConfig>;
+using G1AffinePoint = AffinePoint<G1Curve>;
+using G1AffinePointMont = AffinePoint<G1CurveMont>;
+using G1JacobianPoint = JacobianPoint<G1Curve>;
+using G1JacobianPointMont = JacobianPoint<G1CurveMont>;
+using G1PointXyzz = PointXyzz<G1Curve>;
+using G1PointXyzzMont = PointXyzz<G1CurveMont>;
+
+}  // namespace zk_dtypes::vesta
+
+#endif  // ZK_DTYPES_INCLUDE_ELLIPTIC_CURVE_VESTA_G1_H_

--- a/zk_dtypes/tests/ec_point_test.py
+++ b/zk_dtypes/tests/ec_point_test.py
@@ -28,7 +28,7 @@ import numpy as np
 
 # Curve-list-driven fixtures. Adding a curve here (and to _GROUPS, if a curve
 # lacks g2) regenerates every per-type fixture below.
-_CURVES = ["bn254"]
+_CURVES = ["bn254", "pallas", "vesta"]
 _GROUPS = ["g1", "g2"]
 
 EC_STD_POINT_TYPES = []

--- a/zk_dtypes/tests/elliptic_curve/constexpr_curve_config_unittest.cc
+++ b/zk_dtypes/tests/elliptic_curve/constexpr_curve_config_unittest.cc
@@ -26,9 +26,11 @@ limitations under the License.
 #include "zk_dtypes/include/elliptic_curve/bls12_381/g1.h"
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/g1.h"
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/g2.h"
+#include "zk_dtypes/include/elliptic_curve/pallas/g1.h"
 #include "zk_dtypes/include/elliptic_curve/secp256k1/g1.h"
 #include "zk_dtypes/include/elliptic_curve/secp256r1/fq.h"
 #include "zk_dtypes/include/elliptic_curve/secp256r1/g1.h"
+#include "zk_dtypes/include/elliptic_curve/vesta/g1.h"
 
 namespace zk_dtypes {
 namespace {
@@ -52,6 +54,8 @@ static_assert(VerifyConstexpr<bn254::G2SwCurveMontConfig>());
 static_assert(VerifyConstexpr<secp256k1::G1SwCurveMontConfig>());
 static_assert(VerifyConstexpr<secp256r1::G1SwCurveMontConfig>());
 static_assert(VerifyConstexpr<bls12_381::G1SwCurveMontConfig>());
+static_assert(VerifyConstexpr<pallas::G1SwCurveMontConfig>());
+static_assert(VerifyConstexpr<vesta::G1SwCurveMontConfig>());
 
 // =========================================================================
 // Runtime correctness via TYPED_TEST on MontConfig.
@@ -61,7 +65,8 @@ using MontConfigs =
     ::testing::Types<bn254::G1SwCurveMontConfig, bn254::G2SwCurveMontConfig,
                      secp256k1::G1SwCurveMontConfig,
                      secp256r1::G1SwCurveMontConfig,
-                     bls12_381::G1SwCurveMontConfig>;
+                     bls12_381::G1SwCurveMontConfig,
+                     pallas::G1SwCurveMontConfig, vesta::G1SwCurveMontConfig>;
 
 template <typename T>
 class CurveConfigTest : public ::testing::Test {};


### PR DESCRIPTION
Adds Pallas and Vesta as first-class non-pairing, prime-order curves
(y² = x³ + 5), each exposing scalar field `Fr` and G1 points
(affine/jacobian/xyzz, std + Montgomery) with full numpy surface. This is
M0 (the CPU dtype foundation) of the GPU-accelerated Pasta recursive IVC PoC.

## What's added
- **Field + curve configs** (`elliptic_curve/{pallas,vesta}/{fq,fr,g1}.h`):
  cloned from the `secp256k1` 3-file shape (non-pairing, no G2/tower). The two
  curves form a 2-cycle — `Pallas.base = Vesta.scalar` (p) and
  `Vesta.base = Pallas.scalar` (q). Unlike secp256k1, the Pasta fields are
  2-adicity 32 (they are proving scalar fields), so `kTwoAdicity` / `kTrace` /
  `kTwoAdicRootOfUnity` are the real derived constants.
- **numpy surface**: scalar field `Fr` (std+Mont) + G1 affine/jacobian/xyzz
  (std+Mont) registered the same way as bn254 (minus G2). Both hidden
  `is_same_v<ScalarField, bn254::Fr>` dispatches (`_src/ec_point_numpy.h` —
  PyInit-critical — and `_src/field_numpy.h`) gained Pasta branches.
- **`scripts/derive_field_constants.py`**: derives every Montgomery / 2-adic
  constant from the arkworks `ark-pallas`/`ark-vesta` moduli + generator 5
  (never hand-typed) and self-validates against secp256k1's committed constants
  before trusting it for a new curve.
- `_ecinfo.py` G1 parameter selection refactored from bn254-hardcoded to a
  per-`(curve, is_montgomery)` table.

## Header shape vs registration scope
Header shape follows **secp256k1** (non-pairing). numpy registration follows
**bn254** (PUBLIC scalar field + PUBLIC G1 points), because secp256k1 is
C++-only with no python dtypes, whereas the acceptance test needs numpy
scalar-mul / MSM exposed.

## Testing
- `bazel test //zk_dtypes:elliptic_curve_unittests` — both G1 std+Mont configs
  added to the `MontConfigs` typelist; `GeneratorOnCurve` validates R²/N′ and
  the curve constants under Montgomery arithmetic, `MontReduceMatchesStandard`
  validates the std limbs.
- `bazel test //zk_dtypes:pasta_curve_test` — scalar-mul and a small MSM for
  both curves (std + Montgomery) match an independent pure-Python implementation
  of the group law over the arkworks-defined curve.
- `import zk_dtypes` succeeds with all 16 new Pasta dtypes registered.

## Downstream impact
Purely additive — no existing type changes, so no ABI/layout/value-rep impact
on prime-ir or riscv-witness.

Closes #140