### PR TITLE
feat(field): add flat AES-basis GF(2⁸) binary field (binary_field_gf8_aes)

### DIFF
--- a/zk_dtypes/BUILD.bazel
+++ b/zk_dtypes/BUILD.bazel
@@ -1245,6 +1245,17 @@ py_test(
 )
 
 py_test(
+    name = "descr_char_test",
+    srcs = ["tests/descr_char_test.py"],
+    main = "tests/descr_char_test.py",
+    deps = [
+        ":zk_dtypes_py",
+        "@pypi//absl_py",
+        "@pypi//numpy",
+    ],
+)
+
+py_test(
     name = "ec_point_test",
     srcs = ["tests/ec_point_test.py"],
     main = "tests/ec_point_test.py",

--- a/zk_dtypes/__init__.py
+++ b/zk_dtypes/__init__.py
@@ -62,6 +62,7 @@ __all__ = [
     "binary_field_t6",
     "binary_field_t7",
     "binary_field_ghash",
+    "binary_field_gf8_aes",
     # Elliptic curve types
     "bn254_g1_affine",
     "bn254_g1_affine_mont",
@@ -132,6 +133,7 @@ from zk_dtypes._zk_dtypes_ext import binary_field_t5
 from zk_dtypes._zk_dtypes_ext import binary_field_t6
 from zk_dtypes._zk_dtypes_ext import binary_field_t7
 from zk_dtypes._zk_dtypes_ext import binary_field_ghash
+from zk_dtypes._zk_dtypes_ext import binary_field_gf8_aes
 from zk_dtypes._zk_dtypes_ext import bn254_g1_affine
 from zk_dtypes._zk_dtypes_ext import bn254_g1_affine_mont
 from zk_dtypes._zk_dtypes_ext import bn254_g1_jacobian
@@ -196,6 +198,7 @@ binary_field_t5: Type[np.generic]
 binary_field_t6: Type[np.generic]
 binary_field_t7: Type[np.generic]
 binary_field_ghash: Type[np.generic]
+binary_field_gf8_aes: Type[np.generic]
 bn254_g1_affine: Type[np.generic]
 bn254_g1_affine_mont: Type[np.generic]
 bn254_g1_jacobian: Type[np.generic]

--- a/zk_dtypes/_src/dtypes.cc
+++ b/zk_dtypes/_src/dtypes.cc
@@ -376,7 +376,9 @@ struct TypeDescriptorBase<BinaryFieldGf8Aes>
   static constexpr const char* kTpDoc =
       "GF(2⁸) binary field values in the AES/Rijndael basis "
       "(p(x) = x⁸ + x⁴ + x³ + x + 1)";
-  static constexpr char kNpyDescrType = 'f';
+  // Reuses t3's descr char (both GF(2⁸)); 'f' would collide with numpy's
+  // builtin float32 typecode.
+  static constexpr char kNpyDescrType = '8';
 };
 
 //===----------------------------------------------------------------------===//

--- a/zk_dtypes/_src/dtypes.cc
+++ b/zk_dtypes/_src/dtypes.cc
@@ -370,6 +370,15 @@ struct TypeDescriptorBase<BinaryFieldGhash>
   static constexpr char kNpyDescrType = 'h';
 };
 
+template <>
+struct TypeDescriptorBase<BinaryFieldGf8Aes>
+    : FieldTypeDescriptor<BinaryFieldGf8Aes> {
+  static constexpr const char* kTpDoc =
+      "GF(2⁸) binary field values in the AES/Rijndael basis "
+      "(p(x) = x⁸ + x⁴ + x³ + x + 1)";
+  static constexpr char kNpyDescrType = 'f';
+};
+
 //===----------------------------------------------------------------------===//
 // EcPoint TypeDescriptorBase
 //===----------------------------------------------------------------------===//

--- a/zk_dtypes/include/all_types.h
+++ b/zk_dtypes/include/all_types.h
@@ -62,7 +62,8 @@ V(::zk_dtypes::BinaryFieldT4, BinaryFieldT4, BINARY_FIELD_T4, binary_field_t4) \
 V(::zk_dtypes::BinaryFieldT5, BinaryFieldT5, BINARY_FIELD_T5, binary_field_t5) \
 V(::zk_dtypes::BinaryFieldT6, BinaryFieldT6, BINARY_FIELD_T6, binary_field_t6) \
 V(::zk_dtypes::BinaryFieldT7, BinaryFieldT7, BINARY_FIELD_T7, binary_field_t7) \
