### PR TITLE
feat(field): add flat GHASH GF(2^128) binary field (binary_field_ghash)

### DIFF
--- a/zk_dtypes/__init__.py
+++ b/zk_dtypes/__init__.py
@@ -61,6 +61,7 @@ __all__ = [
     "binary_field_t5",
     "binary_field_t6",
     "binary_field_t7",
+    "binary_field_ghash",
     # Elliptic curve types
     "bn254_g1_affine",
     "bn254_g1_affine_mont",
@@ -130,6 +131,7 @@ from zk_dtypes._zk_dtypes_ext import binary_field_t4
 from zk_dtypes._zk_dtypes_ext import binary_field_t5
 from zk_dtypes._zk_dtypes_ext import binary_field_t6
 from zk_dtypes._zk_dtypes_ext import binary_field_t7
+from zk_dtypes._zk_dtypes_ext import binary_field_ghash
 from zk_dtypes._zk_dtypes_ext import bn254_g1_affine
 from zk_dtypes._zk_dtypes_ext import bn254_g1_affine_mont
 from zk_dtypes._zk_dtypes_ext import bn254_g1_jacobian
@@ -193,6 +195,7 @@ binary_field_t4: Type[np.generic]
 binary_field_t5: Type[np.generic]
 binary_field_t6: Type[np.generic]
 binary_field_t7: Type[np.generic]
+binary_field_ghash: Type[np.generic]
 bn254_g1_affine: Type[np.generic]
 bn254_g1_affine_mont: Type[np.generic]
 bn254_g1_jacobian: Type[np.generic]

--- a/zk_dtypes/_src/dtypes.cc
+++ b/zk_dtypes/_src/dtypes.cc
@@ -361,6 +361,15 @@ struct TypeDescriptorBase<BinaryFieldT7> : FieldTypeDescriptor<BinaryFieldT7> {
   static constexpr char kNpyDescrType = 'w';
 };
 
+template <>
+struct TypeDescriptorBase<BinaryFieldGhash>
+    : FieldTypeDescriptor<BinaryFieldGhash> {
+  static constexpr const char* kTpDoc =
+      "GF(2¹²⁸) binary field values in the GHASH/POLYVAL basis "
+      "(p(x) = x¹²⁸ + x⁷ + x² + x + 1)";
+  static constexpr char kNpyDescrType = 'h';
+};
+
 //===----------------------------------------------------------------------===//
 // EcPoint TypeDescriptorBase
 //===----------------------------------------------------------------------===//

--- a/zk_dtypes/include/all_types.h
+++ b/zk_dtypes/include/all_types.h
@@ -61,7 +61,8 @@ V(::zk_dtypes::BinaryFieldT3, BinaryFieldT3, BINARY_FIELD_T3, binary_field_t3) \
 V(::zk_dtypes::BinaryFieldT4, BinaryFieldT4, BINARY_FIELD_T4, binary_field_t4) \
 V(::zk_dtypes::BinaryFieldT5, BinaryFieldT5, BINARY_FIELD_T5, binary_field_t5) \
 V(::zk_dtypes::BinaryFieldT6, BinaryFieldT6, BINARY_FIELD_T6, binary_field_t6) \
-V(::zk_dtypes::BinaryFieldT7, BinaryFieldT7, BINARY_FIELD_T7, binary_field_t7)
+V(::zk_dtypes::BinaryFieldT7, BinaryFieldT7, BINARY_FIELD_T7, binary_field_t7) \
+V(::zk_dtypes::BinaryFieldGhash, BinaryFieldGhash, BINARY_FIELD_GHASH, binary_field_ghash)
 
 #define ZK_DTYPES_ALL_BINARY_FIELD_TYPE_LIST(V) \
 ZK_DTYPES_PUBLIC_BINARY_FIELD_TYPE_LIST(V)      \

--- a/zk_dtypes/include/field/big_binary_field.h
+++ b/zk_dtypes/include/field/big_binary_field.h
@@ -42,6 +42,7 @@ class BinaryField<_Config, std::enable_if_t<(_Config::kStorageBits > 64)>>
     : public FiniteField<BinaryField<_Config>> {
  public:
   constexpr static bool kUseMontgomery = false;
+  constexpr static bool kIsTower = _Config::kIsTower;
   constexpr static size_t kTowerLevel = _Config::kTowerLevel;
   constexpr static size_t kStorageBits = _Config::kStorageBits;
   constexpr static size_t kLimbNums = (kStorageBits + 63) / 64;
@@ -129,10 +130,15 @@ class BinaryField<_Config, std::enable_if_t<(_Config::kStorageBits > 64)>>
   // Negation: Identity
   constexpr BinaryField operator-() const { return *this; }
 
-  // Multiplication: Tower field multiplication
-  // GF(2¹²⁸) = GF(2⁶⁴)[x] / (x² + x + α) where α = TowerAlpha<7>::value
+  // Multiplication: tower field multiply
+  // (GF(2¹²⁸) = GF(2⁶⁴)[x] / (x² + x + α), α = TowerAlpha<7>::value), or the
+  // flat GHASH multiply when the config is not a tower.
   constexpr BinaryField operator*(BinaryField other) const {
-    return FromUnchecked(BinaryMul<7>(value_, other.value_));
+    if constexpr (kIsTower) {
+      return FromUnchecked(BinaryMul<7>(value_, other.value_));
+    } else {
+      return FromUnchecked(GhashMul(value_, other.value_));
+    }
   }
 
   constexpr BinaryField& operator*=(BinaryField other) {
@@ -140,19 +146,31 @@ class BinaryField<_Config, std::enable_if_t<(_Config::kStorageBits > 64)>>
   }
 
   constexpr BinaryField Square() const {
-    return FromUnchecked(BinarySquare<7>(value_));
+    if constexpr (kIsTower) {
+      return FromUnchecked(BinarySquare<7>(value_));
+    } else {
+      return FromUnchecked(GhashSquare(value_));
+    }
   }
 
   // Multiply by X (extension generator)
   // X² = X + α where α = TowerAlpha<7>::value
   constexpr BinaryField MulX() const {
-    return FromUnchecked(BinaryMulX<7>(value_));
+    if constexpr (kIsTower) {
+      return FromUnchecked(BinaryMulX<7>(value_));
+    } else {
+      return FromUnchecked(GhashMulX(value_));
+    }
   }
 
   // Inverse using Fermat's Little Theorem: a⁻¹ = a^(2¹²⁸ - 2)
   // a^(2¹²⁸ - 2) = a² · a⁴ · a⁸ · ... · a^(2¹²⁷)
   constexpr BinaryField Inverse() const {
-    return FromUnchecked(BinaryInverse<7>(value_));
+    if constexpr (kIsTower) {
+      return FromUnchecked(BinaryInverse<7>(value_));
+    } else {
+      return FromUnchecked(GhashInverse(value_));
+    }
   }
 
   constexpr BinaryField operator/(BinaryField other) const {

--- a/zk_dtypes/include/field/binary_field.h
+++ b/zk_dtypes/include/field/binary_field.h
@@ -54,7 +54,9 @@ using BinaryFieldT3 = BinaryField<BinaryFieldConfig<3>>;  // GF(2⁸)
 using BinaryFieldT4 = BinaryField<BinaryFieldConfig<4>>;  // GF(2¹⁶)
 using BinaryFieldT5 = BinaryField<BinaryFieldConfig<5>>;  // GF(2³²)
 using BinaryFieldT6 = BinaryField<BinaryFieldConfig<6>>;  // GF(2⁶⁴)
-using BinaryFieldT7 = BinaryField<BinaryFieldConfig<7>>;  // GF(2¹²⁸)
+using BinaryFieldT7 = BinaryField<BinaryFieldConfig<7>>;  // GF(2¹²⁸) tower
+// GF(2¹²⁸) in the GHASH/POLYVAL basis (p(x) = x¹²⁸ + x⁷ + x² + x + 1).
+using BinaryFieldGhash = BinaryField<GhashFieldConfig>;
 
 }  // namespace zk_dtypes
 

--- a/zk_dtypes/include/field/binary_field_config.h
+++ b/zk_dtypes/include/field/binary_field_config.h
@@ -35,6 +35,8 @@ struct BinaryFieldConfig;
 template <size_t TowerLevel>
 struct BaseBinaryFieldConfig {
   constexpr static bool kUseMontgomery = false;
+  // Tower construction by default; a flat (e.g. GHASH) config overrides this.
+  constexpr static bool kIsTower = true;
   constexpr static size_t kTowerLevel = TowerLevel;
   constexpr static size_t kStorageBits = 1 << kTowerLevel;
   constexpr static size_t kModulusBits = kStorageBits + 1;
@@ -87,6 +89,17 @@ struct BinaryFieldConfig<6> : public BaseBinaryFieldConfig<6> {
 // GF(2¹²⁸) - Tower Level 7
 template <>
 struct BinaryFieldConfig<7> : public BaseBinaryFieldConfig<7> {};
+
+// GF(2¹²⁸) in the GHASH/POLYVAL basis — a FLAT (non-tower) construction with
+// irreducible p(x) = x¹²⁸ + x⁷ + x² + x + 1 (reduction constant 0x87), natural
+// (non-bit-reflected) bit order. Reuses the tower-level-7 sizing (128-bit
+// storage, BigInt<2>) but flips kIsTower so BinaryField dispatches to the GHASH
+// multiply instead of the tower multiply. Isomorphic to BinaryFieldConfig<7>
+// but NOT bit-compatible: this basis matches GHASH/POLYVAL byte-for-byte, which
+// consumers that hash raw field bytes depend on.
+struct GhashFieldConfig : public BaseBinaryFieldConfig<7> {
+  constexpr static bool kIsTower = false;
+};
 
 }  // namespace zk_dtypes
 

--- a/zk_dtypes/include/field/binary_field_multiplication.h
+++ b/zk_dtypes/include/field/binary_field_multiplication.h
@@ -367,6 +367,89 @@ constexpr T BinaryInverse(T a) {
   return BinaryOps<TowerLevel>::Inverse(a);
 }
 
+// =============================================================================
+// GHASH / POLYVAL flat GF(2¹²⁸) multiplication (non-tower)
+// =============================================================================
+// GF(2¹²⁸) in the GHASH/POLYVAL basis: p(x) = x¹²⁸ + x⁷ + x² + x + 1 (reduction
+// constant 0x87), natural (non-bit-reflected) bit order. An element is a
+// BigInt<2> whose limb 0 holds x⁰..x⁶³ and limb 1 holds x⁶⁴..x¹²⁷. This is
+// isomorphic to the tower GF(2¹²⁸) but a DIFFERENT, bit-incompatible basis: it
+// matches the GHASH/POLYVAL representation byte-for-byte. These are the
+// reference (portable, constexpr) semantics; a hardware carryless-multiply
+// lowering (PCLMULQDQ) lives downstream in the compiler.
+
+// Carryless (GF(2)[x]) 64×64 → 128 product, portable bit-serial. Writes the low
+// and high 64 bits of the product to `lo`/`hi`.
+constexpr void GhashClmul64(uint64_t a, uint64_t b, uint64_t& lo,
+                            uint64_t& hi) {
+  lo = 0;
+  hi = 0;
+  for (size_t i = 0; i < 64; ++i) {
+    if ((a >> i) & uint64_t{1}) {
+      lo ^= b << i;
+      if (i != 0) hi ^= b >> (64 - i);  // i == 0 would be a shift-by-64 (UB)
+    }
+  }
+}
+
+// GF(2¹²⁸) multiply in the GHASH basis: schoolbook carryless 128×128 → 256
+// product, then reduction mod x¹²⁸ + x⁷ + x² + x + 1.
+constexpr BigInt<2> GhashMul(const BigInt<2>& a, const BigInt<2>& b) {
+  uint64_t a_lo = a[0], a_hi = a[1], b_lo = b[0], b_hi = b[1];
+
+  // Schoolbook 128×128 → 256 (unreduced): four 64×64 carryless products.
+  uint64_t ll_lo = 0, ll_hi = 0, lh_lo = 0, lh_hi = 0;
+  uint64_t hl_lo = 0, hl_hi = 0, hh_lo = 0, hh_hi = 0;
+  GhashClmul64(a_lo, b_lo, ll_lo, ll_hi);
+  GhashClmul64(a_lo, b_hi, lh_lo, lh_hi);
+  GhashClmul64(a_hi, b_lo, hl_lo, hl_hi);
+  GhashClmul64(a_hi, b_hi, hh_lo, hh_hi);
+  uint64_t cr_lo = lh_lo ^ hl_lo;
+  uint64_t cr_hi = lh_hi ^ hl_hi;
+  uint64_t r0 = ll_lo;
+  uint64_t r1 = ll_hi ^ cr_lo;
+  uint64_t r2 = hh_lo ^ cr_hi;
+  uint64_t r3 = hh_hi;
+
+  // Fold the high half (r2:r3) down via x¹²⁸ ≡ x⁷ + x² + x + 1, with a 7-bit
+  // overflow correction for coefficients pushed past x¹²⁷.
+  uint64_t s1_lo = r2 << 1;
+  uint64_t s1_hi = (r3 << 1) | (r2 >> 63);
+  uint64_t s2_lo = r2 << 2;
+  uint64_t s2_hi = (r3 << 2) | (r2 >> 62);
+  uint64_t s7_lo = r2 << 7;
+  uint64_t s7_hi = (r3 << 7) | (r2 >> 57);
+  uint64_t t_lo = r2 ^ s1_lo ^ s2_lo ^ s7_lo;
+  uint64_t t_hi = r3 ^ s1_hi ^ s2_hi ^ s7_hi;
+  uint64_t ov = (r3 >> 63) ^ (r3 >> 62) ^ (r3 >> 57);
+  uint64_t corr = ov ^ (ov << 1) ^ (ov << 2) ^ (ov << 7);
+  return BigInt<2>({r0 ^ t_lo ^ corr, r1 ^ t_hi});
+}
+
+constexpr BigInt<2> GhashSquare(const BigInt<2>& a) { return GhashMul(a, a); }
+
+// Multiply by the generator x: shift coefficients up by one and reduce the
+// x¹²⁸ overflow via x¹²⁸ ≡ x⁷ + x² + x + 1 (= 0x87).
+constexpr BigInt<2> GhashMulX(const BigInt<2>& a) {
+  uint64_t lo = a[0], hi = a[1];
+  uint64_t overflow = hi >> 63;
+  uint64_t new_hi = (hi << 1) | (lo >> 63);
+  uint64_t new_lo = (lo << 1) ^ (overflow ? uint64_t{0x87} : uint64_t{0});
+  return BigInt<2>({new_lo, new_hi});
+}
+
+// Inverse via Fermat: a⁻¹ = a^(2¹²⁸ − 2) = a² · a⁴ · a⁸ · … · a^(2¹²⁷).
+constexpr BigInt<2> GhashInverse(const BigInt<2>& a) {
+  if (a.IsZero()) return BigInt<2>(0);
+  BigInt<2> result = GhashSquare(a);
+  BigInt<2> power = result;
+  for (size_t i = 2; i < 128; ++i) {
+    power = GhashSquare(power);
+    result = GhashMul(result, power);
+  }
+  return result;
+}
+
 }  // namespace zk_dtypes
 
 #endif  // ZK_DTYPES_INCLUDE_FIELD_BINARY_FIELD_MULTIPLICATION_H_

--- a/zk_dtypes/tests/binary_field_test.py
+++ b/zk_dtypes/tests/binary_field_test.py
@@ -36,6 +36,7 @@ binary_field_t4 = zk_dtypes.binary_field_t4
 binary_field_t5 = zk_dtypes.binary_field_t5
 binary_field_t6 = zk_dtypes.binary_field_t6
 binary_field_t7 = zk_dtypes.binary_field_t7
+binary_field_ghash = zk_dtypes.binary_field_ghash
 
 BINARY_FIELD_TYPES = [
     binary_field_t0,
@@ -46,6 +47,7 @@ BINARY_FIELD_TYPES = [
     binary_field_t5,
     binary_field_t6,
     binary_field_t7,
+    binary_field_ghash,
 ]
 
 # Small binary fields (fit in 64 bits) for tests that need int conversion
@@ -69,6 +71,7 @@ VALUE_MASKS = {
     binary_field_t5: (1 << 32) - 1,
     binary_field_t6: (1 << 64) - 1,
     binary_field_t7: (1 << 128) - 1,
+    binary_field_ghash: (1 << 128) - 1,
 }
 
 # Test values for each binary field type (within valid range)
@@ -81,7 +84,28 @@ VALUES = {
     binary_field_t5: random.sample(range(0, 2**16), 4),
     binary_field_t6: random.sample(range(0, 2**16), 4),
     binary_field_t7: random.sample(range(0, 2**16), 4),
+    binary_field_ghash: random.sample(range(0, 2**16), 4),
 }
+
+
+# Reference GF(2^128) multiply in the flat GHASH/POLYVAL basis
+# (p(x) = x^128 + x^7 + x^2 + x + 1), independent of the C++ implementation:
+# a schoolbook carryless product then bit-by-bit reduction. Bit i of each 128-bit
+# int is the coefficient of x^i. Pins binary_field_ghash to the exact basis that
+# GHASH/POLYVAL consumers hash raw field bytes in.
+_GHASH_MASK = (1 << 128) - 1
+_GHASH_REDUCE = (1 << 7) | (1 << 2) | (1 << 1) | 1  # x^7 + x^2 + x + 1 = 0x87
+
+
+def _ghash_ref_mul(a: int, b: int) -> int:
+  prod = 0
+  for i in range(128):
+    if (a >> i) & 1:
+      prod ^= b << i
+  for i in range(255, 127, -1):
+    if (prod >> i) & 1:
+      prod ^= (1 << i) | (_GHASH_REDUCE << (i - 128))
+  return prod & _GHASH_MASK
 
 
 @contextlib.contextmanager
@@ -434,6 +458,64 @@ class ArrayTest(parameterized.TestCase):
     y = x.astype(scalar_type)
     for i, v in enumerate(values):
       self.assertEqual(int(y[i]), v)
+
+
+@multi_threaded(num_workers=3)
+class GhashBasisTest(parameterized.TestCase):
+  """binary_field_ghash must realize the flat GHASH/POLYVAL basis exactly."""
+
+  GF = binary_field_ghash
+  EDGE = [
+      0,
+      1,
+      2,  # x
+      1 << 63,
+      1 << 64,  # x^64
+      1 << 127,  # x^127
+      (1 << 128) - 1,
+      0x0123456789ABCDEFFEDCBA9876543210,
+  ]
+
+  def _samples(self, n=400):
+    rng = random.Random(20260702)
+    return self.EDGE + [rng.getrandbits(128) for _ in range(n)]
+
+  def testFullWidthRoundTrip(self):
+    for a in self._samples(50):
+      self.assertEqual(int(self.GF(a)), a, msg=hex(a))
+
+  def testMultiplyMatchesReference(self):
+    rng = random.Random(7)
+    for a in self._samples():
+      b = rng.getrandbits(128)
+      self.assertEqual(
+          int(self.GF(a) * self.GF(b)),
+          _ghash_ref_mul(a, b),
+          msg=(hex(a), hex(b)),
+      )
+
+  def testSquareMatchesReference(self):
+    for a in self._samples():
+      self.assertEqual(
+          int(self.GF(a) * self.GF(a)), _ghash_ref_mul(a, a), msg=hex(a)
+      )
+
+  def testInverseIsMultiplicative(self):
+    for a in self._samples(100):
+      if a == 0:
+        continue
+      self.assertEqual(int(self.GF(a) * (self.GF(a) ** -1)), 1, msg=hex(a))
+
+  def testByteLayoutIsLittleEndianLoHi(self):
+    for a in self.EDGE:
+      arr = np.array([a], dtype=self.GF)
+      lo = a & ((1 << 64) - 1)
+      hi = (a >> 64) & ((1 << 64) - 1)
+      self.assertEqual(
+          arr.tobytes(),
+          lo.to_bytes(8, "little") + hi.to_bytes(8, "little"),
+          msg=hex(a),
+      )
 
 
 if __name__ == "__main__":

--- a/zk_dtypes/tests/field/binary_field_unittest.cc
+++ b/zk_dtypes/tests/field/binary_field_unittest.cc
@@ -51,7 +51,8 @@ class BinaryFieldTypedTest : public testing::Test {};
 
 using BinaryFieldTypes =
     testing::Types<BinaryFieldT0, BinaryFieldT1, BinaryFieldT2, BinaryFieldT3,
-                   BinaryFieldT4, BinaryFieldT5, BinaryFieldT6, BinaryFieldT7>;
+                   BinaryFieldT4, BinaryFieldT5, BinaryFieldT6, BinaryFieldT7,
+                   BinaryFieldGhash>;
 
 TYPED_TEST_SUITE(BinaryFieldTypedTest, BinaryFieldTypes);
 
@@ -182,6 +183,20 @@ TYPED_TEST(BinaryFieldTypedTest, SubfieldDecomposition) {
     F reconstructed = F::FromSubfields(a0, a1);
     EXPECT_EQ(a, reconstructed);
   }
+}
+
+// GHASH/POLYVAL basis known-answer vectors. Self-consistency tests (Square ==
+// a*a, inverse round-trip) hold for any irreducible polynomial; these pin the
+// basis to p(x) = x¹²⁸ + x⁷ + x² + x + 1, i.e. x¹²⁸ ≡ x⁷ + x² + x + 1 = 0x87.
+TEST(BinaryFieldGhashTest, KnownAnswerReduction) {
+  using F = BinaryFieldGhash;
+  auto E = [](uint64_t lo, uint64_t hi) {
+    return F::FromUnchecked(BigInt<2>({lo, hi}));
+  };
+  EXPECT_EQ(E(2, 0) * E(2, 0), E(4, 0));     // x·x = x² (no reduction)
+  EXPECT_EQ(E(0, 1) * E(0, 1), E(0x87, 0));  // x⁶⁴·x⁶⁴ = x¹²⁸ ≡ 0x87
+  EXPECT_EQ(E(0, uint64_t{1} << 63) * E(2, 0), E(0x87, 0));  // x¹²⁷·x = x¹²⁸
+  EXPECT_EQ(E(0, uint64_t{1} << 63).MulX(), E(0x87, 0));     // MulX at top bit
 }
 
 }  // namespace


### PR DESCRIPTION
Adds GF(2^128) in the flat **GHASH/POLYVAL** basis (`p(x) = x^128 + x^7 + x^2 + x + 1`,
reduction constant `0x87`, `{lo,hi}` uint64 lanes) as a first-class binary dtype
`binary_field_ghash` — a non-tower sibling of `binary_field_t7`.

## Why
`binary_field_t7` is GF(2^128) in the recursive **tower** basis, isomorphic to GHASH but
bit-incompatible (`2·2 = 3` tower vs `4` GHASH). Consumers that hash raw field bytes
(GHASH/POLYVAL provers, flock) need arithmetic in the exact GHASH basis for byte-identity.
This adds that field alongside the tower one.

## How
`BinaryField<Config>` is basis-agnostic except for multiply, so this is a **config-flag
add**, not a parallel class hierarchy:
- `GhashFieldConfig` (`kIsTower = false`) reuses the level-7 sizing (128-bit, `BigInt<2>`);
- `GhashMul/GhashSquare/GhashMulX/GhashInverse` in `binary_field_multiplication.h`
  (schoolbook carryless 128×128 → 256, then fold mod `0x87`);
- the four multiplicative methods in `big_binary_field.h` branch on `if constexpr (kIsTower)`.

It stays a `BinaryField<Config>`, so `IsBinaryField` and the whole numpy surface are
unchanged; `BigInt<2>` storage serializes little-endian `lo‖hi` with no custom code.
Registered end-to-end via the `all_types.h` X-macro. Diff-template: the tower binary-field
add in 6898949 (#78).

## Tests
- C++ `field_unittests`: the new type runs the full typed suite, plus a known-answer test
  pinning the reduction (`x^64 · x^64 = x^128 = 0x87`) — self-consistency alone can't fix
  the basis.
- Python `binary_field_test`: `binary_field_ghash` runs the array/ufunc suites, plus a new
  `GhashBasisTest` cross-checking multiply/square/inverse against an independent GHASH
  reference over random 128-bit inputs, and the LE `lo‖hi` byte layout.

For fractalyze/flock-zorch#27 (first-class GHASH field; prerequisite for the additive-NTT
`FoldableCode` in flock-zorch#11).
