### PR TITLE
feat(field)!: adopt Fan-Paar/Binius canonical binary tower

### DIFF
--- a/examples/zk_dtypes_examples.ipynb
+++ b/examples/zk_dtypes_examples.ipynb
@@ -847,15 +847,15 @@
       "y = 11\n",
       "\n",
       "Multiplication (tower field):\n",
-      "x * y = 1\n",
+      "x * y = 4\n",
       "(x * y) / y = 7\n",
       "\n",
       "Inverse:\n",
-      "x⁻¹ = 11\n",
+      "x⁻¹ = 15\n",
       "x * x⁻¹ = 1\n",
       "\n",
       "Power:\n",
-      "x³ = 10\n"
+      "x³ = 4\n"
      ]
     }
    ],

--- a/zk_dtypes/include/field/big_binary_field.h
+++ b/zk_dtypes/include/field/big_binary_field.h
@@ -131,7 +131,7 @@ class BinaryField<_Config, std::enable_if_t<(_Config::kStorageBits > 64)>>
   constexpr BinaryField operator-() const { return *this; }
 
   // Multiplication: tower field multiply
-  // (GF(2¹²⁸) = GF(2⁶⁴)[x] / (x² + x + α), α = TowerAlpha<7>::value), or the
+  // (GF(2¹²⁸) = GF(2⁶⁴)[x] / (x² + β₆·x + 1), Fan-Paar/Binius tower), or the
   // flat GHASH multiply when the config is not a tower.
   constexpr BinaryField operator*(BinaryField other) const {
     if constexpr (kIsTower) {
@@ -154,7 +154,7 @@ class BinaryField<_Config, std::enable_if_t<(_Config::kStorageBits > 64)>>
   }
 
   // Multiply by X (extension generator)
-  // X² = X + α where α = TowerAlpha<7>::value
+  // X² = β₆·X + 1, β₆ = generator of GF(2⁶⁴) (Fan-Paar/Binius tower)
   constexpr BinaryField MulX() const {
     if constexpr (kIsTower) {
       return FromUnchecked(BinaryMulX<7>(value_));

--- a/zk_dtypes/include/field/binary_field_config.h
+++ b/zk_dtypes/include/field/binary_field_config.h
@@ -25,9 +25,10 @@ namespace zk_dtypes {
 // BinaryField Configs (Tower Field Structure)
 // =============================================================================
 // Binary tower fields: GF(2) -> GF(2²) -> GF(2⁴) -> ... -> GF(2¹²⁸)
-// Each level is a degree-2 extension of the previous level.
-// The extension is defined by the irreducible polynomial x^2 + x + alpha,
-// where alpha is the multiplicative generator of the subfield.
+// Each level is a degree-2 extension of the previous level, defined by the
+// irreducible polynomial x² + βₖ₋₁·x + 1 where βₖ₋₁ is the generator of the
+// subfield (the Fan-Paar/Binius tower — byte-compatible with Binius'
+// BinaryField*b). See binary_field_multiplication.h for the arithmetic.
 
 template <size_t TowerLevel>
 struct BinaryFieldConfig;

--- a/zk_dtypes/include/field/binary_field_multiplication.h
+++ b/zk_dtypes/include/field/binary_field_multiplication.h
@@ -27,18 +27,24 @@ namespace zk_dtypes {
 // =============================================================================
 // Tower Field Multiplication
 // =============================================================================
-// Binary tower fields use degree-2 extensions at each level.
-// GF(2²ⁿ) is constructed as GF(2ⁿ)[X] / (X² + X + α)
-// where α is the primitive element (multiplicative generator) of GF(2ⁿ).
+// Binary tower fields use degree-2 extensions at each level, following the
+// Fan-Paar / Wiedemann tower (Diamond–Posen 2023 §2.3) that Binius' canonical
+// BinaryField*b types use. Choosing this tower makes stored bit patterns
+// byte-compatible with Binius: the same u8/u16/u32/… value denotes the same
+// field element, and products agree (e.g. GF(2⁸): 0x12·0x34 = 0x9B).
 //
-// For (a₀ + a₁·X) * (b₀ + b₁·X) in GF(2²ⁿ):
-//   = a₀·b₀ + (a₀·b₁ + a₁·b₀)·X + a₁·b₁·X²
-// Using X² = X + α:
-//   = a₀·b₀ + a₁·b₁·α + (a₀·b₁ + a₁·b₀ + a₁·b₁)·X
+// Level k (k ≥ 2) is GF(2^{2^{k-1}})[X] / (X² + βₖ₋₁·X + 1), where βₖ₋₁ is the
+// generator of the subfield (bit pattern 2^{2^{k-2}}, i.e. the subfield element
+// (0,1)). This is NOT a constant-α tower: the linear coefficient is the
+// subfield GENERATOR, not a fixed subfield constant. Multiplying a subfield
+// element by βₖ₋₁ is exactly the recursive "multiply by generator" — BinaryMulX
+// one level down. (At k = 1, β₀ = 1, so X² + X + 1 — the base GF(4) case.)
 //
-// With Karatsuba optimization:
-//   c₀ = a₀·b₀ + a₁·b₁·α
-//   c₁ = (a₀+a₁)·(b₀+b₁) + a₀·b₀  (characteristic 2: subtraction = addition)
+// For (a₀ + a₁·X) * (b₀ + b₁·X), using X² = βₖ₋₁·X + 1:
+//   = a₀·b₀ + a₁·b₁ + [(a₀·b₁ + a₁·b₀) + βₖ₋₁·a₁·b₁]·X
+// With Karatsuba (characteristic 2, subtraction = addition):
+//   c₀ = a₀·b₀ + a₁·b₁
+//   c₁ = (a₀+a₁)·(b₀+b₁) + a₀·b₀ + a₁·b₁ + βₖ₋₁·(a₁·b₁)
 
 // =============================================================================
 // Tower Traits - Defines type mappings for each tower level
@@ -108,58 +114,9 @@ struct TowerTraits<7> : public BaseTowerTraits<7, BigInt<2>> {
   static constexpr ValueType kMask = BigInt<2>::Max();
 };
 
-// =============================================================================
-// Tower Polynomial Constants (α for each level)
-// =============================================================================
-// At each tower level n, we extend GF(2^(2ⁿ⁻¹)) to GF(2^(2ⁿ)) using
-// the irreducible polynomial X² + X + αₙ = 0.
-// The αₙ value must be chosen such that X² + X + αₙ is irreducible.
-// This means αₙ must NOT be in the image of the map a → a² + a.
-
-template <size_t TowerLevel>
-struct TowerAlpha;
-
-template <>
-struct TowerAlpha<1> {
-  // GF(2²): X² + X + 1
-  static constexpr uint8_t value = 1;
-};
-
-template <>
-struct TowerAlpha<2> {
-  // GF(2⁴): X² + X + 2
-  static constexpr uint8_t value = 2;
-};
-
-template <>
-struct TowerAlpha<3> {
-  // GF(2⁸): X² + X + 8
-  static constexpr uint8_t value = 8;
-};
-
-template <>
-struct TowerAlpha<4> {
-  // GF(2¹⁶): X² + X + 128
-  static constexpr uint8_t value = 128;
-};
-
-template <>
-struct TowerAlpha<5> {
-  // GF(2³²): X² + X + 0x8000
-  static constexpr uint16_t value = 32768;
-};
-
-template <>
-struct TowerAlpha<6> {
-  // GF(2⁶⁴): X² + X + 0x80000000
-  static constexpr uint32_t value = 2147483648u;
-};
-
-template <>
-struct TowerAlpha<7> {
-  // GF(2¹²⁸)
-  static constexpr uint64_t value = 0x8000000000000000ull;
-};
+// The tower's per-level linear coefficient βₖ₋₁ is the subfield generator, not
+// a stored constant: "multiply by βₖ₋₁" is the recursive BinaryMulX below, so
+// no TowerAlpha table is needed.
 
 // =============================================================================
 // Forward declarations
@@ -298,15 +255,15 @@ struct BinaryOps<TowerLevel,
     auto a0b0 = BinaryMul<TowerLevel - 1>(a0, b0);
     auto a1b1 = BinaryMul<TowerLevel - 1>(a1, b1);
 
-    // c₀ = a₀·b₀ + α·a₁·b₁
-    auto alpha_a1b1 =
-        BinaryMul<TowerLevel - 1>(a1b1, TowerAlpha<TowerLevel>::value);
-    auto c0 = SubXor<TowerLevel>(a0b0, alpha_a1b1);
-    // c1 = (a₀ + a₁)(b₀ + b₁) + a₀·b₀
+    // X² = βₖ₋₁·X + 1  ⇒  c₀ = a₀·b₀ + a₁·b₁
+    auto c0 = SubXor<TowerLevel>(a0b0, a1b1);
+    // c₁ = (a₀ + a₁)(b₀ + b₁) + a₀·b₀ + a₁·b₁ + βₖ₋₁·(a₁·b₁), where βₖ₋₁·(·) is
+    // multiply-by-generator one level down (BinaryMulX).
+    auto cross = BinaryMul<TowerLevel - 1>(SubXor<TowerLevel>(a0, a1),
+                                           SubXor<TowerLevel>(b0, b1));
     auto c1 = SubXor<TowerLevel>(
-        BinaryMul<TowerLevel - 1>(SubXor<TowerLevel>(a0, a1),
-                                  SubXor<TowerLevel>(b0, b1)),
-        a0b0);
+        SubXor<TowerLevel>(SubXor<TowerLevel>(cross, a0b0), a1b1),
+        BinaryMulX<TowerLevel - 1>(a1b1));
 
     return Combine<TowerLevel>(c0, c1);
   }
@@ -315,19 +272,17 @@ struct BinaryOps<TowerLevel,
     auto a0 = ExtractLo<TowerLevel>(a), a1 = ExtractHi<TowerLevel>(a);
     auto a0_sq = BinarySquare<TowerLevel - 1>(a0);
     auto a1_sq = BinarySquare<TowerLevel - 1>(a1);
-    // c₀ = a₀² + α·a1²
-    auto alpha_a1_sq =
-        BinaryMul<TowerLevel - 1>(a1_sq, TowerAlpha<TowerLevel>::value);
-    return Combine<TowerLevel>(SubXor<TowerLevel>(a0_sq, alpha_a1_sq), a1_sq);
+    // c₀ = a₀² + a₁²,  c₁ = βₖ₋₁·a₁²
+    return Combine<TowerLevel>(SubXor<TowerLevel>(a0_sq, a1_sq),
+                               BinaryMulX<TowerLevel - 1>(a1_sq));
   }
 
   static constexpr T MulX(T a) {
-    // a·X = (a₀ + a₁·X)·X = a₀·X + a₁·X² = a₀·X + a₁·(X + α)
-    //     = α·a₁ + (a₀ + a₁)·X
+    // a·X = (a₀ + a₁·X)·X = a₀·X + a₁·X² = a₀·X + a₁·(βₖ₋₁·X + 1)
+    //     = a₁ + (a₀ + βₖ₋₁·a₁)·X
     auto a0 = ExtractLo<TowerLevel>(a), a1 = ExtractHi<TowerLevel>(a);
-    auto alpha_a1 =
-        BinaryMul<TowerLevel - 1>(a1, TowerAlpha<TowerLevel>::value);
-    return Combine<TowerLevel>(alpha_a1, SubXor<TowerLevel>(a0, a1));
+    return Combine<TowerLevel>(
+        a1, SubXor<TowerLevel>(a0, BinaryMulX<TowerLevel - 1>(a1)));
   }
 
   static constexpr T Inverse(T a) {

--- a/zk_dtypes/tests/binary_field_test.py
+++ b/zk_dtypes/tests/binary_field_test.py
@@ -108,6 +108,61 @@ def _ghash_ref_mul(a: int, b: int) -> int:
   return prod & _GHASH_MASK
 
 
+# Reference multiply for the Fan-Paar / Binius tower, independent of the C++
+# implementation. Level k (k >= 1) is GF(2^{2^{k-1}})[X] / (X^2 + beta_{k-1}*X
+# + 1), where beta_{k-1} is the subfield generator; multiplying by it is the
+# recursive "multiply by generator" _tower_mulgen. Pins BinaryFieldT* to the
+# same tower Binius' BinaryField*b types use (byte-compatible).
+def _tower_mulgen(x: int, level: int) -> int:
+  if level == 0:
+    return x & 1  # generator of GF(2) is 1
+  h = 1 << (level - 1)
+  mask = (1 << h) - 1
+  a0, a1 = x & mask, (x >> h) & mask
+  return a1 | ((a0 ^ _tower_mulgen(a1, level - 1)) << h)
+
+
+def _tower_ref_mul(a: int, b: int, level: int) -> int:
+  if level == 0:
+    return a & b & 1
+  h = 1 << (level - 1)
+  mask = (1 << h) - 1
+  a0, a1 = a & mask, (a >> h) & mask
+  b0, b1 = b & mask, (b >> h) & mask
+  a0b0 = _tower_ref_mul(a0, b0, level - 1)
+  a1b1 = _tower_ref_mul(a1, b1, level - 1)
+  c0 = a0b0 ^ a1b1
+  cross = _tower_ref_mul(a0 ^ a1, b0 ^ b1, level - 1)
+  c1 = cross ^ a0b0 ^ a1b1 ^ _tower_mulgen(a1b1, level - 1)
+  return c0 | (c1 << h)
+
+
+# Tower level per type; the flat GHASH field is not a tower and is excluded.
+TOWER_LEVELS = {
+    binary_field_t0: 0,
+    binary_field_t1: 1,
+    binary_field_t2: 2,
+    binary_field_t3: 3,
+    binary_field_t4: 4,
+    binary_field_t5: 5,
+    binary_field_t6: 6,
+    binary_field_t7: 7,
+}
+
+# Known-answer products from Binius' canonical BinaryField{8,16,32}b (real
+# reference outputs, per issue #147). Pin byte-compatibility with Binius, which
+# the self-consistent oracle above cannot establish on its own.
+BINIUS_CANONICAL_KAT = {
+    binary_field_t3: [
+        (0x12, 0x34, 0x9B),
+        (0x2D, 0x2D, 0xCC),
+        (0x80, 0x80, 0x57),
+    ],
+    binary_field_t4: [(0x1234, 0x5678, 0x54FE), (0x8000, 0x8000, 0xA557)],
+    binary_field_t5: [(0x12345678, 0x9ABCDEF0, 0x9F77A270)],
+}
+
+
 @contextlib.contextmanager
 def ignore_warning(**kw):
   with warnings.catch_warnings():
@@ -458,6 +513,36 @@ class ArrayTest(parameterized.TestCase):
     y = x.astype(scalar_type)
     for i, v in enumerate(values):
       self.assertEqual(int(y[i]), v)
+
+
+@multi_threaded(num_workers=3)
+class TowerBasisTest(parameterized.TestCase):
+  """BinaryFieldT* must realize the Fan-Paar / Binius tower exactly."""
+
+  @parameterized.product(scalar_type=list(TOWER_LEVELS))
+  def testMultiplyMatchesTowerOracle(self, scalar_type):
+    level = TOWER_LEVELS[scalar_type]
+    bits = 1 << level
+    rng = random.Random(0xB1)
+    samples = [0, 1, VALUE_MASKS[scalar_type]] + [
+        rng.getrandbits(bits) for _ in range(64)
+    ]
+    for a in samples:
+      for b in samples:
+        self.assertEqual(
+            int(scalar_type(a) * scalar_type(b)),
+            _tower_ref_mul(a, b, level),
+            msg=(scalar_type.__name__, hex(a), hex(b)),
+        )
+
+  @parameterized.product(scalar_type=list(BINIUS_CANONICAL_KAT))
+  def testMatchesBiniusCanonicalVectors(self, scalar_type):
+    for a, b, want in BINIUS_CANONICAL_KAT[scalar_type]:
+      self.assertEqual(
+          int(scalar_type(a) * scalar_type(b)),
+          want,
+          msg=(scalar_type.__name__, hex(a), hex(b)),
+      )
 
 
 @multi_threaded(num_workers=3)

--- a/zk_dtypes/tests/field/binary_field_unittest.cc
+++ b/zk_dtypes/tests/field/binary_field_unittest.cc
@@ -185,6 +185,33 @@ TYPED_TEST(BinaryFieldTypedTest, SubfieldDecomposition) {
   }
 }
 
+// Fan-Paar / Binius tower known-answer vectors. Self-consistency (Square==a*a,
+// inverse round-trip) holds for any tower; these pin BinaryFieldT* to the SAME
+// tower Binius' canonical BinaryField*b types use, so stored bytes are
+// Binius-compatible. Values are real Binius reference outputs (issue #147).
+TEST(BinaryFieldTest, MatchesBiniusCanonicalTower) {
+  EXPECT_EQ(
+      (BinaryFieldT3::FromUnchecked(0x12) * BinaryFieldT3::FromUnchecked(0x34))
+          .value(),
+      0x9B);
+  EXPECT_EQ(
+      (BinaryFieldT3::FromUnchecked(0x80) * BinaryFieldT3::FromUnchecked(0x80))
+          .value(),
+      0x57);
+  EXPECT_EQ((BinaryFieldT4::FromUnchecked(0x1234) *
+             BinaryFieldT4::FromUnchecked(0x5678))
+                .value(),
+            0x54FE);
+  EXPECT_EQ((BinaryFieldT4::FromUnchecked(0x8000) *
+             BinaryFieldT4::FromUnchecked(0x8000))
+                .value(),
+            0xA557);
+  EXPECT_EQ((BinaryFieldT5::FromUnchecked(0x12345678) *
+             BinaryFieldT5::FromUnchecked(0x9ABCDEF0))
+                .value(),
+            0x9F77A270u);
+}
+
 // GHASH/POLYVAL basis known-answer vectors. Self-consistency tests (Square ==
 // a*a, inverse round-trip) hold for any irreducible polynomial; these pin the
 // basis to p(x) = x¹²⁸ + x⁷ + x² + x + 1, i.e. x¹²⁸ ≡ x⁷ + x² + x + 1 = 0x87.


### PR DESCRIPTION
## What

Switch `BinaryFieldT*` from the constant-α tower `GF(2ⁿ)[X]/(X²+X+α)` to the
Fan-Paar / Wiedemann tower **`X² + βₖ₋₁·X + 1`** — the canonical tower Binius'
`BinaryField*b` types use. `βₖ₋₁` is the generator of the subfield, so
"multiply by βₖ₋₁" is exactly the recursive `BinaryMulX` one level down; the
`TowerAlpha` constant table is removed.

Resolves the decision in #147 in favor of **option 2** (adopt Binius' polynomial):
stored bit patterns are now byte-compatible with Binius, so the same u8/u16/u32/…
value denotes the same field element and products agree. This unblocks
fractalyze/xla#171's additive-NTT byte-match against the Binius `crates/ntt`
reference.

## Breaking change

Alters the byte semantics of every `BinaryFieldT{2..7}` value. Example:
`GF(2⁸): 0x12·0x34` is now `0x9B` (was `0x6C`). `T0`/`T1` are unchanged
(`β₀ = 1`, so those levels are already `X²+X+1`). The flat `BinaryFieldGhash`
(POLYVAL basis) is a separate, non-tower encoding and is untouched.

## Verification

- **C++** `MatchesBiniusCanonicalTower`: pins `t3`/`t4`/`t5` products to real
  Binius `binary_field` reference outputs.
- **Python** `TowerBasisTest`: an independent reference oracle (`_tower_ref_mul`)
  cross-checks the C++ implementation at every level `t0`–`t7`, plus the real
  Binius known-answer vectors at `t3`/`t4`/`t5`.
- Existing self-consistency tests (`Square == a*a`, inverse round-trip,
  division, power) pass unchanged.

Derivation cross-checked against Binius' `hybrid_recursive_arithmetics.rs`
(`mul` / `mul_alpha`): its `α` is the subfield generator, and the multiply
matches `X² = βₖ₋₁·X + 1`.

Closes #147

https://claude.ai/code/session_013JpjzZZUDqSrzeWWrfrKNH