-V(::zk_dtypes::BinaryFieldGhash, BinaryFieldGhash, BINARY_FIELD_GHASH, binary_field_ghash)
+V(::zk_dtypes::BinaryFieldGhash, BinaryFieldGhash, BINARY_FIELD_GHASH, binary_field_ghash) \
+V(::zk_dtypes::BinaryFieldGf8Aes, BinaryFieldGf8Aes, BINARY_FIELD_GF8_AES, binary_field_gf8_aes)
 
 #define ZK_DTYPES_ALL_BINARY_FIELD_TYPE_LIST(V) \
 ZK_DTYPES_PUBLIC_BINARY_FIELD_TYPE_LIST(V)      \

--- a/zk_dtypes/include/field/binary_field.h
+++ b/zk_dtypes/include/field/binary_field.h
@@ -57,6 +57,8 @@ using BinaryFieldT6 = BinaryField<BinaryFieldConfig<6>>;  // GF(2⁶⁴)
 using BinaryFieldT7 = BinaryField<BinaryFieldConfig<7>>;  // GF(2¹²⁸) tower
 // GF(2¹²⁸) in the GHASH/POLYVAL basis (p(x) = x¹²⁸ + x⁷ + x² + x + 1).
 using BinaryFieldGhash = BinaryField<GhashFieldConfig>;
+// GF(2⁸) in the AES/Rijndael basis (p(x) = x⁸ + x⁴ + x³ + x + 1).
+using BinaryFieldGf8Aes = BinaryField<Gf8AesFieldConfig>;
 
 }  // namespace zk_dtypes
 

--- a/zk_dtypes/include/field/binary_field_config.h
+++ b/zk_dtypes/include/field/binary_field_config.h
@@ -102,6 +102,17 @@ struct GhashFieldConfig : public BaseBinaryFieldConfig<7> {
   constexpr static bool kIsTower = false;
 };
 
+// GF(2⁸) in the AES/Rijndael basis — a FLAT (non-tower) construction with
+// irreducible p(x) = x⁸ + x⁴ + x³ + x + 1 (reduction constant 0x1B), natural
+// bit order. Reuses the tower-level-3 sizing (8-bit storage, uint8, and
+// kValueMask = 0xFF inherited from BinaryFieldConfig<3>) but flips kIsTower so
+// BinaryField dispatches to the AES multiply instead of the tower multiply.
+// Isomorphic to BinaryFieldConfig<3> but NOT bit-compatible: this basis matches
+// AES and flock's φ₈ univariate skip byte-for-byte.
+struct Gf8AesFieldConfig : public BinaryFieldConfig<3> {
+  constexpr static bool kIsTower = false;
+};
+
 }  // namespace zk_dtypes
 
 #endif  // ZK_DTYPES_INCLUDE_FIELD_BINARY_FIELD_CONFIG_H_

--- a/zk_dtypes/include/field/binary_field_multiplication.h
+++ b/zk_dtypes/include/field/binary_field_multiplication.h
@@ -405,6 +405,57 @@ constexpr BigInt<2> GhashInverse(const BigInt<2>& a) {
   return result;
 }
 
