### PR TITLE
ci: build manylinux_2_28 wheels so the test env installs numpy as a wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,14 @@ test-command = "pytest {project}/zk_dtypes/tests"
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]
+# numpy >= 2.3.5 (our runtime floor) ships manylinux_2_28 wheels only, so in
+# the default manylinux2014 container the test phase falls back to building
+# numpy from its sdist — which numpy 2.5 broke by raising its compiler floor
+# to GCC >= 10.3 (the 2014 image carries 10.2). Building in the 2_28 image
+# lets the test env install the numpy wheel directly and tags our wheels
+# manylinux_2_28, matching numpy's own platform baseline.
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
 environment = { LDFLAGS = "-Wl,-s" }
 before-all = """
     ARCH="$(uname -m)"


### PR DESCRIPTION
Unblocks the 0.0.8 publish (run 28733842208 failed in `Build / Linux x86_64`).

## Root cause

`numpy >= 2.3.5` (our runtime floor) publishes **manylinux_2_28 wheels only**. In cibuildwheel's default manylinux2014 container, the test phase (`pip install <repaired wheel>`) can't use those wheels, so pip falls back to **building numpy from its sdist** — the 2026-06-18 0.0.7 publish already did this (a ~6-minute numpy source build per python version, visible in that run's logs). numpy 2.5 (2.5.1 released 2026-07-04) raised its build floor to **GCC >= 10.3**; the manylinux2014 image carries GCC 10.2.1, so the sdist build now fails:

```
../meson.build:25:4: ERROR: Problem encountered: NumPy requires GCC >= 10.3
error: metadata-generation-failed
```

## Fix

Pin `manylinux-x86_64-image` / `manylinux-aarch64-image` to `manylinux_2_28`. The test env then installs numpy's own wheel directly (no source build at all — also removes ~6 min/python-version from publish), and our wheels are tagged `manylinux_2_28`, matching numpy's platform baseline. Consumers (jax fork wheels, flock/zorch envs) are already on ≥ glibc 2.28 systems.

After merge: re-dispatch `publish.yml` with `target=pypi` to ship 0.0.8 (tag `v0.0.8` already points at the version-bump commit `f250a96`; the wheel version comes from `__version__` on main).