### PR TITLE
[DO NOT MERGE] ci: diagnose build-server-3 (GoldilocksX3 Pil2 flake + toolchain fingerprint)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # TEMPORARY (draft-PR only, do not merge): fan 6 copies across the runner
+  # pool so at least one lands on each build-server-3 slot. Fingerprints the
+  # box toolchain and reruns the GoldilocksX3 Pil2 goldens 20x — the tests
+  # that fail deterministically on build-server-3-cpu-* and pass on gpu1-*.
+  diagnose-runner:
+    strategy:
+      fail-fast: false
+      matrix:
+        idx: [1, 2, 3, 4, 5, 6]
+    runs-on: [self-hosted, cpu]
+    continue-on-error: true
+    steps:
+      - name: Checkout zk_dtypes
+        uses: actions/checkout@v4
+
+      - name: Toolchain fingerprint
+        run: |
+          echo "runner: ${{ runner.name }}"
+          uname -a
+          head -3 /etc/os-release
+          gcc --version | head -1
+          g++ --version | head -1
+          ld --version | head -1
+          python3 --version
+          ls /usr/lib/python3.*/EXTERNALLY-MANAGED 2>/dev/null || echo "(no PEP 668 marker)"
+          nproc
+          free -h | head -2
+
+      - name: Repro GoldilocksX3 Pil2 goldens 20x
+        run: |
+          bazel --bazelrc=.bazelrc.ci test \
+            --config=ci \
+            --test_filter='GoldilocksX3Test.*' \
+            --runs_per_test=20 \
+            --cache_test_results=no \
+            --test_output=errors \
+            //zk_dtypes:field_unittests
+
   build-and-test:
     runs-on: [self-hosted, cpu]
     steps:


### PR DESCRIPTION
**Draft diagnostic — will be closed after reading results, never merged.**

build-server-3 breaks CI two independent ways while gpu1 passes everything (100% runner correlation across the last 6 CI runs):

1. `build-and-test`: `GoldilocksX3Test.{Square,Inverse}MatchesPil2` fail **with gtest printing identical values on both sides** — 3/3 occurrences on `build-server-3-cpu-1` (main runs for 760107d and 2a13226, plus #149's first attempt), 0 occurrences on `gpu1-*` and on local machines at the same commits.
2. `notebook-check`: `error: externally-managed-environment` (PEP 668 marker on the box's system python) — fix in #151.

SSH to the box is tailnet-restricted and runner names aren't schedulable labels, so this PR fans **6 matrix copies** of a diagnostic job across the pool to saturate all slots: each prints `runner.name` + toolchain fingerprint (os-release, gcc/g++/ld, python3, PEP 668 marker, nproc/mem) and reruns the GoldilocksX3 goldens 20x with `--cache_test_results=no`.

Read the `build-server-3-cpu-*` legs vs a `gpu1-*` leg and diff the fingerprints. Expected outcome: a gcc/binutils version delta explaining a miscompile of the Pil2 golden path (bazel uses the box's local C++ toolchain — no hermetic toolchain pinned), which then motivates either aligning the box toolchain or pinning a hermetic C++ toolchain / containerized CI.