+// =============================================================================
+// AES / Rijndael flat GF(2⁸) multiplication (non-tower)
+// =============================================================================
+// GF(2⁸) in the AES basis: p(x) = x⁸ + x⁴ + x³ + x + 1 (reduction constant
+// 0x1B), natural bit order. An element is a uint8_t whose bit i is the
+// coefficient of xⁱ. Isomorphic to the tower GF(2⁸) but a DIFFERENT,
+// bit-incompatible basis matching AES and flock's φ₈ univariate skip. These are
+// the reference (portable, constexpr) semantics; a hardware GFNI/PTX lowering
+// lives downstream in the compiler.
+
+// Reduce a degree-≤14 product (uint16) mod x⁸ + x⁴ + x³ + x + 1. Two folds
+// (x⁸ ≡ x⁴ + x³ + x + 1 = 0x1B); the first fold can re-overflow bit 8, so a
+// second pass is required.
+constexpr uint8_t Gf8AesReduce(uint16_t p) {
+  uint16_t h = p >> 8;
+  uint16_t t = (p & 0xFF) ^ h ^ (h << 1) ^ (h << 3) ^ (h << 4);
+  uint16_t h2 = t >> 8;
+  return static_cast<uint8_t>((t & 0xFF) ^ h2 ^ (h2 << 1) ^ (h2 << 3) ^
+                              (h2 << 4));
+}
+
+// GF(2⁸) multiply in the AES basis: carryless 8×8 → 16 product, then reduce.
+constexpr uint8_t Gf8AesMul(uint8_t a, uint8_t b) {
+  uint16_t acc = 0;
+  for (size_t i = 0; i < 8; ++i) {
+    if ((a >> i) & 1) acc ^= static_cast<uint16_t>(b) << i;
+  }
+  return Gf8AesReduce(acc);
+}
+
+constexpr uint8_t Gf8AesSquare(uint8_t a) { return Gf8AesMul(a, a); }
+
+// Multiply by the generator x: shift up by one and reduce the x⁸ overflow via
+// x⁸ ≡ x⁴ + x³ + x + 1 (= 0x1B).
+constexpr uint8_t Gf8AesMulX(uint8_t a) {
+  uint8_t overflow = a >> 7;
+  return static_cast<uint8_t>((a << 1) ^ (overflow ? 0x1B : 0x00));
+}
+
+// Inverse via Fermat: a⁻¹ = a^(2⁸ − 2) = a² · a⁴ · a⁸ · … · a^(2⁷).
+constexpr uint8_t Gf8AesInverse(uint8_t a) {
+  if (a == 0) return 0;
+  uint8_t result = Gf8AesSquare(a);
+  uint8_t power = result;
+  for (size_t i = 2; i < 8; ++i) {
+    power = Gf8AesSquare(power);
+    result = Gf8AesMul(result, power);
+  }
+  return result;
+}
+
 }  // namespace zk_dtypes
 
 #endif  // ZK_DTYPES_INCLUDE_FIELD_BINARY_FIELD_MULTIPLICATION_H_

--- a/zk_dtypes/include/field/small_binary_field.h
+++ b/zk_dtypes/include/field/small_binary_field.h
@@ -54,6 +54,7 @@ class BinaryField<_Config, std::enable_if_t<(_Config::kStorageBits <= 64)>>
 
   constexpr static bool kUseMontgomery =
       false;  // Binary fields don't use Montgomery
+  constexpr static bool kIsTower = Config::kIsTower;
   constexpr static size_t kTowerLevel = Config::kTowerLevel;
   constexpr static size_t kStorageBits = Config::kStorageBits;
   constexpr static size_t kLimbNums = 1;
@@ -137,10 +138,15 @@ class BinaryField<_Config, std::enable_if_t<(_Config::kStorageBits <= 64)>>
   // Negation: Identity in characteristic 2 (-a = a)
   constexpr BinaryField operator-() const { return *this; }
 
-  // Multiplication: Tower field multiplication
+  // Multiplication: tower field multiply, or the flat AES multiply when the
+  // config is not a tower (the only flat small field is Gf8AesFieldConfig).
   constexpr BinaryField operator*(BinaryField other) const {
-    return FromUnchecked(
-        BinaryMul<kTowerLevel, UnderlyingType>(value_, other.value_));
+    if constexpr (kIsTower) {
+      return FromUnchecked(
+          BinaryMul<kTowerLevel, UnderlyingType>(value_, other.value_));
+    } else {
+      return FromUnchecked(Gf8AesMul(value_, other.value_));
+    }
   }
 
   constexpr BinaryField& operator*=(BinaryField other) {
@@ -148,17 +154,29 @@ class BinaryField<_Config, std::enable_if_t<(_Config::kStorageBits <= 64)>>
   }
 
   constexpr BinaryField Square() const {
-    return FromUnchecked(BinarySquare<kTowerLevel, UnderlyingType>(value_));
+    if constexpr (kIsTower) {
+      return FromUnchecked(BinarySquare<kTowerLevel, UnderlyingType>(value_));
+    } else {
+      return FromUnchecked(Gf8AesSquare(value_));
+    }
   }
 
   // Multiply by X (extension generator)
   constexpr BinaryField MulX() const {
-    return FromUnchecked(BinaryMulX<kTowerLevel, UnderlyingType>(value_));
+    if constexpr (kIsTower) {
+      return FromUnchecked(BinaryMulX<kTowerLevel, UnderlyingType>(value_));
+    } else {
+      return FromUnchecked(Gf8AesMulX(value_));
+    }
   }
 
   // Inverse: Returns Zero() if not invertible (i.e., input is zero)
   constexpr BinaryField Inverse() const {
-    return FromUnchecked(BinaryInverse<kTowerLevel, UnderlyingType>(value_));
+    if constexpr (kIsTower) {
+      return FromUnchecked(BinaryInverse<kTowerLevel, UnderlyingType>(value_));
+    } else {
+      return FromUnchecked(Gf8AesInverse(value_));
+    }
   }
 
   constexpr BinaryField operator/(BinaryField other) const {

--- a/zk_dtypes/include/field/small_binary_field.h
+++ b/zk_dtypes/include/field/small_binary_field.h
@@ -145,6 +145,9 @@ class BinaryField<_Config, std::enable_if_t<(_Config::kStorageBits <= 64)>>
       return FromUnchecked(
           BinaryMul<kTowerLevel, UnderlyingType>(value_, other.value_));
     } else {
+      static_assert(std::is_same_v<Config, Gf8AesFieldConfig>,
+                    "flat small binary field arithmetic only supports "
+                    "Gf8AesFieldConfig");
       return FromUnchecked(Gf8AesMul(value_, other.value_));
     }
   }

