### PR TITLE
ci: restore macOS arm64 wheel build in publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,12 +16,19 @@ concurrency:
   group: publish
   cancel-in-progress: false
 
+# Least privilege: build jobs only read source and upload artifacts. The
+# publish job overrides this with id-token: write for OIDC trusted publishing.
+permissions:
+  contents: read
+
 jobs:
   build-linux-x86_64:
     name: Build / Linux x86_64
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v4.7.0
@@ -40,10 +47,32 @@ jobs:
           path: wheelhouse/*.whl
           retention-days: 3
 
+  build-macos-arm64:
+    name: Build / macOS arm64
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.22
+        env:
+          # Pin the arm64-only release contract instead of relying on
+          # macos-latest defaulting to Apple Silicon.
+          CIBW_ARCHS_MACOS: arm64
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos-arm64
+          path: wheelhouse/*.whl
+          retention-days: 3
+
   publish:
     name: Publish
     if: inputs.target != 'build-only'
-    needs: [build-linux-x86_64]
+    needs: [build-linux-x86_64, build-macos-arm64]
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -61,7 +90,10 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
 
       - name: Publish to PyPI
         if: inputs.target == 'pypi'
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true


### PR DESCRIPTION
## What

Restore the `build-macos-arm64` wheel job to the publish workflow and wire it
into the `publish` job's `needs`.

## Why

macOS (and aarch64) wheel builds were removed in #122 ("drop linux-aarch64 and
macos-arm64 wheel builds from publish") explicitly as **temporary** — *"restore
when a non-x86_64-linux consumer appears."*
[awesome-zorch](https://github.com/fractalyze/awesome-zorch) is that consumer:
it needs macOS wheels of `zk_dtypes`. This restores **only the macOS arm64**
build (linux-aarch64 is still not needed).

## No version bump needed

`zk_dtypes` is already published at `0.0.10`. This adds a **new platform wheel
to the existing release** — the macOS wheel has a distinct platform tag
(`macosx_11_0_arm64`), so its filename doesn't collide with the existing
`x86_64` file, and PyPI accepts new files on an existing version.
`skip-existing: true` is added to both the TestPyPI and PyPI publish steps so
re-running is idempotent and the already-uploaded `0.0.10` `x86_64` wheel is
left untouched.

## Test plan

- [ ] TestPyPI dry-run on this branch is green
- [ ] A `...-macosx_11_0_arm64.whl` appears in the run artifacts / on TestPyPI
- [ ] After merge: run `publish.yml` on `main` with `target=pypi`

## Notes

- macOS is **arm64-only** (the `macos-latest` runner is Apple Silicon).
  Intel-mac (`x86_64`) coverage is intentionally omitted — no Intel-mac
  consumer, and cross-compiling on the ARM runner isn't wired up. Add a
  separate `macos-13` job later if it's ever needed.
