### PR TITLE
fix(field): move goldilocksx3 off numpy-reserved descr char 'T'

### DIFF
--- a/zk_dtypes/_src/dtypes.cc
+++ b/zk_dtypes/_src/dtypes.cc
@@ -295,7 +295,7 @@ template <>
 struct TypeDescriptorBase<GoldilocksX3> : FieldTypeDescriptor<GoldilocksX3> {
   static constexpr const char* kTpDoc =
       "goldilocks cubic extension field values on standard domain";
-  static constexpr char kNpyDescrType = 'T';
+  static constexpr char kNpyDescrType = 'W';
 };
 
 template <>

--- a/zk_dtypes/tests/extension_field_test.py
+++ b/zk_dtypes/tests/extension_field_test.py
@@ -230,6 +230,22 @@ class ExtensionFieldArrayTest(parameterized.TestCase):
     self.assertEqual(scalar_type, np.dtype(scalar_type))
 
   @parameterized.product(scalar_type=EXT_FIELD_TYPES)
+  def testDescrCharIsNotAReferenceType(self, scalar_type):
+    # A descr char colliding with a numpy reference/flexible dtype (e.g.
+    # 'T' -> StringDType) segfaults on char-based dtype resolution.
+    char = np.dtype(scalar_type).char
+    try:
+      resolved = np.dtype(char)
+    except TypeError:
+      return  # unclaimed by numpy -> safe
+    self.assertNotIn(
+        resolved.kind,
+        "TOUSV",
+        msg=f"{scalar_type.__name__} descr char {char!r} collides with the "
+        f"numpy reference/flexible dtype {resolved!r}",
+    )
+
+  @parameterized.product(scalar_type=EXT_FIELD_TYPES)
   def testHash(self, scalar_type):
     h = hash(np.dtype(scalar_type))
     self.assertEqual(h, hash(np.dtype(scalar_type.dtype)))


### PR DESCRIPTION
## Problem

Plain `goldilocksx3` (standard domain) registers its numpy descriptor char as `'T'`:

```cpp
// zk_dtypes/_src/dtypes.cc
struct TypeDescriptorBase<GoldilocksX3> : FieldTypeDescriptor<GoldilocksX3> {
  static constexpr char kNpyDescrType = 'T';   // <-- collides
};
```

**numpy >= 2.0 reserved `'T'` for `StringDType`** — a 16-byte *reference* dtype
whose buffer holds pointers. A cubic Goldilocks element is a fixed **24-byte**
POD buffer. So any char-based dtype resolution reinterprets the 24-byte field
element as a 16-byte string-reference struct and dereferences garbage →
**segfault**.

This surfaced under **jax 0.10**: `jnp.array(base.view(goldilocksx3))` crashes on
the host→device transfer (`pxla._shard_np_array` → `PJRT_Client_BufferFromHostBuffer`),
segfaulting ~10 downstream tests. The Montgomery variant `goldilocksx3_mont`
(char `'t'`, numpy-unclaimed) is unaffected, which is why the crash is
plain-`goldilocksx3`-only.

### Empirical confirmation

```
# numpy 2.5.1
>>> np.dtype('T')            # goldilocksx3's old char
StringDType()   itemsize=16  kind='T'  hasobject=True
>>> np.dtype('t')            # goldilocksx3_mont's char
TypeError: data type 't' not understood   # unclaimed -> safe
```

`goldilocksx3` is the **only** field dtype in `dtypes.cc` whose descr char maps
to a numpy reference/flexible dtype. All other collisions (`d`=float64,
`e`=float16, `q`=int64, `D`=complex128, `m`=timedelta64) are POD — a wrong-size
reinterpret at worst, never a pointer deref — so they are left unchanged.

## Fix

Move the standard-domain `goldilocksx3` char `'T'` → `'W'`, chosen from the set
of chars that are both numpy-unclaimed and unused by any other zk_dtype
(`o r u v R W 0 3 5 6 7 9`; avoided `'R'` to sidestep Montgomery-radix
confusion). One character.

The descr char is an internal descriptor field; dtype identity/pickle/hash key
off the type name (`__name__` / `.dtype`), not the char, so this is not a
breaking change to serialization.

## Test

Adds `ExtensionFieldArrayTest.testDescrCharIsNotAReferenceType` (parametrized
over all extension field types): asserts each field's descr char does not
resolve to a numpy reference/flexible dtype (`kind in "TOUSV"`). Fails on the
old `'T'`, passes on `'W'`.

## Follow-up (not in this PR)

- Cut a zk_dtypes release (version bump handled separately, as with #142/#149).
- Downstream: bump the `zisk-zorch` zk_dtypes pin to the released wheel; this
  unblocks the plain-Goldilocks migration (zisk-zorch #56) and the plugin
  device-put segfault tracked in zkx #803.