--- a/zk_dtypes/tests/binary_field_test.py
+++ b/zk_dtypes/tests/binary_field_test.py
@@ -37,6 +37,7 @@ binary_field_t5 = zk_dtypes.binary_field_t5
 binary_field_t6 = zk_dtypes.binary_field_t6
 binary_field_t7 = zk_dtypes.binary_field_t7
 binary_field_ghash = zk_dtypes.binary_field_ghash
+binary_field_gf8_aes = zk_dtypes.binary_field_gf8_aes
 
 BINARY_FIELD_TYPES = [
     binary_field_t0,
@@ -48,6 +49,7 @@ BINARY_FIELD_TYPES = [
     binary_field_t6,
     binary_field_t7,
     binary_field_ghash,
+    binary_field_gf8_aes,
 ]
 
 # Small binary fields (fit in 64 bits) for tests that need int conversion
@@ -59,6 +61,7 @@ SMALL_BINARY_FIELD_TYPES = [
     binary_field_t4,
     binary_field_t5,
     binary_field_t6,
+    binary_field_gf8_aes,
 ]
 
 # Value masks for each binary field type
@@ -72,6 +75,7 @@ VALUE_MASKS = {
     binary_field_t6: (1 << 64) - 1,
     binary_field_t7: (1 << 128) - 1,
     binary_field_ghash: (1 << 128) - 1,
+    binary_field_gf8_aes: (1 << 8) - 1,
 }
 
 # Test values for each binary field type (within valid range)
@@ -85,6 +89,7 @@ VALUES = {
     binary_field_t6: random.sample(range(0, 2**16), 4),
     binary_field_t7: random.sample(range(0, 2**16), 4),
     binary_field_ghash: random.sample(range(0, 2**16), 4),
+    binary_field_gf8_aes: random.sample(range(0, 256), 4),
 }
 
 
@@ -106,6 +111,26 @@ def _ghash_ref_mul(a: int, b: int) -> int:
     if (prod >> i) & 1:
       prod ^= (1 << i) | (_GHASH_REDUCE << (i - 128))
   return prod & _GHASH_MASK
+
+
+# Reference GF(2^8) multiply in the flat AES/Rijndael basis
+# (p(x) = x^8 + x^4 + x^3 + x + 1), independent of the C++ implementation:
+# a schoolbook carryless product then bit-by-bit reduction. Bit i of each 8-bit
+# int is the coefficient of x^i. Pins binary_field_gf8_aes to the AES basis that
+# flock's phi8 univariate skip depends on.
+_AES_MASK = (1 << 8) - 1
+_AES_REDUCE = (1 << 4) | (1 << 3) | (1 << 1) | 1  # x^4 + x^3 + x + 1 = 0x1B
+
+
+def _aes_ref_mul(a: int, b: int) -> int:
+  prod = 0
+  for i in range(8):
+    if (a >> i) & 1:
+      prod ^= b << i
+  for i in range(15, 7, -1):
+    if (prod >> i) & 1:
+      prod ^= (1 << i) | (_AES_REDUCE << (i - 8))
+  return prod & _AES_MASK
 
 
 # Reference multiply for the Fan-Paar / Binius tower, independent of the C++
@@ -601,6 +626,53 @@ class GhashBasisTest(parameterized.TestCase):
           lo.to_bytes(8, "little") + hi.to_bytes(8, "little"),
           msg=hex(a),
       )
