### PR TITLE
ci: run notebook-check on setup-python 3.11 instead of the runner's system python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,15 @@ jobs:
       - name: Checkout zk_dtypes
         uses: actions/checkout@v4
 
+      # Use the same hosted-toolcache Python as pre-commit-style (it matches
+      # bazel's hermetic 3.11) instead of the runner's system Python: system
+      # Pythons on updated runner boxes carry the PEP 668 EXTERNALLY-MANAGED
+      # marker, which makes every bare `pip install` below fail.
+      - name: Setup Python
+        uses: actions/setup-python@v4.7.0
+        with:
+          python-version: "3.11"
+
       - name: Build zk_dtypes
         run: |
           bazel build //zk_dtypes:_zk_dtypes_ext.so


### PR DESCRIPTION
Fixes the runner-dependent `notebook-check` failures (e.g. [run 28734288299](https://github.com/fractalyze/zk_dtypes/actions/runs/28734288299): fails on `build-server-3-cpu-2`, passes on `gpu1-cpu-*`).

## Root cause

`notebook-check` pip-installs into the **runner's system Python**. Boxes whose OS Python carries the PEP 668 `EXTERNALLY-MANAGED` marker (build-server-3 after its recent update) reject every bare `pip install`:

```
error: externally-managed-environment
```

`gpu1-*` boxes don't have the marker yet, so the job outcome is a runner lottery.

## Fix

Add the same `actions/setup-python@v4.7.0` (3.11) step `pre-commit-style` already uses. The hosted-toolcache interpreter has no PEP 668 marker, and 3.11 matches the bazel hermetic Python `_zk_dtypes_ext.so` is built against.

Note: the `build-and-test` GoldilocksX3 flake on the same box is a **separate** build-server-3 issue (bazel uses the box's local C++ toolchain) — being diagnosed separately; this PR only fixes the pip path.