+
+
+@multi_threaded(num_workers=3)
+class Gf8AesBasisTest(parameterized.TestCase):
+  """binary_field_gf8_aes must realize the flat AES/Rijndael basis exactly."""
+
+  GF = binary_field_gf8_aes
+  EDGE = [0, 1, 2, 0x10, 0x80, 0x53, 0xCA, 0xFF]
+
+  def _samples(self, n=256):
+    rng = random.Random(20260709)
+    return self.EDGE + [rng.getrandbits(8) for _ in range(n)]
+
+  def testFullWidthRoundTrip(self):
+    for a in self._samples(50):
+      self.assertEqual(int(self.GF(a)), a, msg=hex(a))
+
+  def testMultiplyMatchesReference(self):
+    rng = random.Random(7)
+    for a in self._samples():
+      b = rng.getrandbits(8)
+      self.assertEqual(
+          int(self.GF(a) * self.GF(b)),
+          _aes_ref_mul(a, b),
+          msg=(hex(a), hex(b)),
+      )
+
+  def testSquareMatchesReference(self):
+    for a in self._samples():
+      self.assertEqual(
+          int(self.GF(a) * self.GF(a)), _aes_ref_mul(a, a), msg=hex(a)
+      )
+
+  def testInverseIsMultiplicative(self):
+    for a in self._samples(100):
+      if a == 0:
+        continue
+      self.assertEqual(int(self.GF(a) * (self.GF(a) ** -1)), 1, msg=hex(a))
+
+  def testByteLayoutIsSingleByte(self):
+    for a in self.EDGE:
+      arr = np.array([a], dtype=self.GF)
+      self.assertEqual(arr.tobytes(), a.to_bytes(1, "little"), msg=hex(a))
+
+  def testMatchesFipsExample(self):
+    # FIPS-197 §4.2 worked example: {57} · {83} = {c1}.
+    self.assertEqual(int(self.GF(0x57) * self.GF(0x83)), 0xC1)
 
 
 if __name__ == "__main__":

--- a/zk_dtypes/tests/descr_char_test.py
+++ b/zk_dtypes/tests/descr_char_test.py
@@ -1,0 +1,90 @@
+# Copyright 2026 The zk_dtypes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Guards the kNpyDescrType chars of every registered dtype.
+
+A custom dtype whose ``.char`` shadows a builtin numpy typecode makes
+``np.dtype(arr.dtype.char)`` round-trips silently resolve to the BUILTIN
+(``np.dtype('f')`` stays float32), i.e. a wrong type with no error. New
+dtypes must pick chars outside ``np.typecodes['All']``; the frozen set below
+grandfathers the pre-existing offenders — shrink it, never grow it.
+"""
+
+from absl.testing import absltest
+import numpy as np
+
+import zk_dtypes
+
+# name -> shadowed builtin char. Frozen as of binary_field_gf8_aes ('8', the
+# first dtype gated by this test); each entry predates the test.
+_GRANDFATHERED_BUILTIN_CHARS = {
+    "babybear": "B",
+    "babybear_mont": "b",
+    "babybearx4": "D",
+    "babybearx4_mont": "d",
+    "binary_field_ghash": "h",
+    "binary_field_t5": "l",
+    "binary_field_t6": "L",
+    "bn254_sf": "B",
+    "bn254_sf_mont": "b",
+    "goldilocks": "G",
+    "goldilocks_mont": "g",
+    "int128": "n",
+    "koalabearx4_mont": "e",
+    "mersenne31": "m",
+    "mersenne31x2": "q",
+    "pallas_sf": "P",
+    "pallas_sf_mont": "p",
+    "uint128": "N",
+}
+
+
+def _all_scalar_types():
+  for name in zk_dtypes.__all__:
+    t = getattr(zk_dtypes, name)
+    if isinstance(t, type) and issubclass(t, np.generic):
+      yield name, t
+
+
+class DescrCharTest(absltest.TestCase):
+
+  def testNewDtypesDoNotShadowBuiltinTypecodes(self):
+    builtin = set(np.typecodes["All"])
+    offenders = {
+        name: np.dtype(t).char
+        for name, t in _all_scalar_types()
+        if np.dtype(t).char in builtin
+    }
+    self.assertEqual(
+        offenders,
+        _GRANDFATHERED_BUILTIN_CHARS,
+        "a dtype's kNpyDescrType shadows a builtin numpy typecode (or a "
+        "grandfathered one changed): pick a char outside "
+        "np.typecodes['All']; only remove entries from the frozen set",
+    )
+
+  def testBuiltinCharLookupUnaffectedByRegistration(self):
+    # Registering the zk dtypes must never change what a builtin typecode
+    # resolves to.
+    for c in np.typecodes["All"]:
+      self.assertLess(
+          np.dtype(c).num,
+          256,
+          f"np.dtype({c!r}) resolves to a "
+          "user type after zk_dtypes registration",
+      )
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/zk_dtypes/tests/field/binary_field_unittest.cc
+++ b/zk_dtypes/tests/field/binary_field_unittest.cc
@@ -52,7 +52,7 @@ class BinaryFieldTypedTest : public testing::Test {};
 using BinaryFieldTypes =
     testing::Types<BinaryFieldT0, BinaryFieldT1, BinaryFieldT2, BinaryFieldT3,
                    BinaryFieldT4, BinaryFieldT5, BinaryFieldT6, BinaryFieldT7,
-                   BinaryFieldGhash>;
+                   BinaryFieldGhash, BinaryFieldGf8Aes>;
 
 TYPED_TEST_SUITE(BinaryFieldTypedTest, BinaryFieldTypes);
 
@@ -224,6 +224,19 @@ TEST(BinaryFieldGhashTest, KnownAnswerReduction) {
   EXPECT_EQ(E(0, 1) * E(0, 1), E(0x87, 0));  // x⁶⁴·x⁶⁴ = x¹²⁸ ≡ 0x87
   EXPECT_EQ(E(0, uint64_t{1} << 63) * E(2, 0), E(0x87, 0));  // x¹²⁷·x = x¹²⁸
   EXPECT_EQ(E(0, uint64_t{1} << 63).MulX(), E(0x87, 0));     // MulX at top bit
+}
+
+// AES/Rijndael basis known-answer vectors. Self-consistency tests (Square ==
+// a*a, inverse round-trip) hold for any irreducible polynomial; these pin the
+// basis to p(x) = x⁸ + x⁴ + x³ + x + 1, i.e. x⁸ ≡ x⁴ + x³ + x + 1 = 0x1B.
+TEST(BinaryFieldGf8AesTest, KnownAnswerReduction) {
+  using F = BinaryFieldGf8Aes;
+  auto E = [](uint8_t v) { return F::FromUnchecked(v); };
+  EXPECT_EQ(E(0x02) * E(0x02), E(0x04));  // x·x = x² (no reduction)
+  EXPECT_EQ(E(0x10) * E(0x10), E(0x1B));  // x⁴·x⁴ = x⁸ ≡ 0x1B
+  EXPECT_EQ(E(0x80) * E(0x02), E(0x1B));  // x⁷·x = x⁸ ≡ 0x1B
+  EXPECT_EQ(E(0x80).MulX(), E(0x1B));     // MulX at the top bit
+  EXPECT_EQ(E(0x57) * E(0x83), E(0xC1));  // FIPS-197 §4.2 worked example
 }
 
 }  // namespace


### PR DESCRIPTION
## Description

GF(2⁸) in the AES/Rijndael basis (p(x) = x⁸ + x⁴ + x³ + x + 1, reduction
0x1B) as a first-class flat (non-tower) binary dtype — a sibling of
`binary_field_ghash` one level down. It is isomorphic to the tower GF(2⁸)
(`binary_field_t3`) but a bit-incompatible representation matching AES,
and flock's φ₈ univariate skip, byte-for-byte. flock's byte-identity gate
against unmodified upstream needs this basis; the tower `t3` cannot
provide it.

Follows the `binary_field_ghash` config-flag pattern: multiply is the only
basis-specific part, so `Gf8AesFieldConfig` (`kIsTower=false`) reuses the
level-3 sizing and the multiplicative methods branch on `kIsTower`. ghash
patched the big-field path; AES-8 is a small field, so the branch lands in
`small_binary_field.h`.

Verified: C++ known-answers (`x⁴·x⁴ = x⁸ = 0x1B`, FIPS-197 §4.2 `{57}·{83}={c1}`)
and a Python cross-check of multiply/square/inverse against an independent
bit-by-bit AES reference plus the single-byte LE layout. Full `//zk_dtypes/...`
suite green.

## Related Issues/PRs

Progresses fractalyze/flock-zorch#88. Follows #146 (`binary_field_ghash`).

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline