### PR TITLE
feat(field): user-defined fields & EC points via a NEP-42 parametric numpy dtype

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -4,6 +4,7 @@ skip =
 
 ignore-words-list =
   arithmetics,
+  nin,
   Te,
   TE,
   Toom,

--- a/zk_dtypes/BUILD.bazel
+++ b/zk_dtypes/BUILD.bazel
@@ -1179,6 +1179,8 @@ cc_library(
         "_src/bigint_numpy.h",
         "_src/common.h",
         "_src/dtypes.cc",
+        "_src/ec_point_dtype.cc",
+        "_src/ec_point_dtype.h",
         "_src/ec_point_numpy.h",
         "_src/field_dtype.cc",
         "_src/field_dtype.h",

--- a/zk_dtypes/BUILD.bazel
+++ b/zk_dtypes/BUILD.bazel
@@ -1179,6 +1179,7 @@ cc_library(
         "_src/bigint_numpy.h",
         "_src/common.h",
         "_src/dtypes.cc",
+        "_src/ec_group_law.h",
         "_src/ec_point_dtype.cc",
         "_src/ec_point_dtype.h",
         "_src/ec_point_numpy.h",

--- a/zk_dtypes/BUILD.bazel
+++ b/zk_dtypes/BUILD.bazel
@@ -1180,6 +1180,8 @@ cc_library(
         "_src/common.h",
         "_src/dtypes.cc",
         "_src/ec_point_numpy.h",
+        "_src/field_dtype.cc",
+        "_src/field_dtype.h",
         "_src/field_numpy.h",
         "_src/int_caster.cc",
         "_src/int_caster.h",

--- a/zk_dtypes/BUILD.bazel
+++ b/zk_dtypes/BUILD.bazel
@@ -1221,6 +1221,7 @@ py_library(
         "__init__.py",
         "_ecinfo.py",
         "_efinfo.py",
+        "_field_factory.py",
         "_iinfo.py",
         "_pfinfo.py",
     ],
@@ -1312,6 +1313,18 @@ py_test(
     name = "bigintn_test",
     srcs = ["tests/bigintn_test.py"],
     main = "tests/bigintn_test.py",
+    deps = [
+        ":test_utils",
+        ":zk_dtypes_py",
+        "@pypi//absl_py",
+        "@pypi//numpy",
+    ],
+)
+
+py_test(
+    name = "prime_field_factory_test",
+    srcs = ["tests/prime_field_factory_test.py"],
+    main = "tests/prime_field_factory_test.py",
     deps = [
         ":test_utils",
         ":zk_dtypes_py",

--- a/zk_dtypes/BUILD.bazel
+++ b/zk_dtypes/BUILD.bazel
@@ -1184,6 +1184,7 @@ cc_library(
         "_src/ec_point_numpy.h",
         "_src/field_dtype.cc",
         "_src/field_dtype.h",
+        "_src/field_modarith.h",
         "_src/field_numpy.h",
         "_src/int_caster.cc",
         "_src/int_caster.h",

--- a/zk_dtypes/__init__.py
+++ b/zk_dtypes/__init__.py
@@ -17,10 +17,13 @@
 __version__ = "0.0.11"
 __all__ = [
     "__version__",
+    "binary_field",
     "ecinfo",
     "efinfo",
+    "extension_field",
     "iinfo",
     "pfinfo",
+    "prime_field",
     "int2",
     "int4",
     "int128",
@@ -94,6 +97,9 @@ from typing import Type
 
 from zk_dtypes._ecinfo import ecinfo
 from zk_dtypes._efinfo import efinfo
+from zk_dtypes._field_factory import binary_field
+from zk_dtypes._field_factory import extension_field
+from zk_dtypes._field_factory import prime_field
 from zk_dtypes._iinfo import iinfo
 from zk_dtypes._pfinfo import pfinfo
 from zk_dtypes._zk_dtypes_ext import int2

--- a/zk_dtypes/_field_factory.py
+++ b/zk_dtypes/_field_factory.py
@@ -1,0 +1,266 @@
+# Copyright 2025 The zk_dtypes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Runtime resolution of a field to a numpy dtype.
+
+`prime_field(p, storage)` and `extension_field(p, degree, non_residue, storage)`
+map a field to the numpy dtype used to materialize its buffers. A curated family
+(babybear, koalabear, goldilocks, mersenne31, bn254_sf and their extensions)
+resolves to its pre-built legacy dtype — those keep their enum identity so the
+non-parametric stack still recognizes them. A novel field is registered on the
+parametric ``FieldDType`` (one numpy DType serving every field).
+
+The (base) modulus is validated with a Miller-Rabin test: neither the compiler
+nor the verifier can check primality, and a composite modulus silently produces
+garbage (every field operation assumes Z/pZ is a field, not just a ring).
+"""
+
+import numpy as np
+
+from zk_dtypes import _zk_dtypes_ext as _ext
+from zk_dtypes._efinfo import efinfo
+from zk_dtypes._pfinfo import pfinfo
+from zk_dtypes._zk_dtypes_ext import binary_field_t0
+from zk_dtypes._zk_dtypes_ext import binary_field_t1
+from zk_dtypes._zk_dtypes_ext import binary_field_t2
+from zk_dtypes._zk_dtypes_ext import binary_field_t3
+from zk_dtypes._zk_dtypes_ext import binary_field_t4
+from zk_dtypes._zk_dtypes_ext import binary_field_t5
+from zk_dtypes._zk_dtypes_ext import binary_field_t6
+from zk_dtypes._zk_dtypes_ext import binary_field_t7
+from zk_dtypes._zk_dtypes_ext import babybear
+from zk_dtypes._zk_dtypes_ext import babybearx4
+from zk_dtypes._zk_dtypes_ext import bn254_sf
+from zk_dtypes._zk_dtypes_ext import goldilocks
+from zk_dtypes._zk_dtypes_ext import goldilocksx3
+from zk_dtypes._zk_dtypes_ext import koalabear
+from zk_dtypes._zk_dtypes_ext import koalabearx4
+from zk_dtypes._zk_dtypes_ext import mersenne31
+from zk_dtypes._zk_dtypes_ext import mersenne31x2
+
+# Storage width classes the parametric stack materializes (base) fields into;
+# modulus bit length rounds up to the smallest that fits (xla_fork FIELD32/64/
+# 128/256).
+_WIDTH_CLASSES = (32, 64, 128, 256)
+
+_STORAGE_ALIASES = {
+    "mont": True,
+    "montgomery": True,
+    "std": False,
+    "canonical": False,
+}
+
+# First 12 primes as Miller-Rabin bases: deterministic for n < 3.3e24, and a
+# strong probabilistic test (error < 4^-12) for crypto-scale moduli above it.
+_MILLER_RABIN_BASES = (2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37)
+
+
+def _is_probable_prime(n: int) -> bool:
+  if n < 2:
+    return False
+  for base in _MILLER_RABIN_BASES:
+    if n % base == 0:
+      return n == base
+  d, r = n - 1, 0
+  while d % 2 == 0:
+    d //= 2
+    r += 1
+  for a in _MILLER_RABIN_BASES:
+    x = pow(a, d, n)
+    if x == 1 or x == n - 1:
+      continue
+    for _ in range(r - 1):
+      x = x * x % n
+      if x == n - 1:
+        break
+    else:
+      return False
+  return True
+
+
+def _storage_width(modulus_bits: int) -> int:
+  for width in _WIDTH_CLASSES:
+    if modulus_bits <= width:
+      return width
+  raise ValueError(
+      f"modulus needs {modulus_bits} bits; the widest field storage class is "
+      f"{_WIDTH_CLASSES[-1]} bits"
+  )
+
+
+def _field_descr(
+    modulus: int,
+    degree: int,
+    non_residue: int,
+    base_width: int,
+    is_montgomery: bool,
+) -> np.dtype:
+  """Builds a parametric FieldDType dtype, computing Montgomery constants."""
+  if not is_montgomery:
+    return np.dtype(
+        _ext.field_descr(modulus, degree, non_residue, base_width, 0)
+    )
+  # Per-coefficient Montgomery: bytes are `c*R mod p` with R = 2^base_width
+  # (prime_ir's device encoding). Decode multiplies by R^-1.
+  r_mod_p = (1 << base_width) % modulus
+  rinv_mod_p = pow(r_mod_p, -1, modulus)
+  return np.dtype(
+      _ext.field_descr(
+          modulus, degree, non_residue, base_width, 1, r_mod_p, rinv_mod_p
+      )
+  )
+
+
+def _curated_prime_map() -> dict[tuple[int, bool], type]:
+  out: dict[tuple[int, bool], type] = {}
+  for family in (babybear, koalabear, goldilocks, mersenne31, bn254_sf):
+    info = pfinfo(np.dtype(family))
+    out[(info.modulus, info.is_montgomery)] = family
+  return out
+
+
+def _curated_ext_map() -> dict[tuple[int, int, int, bool], type]:
+  out: dict[tuple[int, int, int, bool], type] = {}
+  for family in (babybearx4, koalabearx4, goldilocksx3, mersenne31x2):
+    info = efinfo(np.dtype(family))
+    base_modulus = pfinfo(info.base_field_dtype).modulus
+    out[(base_modulus, info.degree, info.non_residue, info.is_montgomery)] = (
+        family
+    )
+  return out
+
+
+_CURATED_PRIME = _curated_prime_map()
+_CURATED_EXT = _curated_ext_map()
+_CURATED_BINARY = {
+    0: binary_field_t0,
+    1: binary_field_t1,
+    2: binary_field_t2,
+    3: binary_field_t3,
+    4: binary_field_t4,
+    5: binary_field_t5,
+    6: binary_field_t6,
+    7: binary_field_t7,
+}
+
+
+def prime_field(modulus: int, storage: str = "mont") -> np.dtype:
+  """Resolves a prime modulus + storage form to a field dtype.
+
+  Args:
+    modulus: the field characteristic p. Validated prime (Miller-Rabin).
+    storage: 'mont'/'montgomery' for Montgomery-form buffers, 'std'/'canonical'
+      for canonical residues.
+
+  Returns:
+    The numpy dtype for Z/pZ in the requested storage form.
+
+  Raises:
+    TypeError: modulus is not an int.
+    ValueError: modulus is composite, storage is unrecognized, or the modulus
+      exceeds the widest storage class.
+  """
+  if isinstance(modulus, bool) or not isinstance(modulus, int):
+    raise TypeError(f"modulus must be an int, got {type(modulus).__name__}")
+  if storage not in _STORAGE_ALIASES:
+    raise ValueError(
+        f"storage must be one of {sorted(_STORAGE_ALIASES)}, got {storage!r}"
+    )
+  is_montgomery = _STORAGE_ALIASES[storage]
+  if not _is_probable_prime(modulus):
+    raise ValueError(
+        f"modulus {modulus} is not prime; Z/{modulus}Z is a ring, not a field"
+    )
+  width = _storage_width(modulus.bit_length())
+  curated = _CURATED_PRIME.get((modulus, is_montgomery))
+  if curated is not None:
+    return np.dtype(curated)
+  return _field_descr(modulus, 1, 0, width, is_montgomery)
+
+
+def extension_field(
+    base_modulus: int, degree: int, non_residue: int, storage: str = "mont"
+) -> np.dtype:
+  """Resolves a binomial extension field Fp[X]/(X^degree - non_residue).
+
+  Args:
+    base_modulus: the base prime p. Validated prime (Miller-Rabin).
+    degree: extension degree >= 2 (use ``prime_field`` for degree 1).
+    non_residue: the constant of the binomial modulus; X^degree = non_residue.
+      Must be a non-residue for the field to be a field (the caller is trusted
+      on irreducibility — it cannot be checked cheaply).
+    storage: per-coefficient storage form, as in ``prime_field``.
+
+  Returns:
+    The numpy dtype for the extension field. Elements are ``degree`` base-field
+    coefficients, constant term first.
+
+  Raises:
+    TypeError: base_modulus is not an int.
+    ValueError: base is composite, degree < 2, storage unrecognized, or the base
+      exceeds the widest storage class.
+  """
+  if isinstance(base_modulus, bool) or not isinstance(base_modulus, int):
+    raise TypeError(
+        f"base_modulus must be an int, got {type(base_modulus).__name__}"
+    )
+  if storage not in _STORAGE_ALIASES:
+    raise ValueError(
+        f"storage must be one of {sorted(_STORAGE_ALIASES)}, got {storage!r}"
+    )
+  if degree < 2:
+    raise ValueError(
+        f"degree must be >= 2 (use prime_field for 1), got {degree}"
+    )
+  if not _is_probable_prime(base_modulus):
+    raise ValueError(
+        f"base_modulus {base_modulus} is not prime; the base must be a field"
+    )
+  is_montgomery = _STORAGE_ALIASES[storage]
+  non_residue %= base_modulus
+  base_width = _storage_width(base_modulus.bit_length())
+  curated = _CURATED_EXT.get((base_modulus, degree, non_residue, is_montgomery))
+  if curated is not None:
+    return np.dtype(curated)
+  return _field_descr(
+      base_modulus, degree, non_residue, base_width, is_montgomery
+  )
+
+
+def binary_field(level: int) -> np.dtype:
+  """Resolves a binary tower field GF(2^(2^level)) to a numpy dtype.
+
+  Levels 0..7 are curated families (binary_field_t0..t7) and resolve to their
+  legacy dtype; higher levels mint a parametric ``BinaryFieldDType``. Addition is
+  XOR; multiplication is the recursive Karatsuba tower product.
+
+  Args:
+    level: tower level >= 0; the field is GF(2^(2^level)).
+
+  Returns:
+    The numpy dtype for the binary tower field.
+
+  Raises:
+    TypeError: level is not an int.
+    ValueError: level is negative.
+  """
+  if isinstance(level, bool) or not isinstance(level, int):
+    raise TypeError(f"level must be an int, got {type(level).__name__}")
+  if level < 0:
+    raise ValueError(f"level must be >= 0, got {level}")
+  curated = _CURATED_BINARY.get(level)
+  if curated is not None:
+    return np.dtype(curated)
+  return np.dtype(_ext.binary_field_descr(level))

--- a/zk_dtypes/_field_factory.py
+++ b/zk_dtypes/_field_factory.py
@@ -41,12 +41,19 @@ from zk_dtypes._zk_dtypes_ext import binary_field_t5
 from zk_dtypes._zk_dtypes_ext import binary_field_t6
 from zk_dtypes._zk_dtypes_ext import binary_field_t7
 from zk_dtypes._zk_dtypes_ext import babybear
+from zk_dtypes._zk_dtypes_ext import babybear_mont
 from zk_dtypes._zk_dtypes_ext import babybearx4
+from zk_dtypes._zk_dtypes_ext import babybearx4_mont
 from zk_dtypes._zk_dtypes_ext import bn254_sf
+from zk_dtypes._zk_dtypes_ext import bn254_sf_mont
 from zk_dtypes._zk_dtypes_ext import goldilocks
+from zk_dtypes._zk_dtypes_ext import goldilocks_mont
 from zk_dtypes._zk_dtypes_ext import goldilocksx3
+from zk_dtypes._zk_dtypes_ext import goldilocksx3_mont
 from zk_dtypes._zk_dtypes_ext import koalabear
+from zk_dtypes._zk_dtypes_ext import koalabear_mont
 from zk_dtypes._zk_dtypes_ext import koalabearx4
+from zk_dtypes._zk_dtypes_ext import koalabearx4_mont
 from zk_dtypes._zk_dtypes_ext import mersenne31
 from zk_dtypes._zk_dtypes_ext import mersenne31x2
 
@@ -125,7 +132,20 @@ def _field_descr(
 
 def _curated_prime_map() -> dict[tuple[int, bool], type]:
   out: dict[tuple[int, bool], type] = {}
-  for family in (babybear, koalabear, goldilocks, mersenne31, bn254_sf):
+  # Both storage forms are curated where the legacy stack registers them
+  # (Mersenne uses canonical reduction, so it has no Montgomery variant). The
+  # (modulus, is_montgomery) key keeps the two forms distinct.
+  for family in (
+      babybear,
+      babybear_mont,
+      koalabear,
+      koalabear_mont,
+      goldilocks,
+      goldilocks_mont,
+      mersenne31,
+      bn254_sf,
+      bn254_sf_mont,
+  ):
     info = pfinfo(np.dtype(family))
     out[(info.modulus, info.is_montgomery)] = family
   return out
@@ -133,7 +153,15 @@ def _curated_prime_map() -> dict[tuple[int, bool], type]:
 
 def _curated_ext_map() -> dict[tuple[int, int, int, bool], type]:
   out: dict[tuple[int, int, int, bool], type] = {}
-  for family in (babybearx4, koalabearx4, goldilocksx3, mersenne31x2):
+  for family in (
+      babybearx4,
+      babybearx4_mont,
+      koalabearx4,
+      koalabearx4_mont,
+      goldilocksx3,
+      goldilocksx3_mont,
+      mersenne31x2,
+  ):
     info = efinfo(np.dtype(family))
     base_modulus = pfinfo(info.base_field_dtype).modulus
     out[(base_modulus, info.degree, info.non_residue, info.is_montgomery)] = (

--- a/zk_dtypes/_field_factory.py
+++ b/zk_dtypes/_field_factory.py
@@ -40,22 +40,6 @@ from zk_dtypes._zk_dtypes_ext import binary_field_t4
 from zk_dtypes._zk_dtypes_ext import binary_field_t5
 from zk_dtypes._zk_dtypes_ext import binary_field_t6
 from zk_dtypes._zk_dtypes_ext import binary_field_t7
-from zk_dtypes._zk_dtypes_ext import babybear
-from zk_dtypes._zk_dtypes_ext import babybear_mont
-from zk_dtypes._zk_dtypes_ext import babybearx4
-from zk_dtypes._zk_dtypes_ext import babybearx4_mont
-from zk_dtypes._zk_dtypes_ext import bn254_sf
-from zk_dtypes._zk_dtypes_ext import bn254_sf_mont
-from zk_dtypes._zk_dtypes_ext import goldilocks
-from zk_dtypes._zk_dtypes_ext import goldilocks_mont
-from zk_dtypes._zk_dtypes_ext import goldilocksx3
-from zk_dtypes._zk_dtypes_ext import goldilocksx3_mont
-from zk_dtypes._zk_dtypes_ext import koalabear
-from zk_dtypes._zk_dtypes_ext import koalabear_mont
-from zk_dtypes._zk_dtypes_ext import koalabearx4
-from zk_dtypes._zk_dtypes_ext import koalabearx4_mont
-from zk_dtypes._zk_dtypes_ext import mersenne31
-from zk_dtypes._zk_dtypes_ext import mersenne31x2
 
 # Storage width classes the parametric stack materializes (base) fields into;
 # modulus bit length rounds up to the smallest that fits (xla_fork FIELD32/64/
@@ -130,43 +114,56 @@ def _field_descr(
   )
 
 
-def _curated_prime_map() -> dict[tuple[int, bool], type]:
-  out: dict[tuple[int, bool], type] = {}
-  # Both storage forms are curated where the legacy stack registers them
-  # (Mersenne uses canonical reduction, so it has no Montgomery variant). The
-  # (modulus, is_montgomery) key keeps the two forms distinct.
-  for family in (
-      babybear,
-      babybear_mont,
-      koalabear,
-      koalabear_mont,
-      goldilocks,
-      goldilocks_mont,
-      mersenne31,
-      bn254_sf,
-      bn254_sf_mont,
-  ):
-    info = pfinfo(np.dtype(family))
-    out[(info.modulus, info.is_montgomery)] = family
+def _registered_field_dtypes() -> list[np.dtype]:
+  """Every dtype the native extension registers, probed by attribute name.
+
+  Non-dtype attributes (the field_descr / ec_point_descr factories, the
+  Register* hooks) are ``np.dtype``-unconvertible and skipped.
+  """
+  out: list[np.dtype] = []
+  for name in dir(_ext):
+    if name.startswith("_"):
+      continue
+    try:
+      out.append(np.dtype(getattr(_ext, name)))
+    except TypeError:
+      continue
   return out
 
 
-def _curated_ext_map() -> dict[tuple[int, int, int, bool], type]:
-  out: dict[tuple[int, int, int, bool], type] = {}
-  for family in (
-      babybearx4,
-      babybearx4_mont,
-      koalabearx4,
-      koalabearx4_mont,
-      goldilocksx3,
-      goldilocksx3_mont,
-      mersenne31x2,
-  ):
-    info = efinfo(np.dtype(family))
+def _curated_prime_map() -> dict[tuple[int, bool], np.dtype]:
+  # Resolve a curated modulus back to its legacy prime-field dtype so it keeps
+  # its enum identity. Built by probing every registered dtype (pfinfo raises on
+  # non-prime-fields) rather than a hardcoded family list, so a newly-added
+  # family (pallas/vesta, ...) is picked up without editing this file. Both
+  # storage forms are curated where the legacy stack registers them (Mersenne
+  # has only a canonical form); the (modulus, is_montgomery) key keeps them
+  # distinct.
+  out: dict[tuple[int, bool], np.dtype] = {}
+  for dt in _registered_field_dtypes():
+    try:
+      info = pfinfo(dt)
+    except ValueError:
+      continue
+    out[(info.modulus, info.is_montgomery)] = dt
+  return out
+
+
+def _curated_ext_map() -> dict[tuple[int, int, int, bool], np.dtype]:
+  # Same dynamic probe as the prime map, for binomial extension fields. A
+  # non-binomial legacy extension (e.g. goldilocksx3, X^3 = X + 1, whose efinfo
+  # non_residue is None) has no binomial spelling for the factory to mint, so it
+  # is skipped — only its legacy dtype exists.
+  out: dict[tuple[int, int, int, bool], np.dtype] = {}
+  for dt in _registered_field_dtypes():
+    try:
+      info = efinfo(dt)
+    except (ValueError, TypeError):
+      continue
+    if info.non_residue is None:
+      continue
     base_modulus = pfinfo(info.base_field_dtype).modulus
-    out[(base_modulus, info.degree, info.non_residue, info.is_montgomery)] = (
-        family
-    )
+    out[(base_modulus, info.degree, info.non_residue, info.is_montgomery)] = dt
   return out
 
 

--- a/zk_dtypes/_field_factory.py
+++ b/zk_dtypes/_field_factory.py
@@ -271,18 +271,18 @@ def binary_field(level: int) -> np.dtype:
   """Resolves a binary tower field GF(2^(2^level)) to a numpy dtype.
 
   Levels 0..7 are curated families (binary_field_t0..t7) and resolve to their
-  legacy dtype; higher levels mint a parametric ``BinaryFieldDType``. Addition is
+  legacy dtype; levels 8..12 mint a parametric ``BinaryFieldDType``. Addition is
   XOR; multiplication is the recursive Karatsuba tower product.
 
   Args:
-    level: tower level >= 0; the field is GF(2^(2^level)).
+    level: tower level in [0, 12]; the field is GF(2^(2^level)).
 
   Returns:
     The numpy dtype for the binary tower field.
 
   Raises:
     TypeError: level is not an int.
-    ValueError: level is negative.
+    ValueError: level is negative or exceeds the widest tower level (12).
   """
   if isinstance(level, bool) or not isinstance(level, int):
     raise TypeError(f"level must be an int, got {type(level).__name__}")

--- a/zk_dtypes/_field_factory.py
+++ b/zk_dtypes/_field_factory.py
@@ -27,6 +27,8 @@ nor the verifier can check primality, and a composite modulus silently produces
 garbage (every field operation assumes Z/pZ is a field, not just a ring).
 """
 
+import warnings
+
 import numpy as np
 
 from zk_dtypes import _zk_dtypes_ext as _ext
@@ -79,6 +81,23 @@ def _is_probable_prime(n: int) -> bool:
     else:
       return False
   return True
+
+
+_GOLDILOCKS_MODULUS = 2**64 - 2**32 + 1
+
+
+def _warn_if_inefficient_montgomery(modulus: int, is_montgomery: bool) -> None:
+  # Goldilocks (2^64 - 2^32 + 1) has a fast Solinas reduction and no spare bit
+  # in its 64-bit storage, so its Montgomery form is slower than canonical for
+  # host arithmetic. Steer callers to canonical storage.
+  if is_montgomery and modulus == _GOLDILOCKS_MODULUS:
+    warnings.warn(
+        "Montgomery storage for the Goldilocks field (2^64 - 2^32 + 1) is "
+        "inefficient; its Solinas reduction favors canonical storage. Use "
+        "storage='canonical'.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
 
 
 def _storage_width(modulus_bits: int) -> int:
@@ -208,6 +227,7 @@ def prime_field(modulus: int, storage: str = "mont") -> np.dtype:
     raise ValueError(
         f"modulus {modulus} is not prime; Z/{modulus}Z is a ring, not a field"
     )
+  _warn_if_inefficient_montgomery(modulus, is_montgomery)
   width = _storage_width(modulus.bit_length())
   curated = _CURATED_PRIME.get((modulus, is_montgomery))
   if curated is not None:
@@ -254,6 +274,7 @@ def extension_field(
         f"base_modulus {base_modulus} is not prime; the base must be a field"
     )
   is_montgomery = _STORAGE_ALIASES[storage]
+  _warn_if_inefficient_montgomery(base_modulus, is_montgomery)
   non_residue %= base_modulus
   base_width = _storage_width(base_modulus.bit_length())
   curated = _CURATED_EXT.get((base_modulus, degree, non_residue, is_montgomery))

--- a/zk_dtypes/_src/dtypes.cc
+++ b/zk_dtypes/_src/dtypes.cc
@@ -29,6 +29,7 @@ limitations under the License.
 
 #include "zk_dtypes/_src/bigint_numpy.h"
 #include "zk_dtypes/_src/ec_point_numpy.h"
+#include "zk_dtypes/_src/field_dtype.h"
 #include "zk_dtypes/_src/field_numpy.h"
 #include "zk_dtypes/_src/intn_numpy.h"
 #include "zk_dtypes/include/all_types.h"
@@ -760,6 +761,13 @@ extern "C" EXPORT_SYMBOL PyObject* PyInit__zk_dtypes_ext() {
   }
   ZK_DTYPES_PUBLIC_TYPE_LIST(INIT_MODULE_TYPE)
 #undef INIT_MODULE_TYPE
+
+  // Parametric field DType (user-defined prime + extension fields). Additive:
+  // registered alongside the legacy per-family field dtypes, which are
+  // untouched.
+  if (!RegisterFieldDType(/*numpy=*/nullptr, m.get())) {
+    return nullptr;
+  }
 
 #ifdef Py_GIL_DISABLED
   PyUnstable_Module_SetGIL(m.get(), Py_MOD_GIL_NOT_USED);

--- a/zk_dtypes/_src/dtypes.cc
+++ b/zk_dtypes/_src/dtypes.cc
@@ -28,6 +28,7 @@ limitations under the License.
 #include <Python.h>
 
 #include "zk_dtypes/_src/bigint_numpy.h"
+#include "zk_dtypes/_src/ec_point_dtype.h"
 #include "zk_dtypes/_src/ec_point_numpy.h"
 #include "zk_dtypes/_src/field_dtype.h"
 #include "zk_dtypes/_src/field_numpy.h"
@@ -766,6 +767,9 @@ extern "C" EXPORT_SYMBOL PyObject* PyInit__zk_dtypes_ext() {
   // registered alongside the legacy per-family field dtypes, which are
   // untouched.
   if (!RegisterFieldDType(/*numpy=*/nullptr, m.get())) {
+    return nullptr;
+  }
+  if (!RegisterEcPointDType(/*numpy=*/nullptr, m.get())) {
     return nullptr;
   }
 

--- a/zk_dtypes/_src/ec_group_law.h
+++ b/zk_dtypes/_src/ec_group_law.h
@@ -1,0 +1,131 @@
+/* Copyright 2025 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES__SRC_EC_GROUP_LAW_H_
+#define ZK_DTYPES__SRC_EC_GROUP_LAW_H_
+
+// Short-Weierstrass (a = 0) Jacobian group law, written once over an abstract
+// coordinate field and instantiated per execution tier. `C` is a
+// value-semantic coordinate (copyable; copies may be reference bumps, as in
+// the CPython-int tier) and `Ops` provides:
+//
+//   C    One() / Zero()
+//   C    Add(a, b) / Sub(a, b) / Neg(a) / Mul(a, b) / MulInt(a, k)
+//   bool IsZero(a)
+//   bool Equal(a, b)
+//
+// An Ops whose operations can fail (the CPython tier) reports failure out of
+// band (a poisoned flag checked by its caller) and must make every operation
+// accept the values produced after a failure; the formulas themselves have no
+// error path. Each formula reads all of its inputs before writing `out`, so
+// `out` may alias an input.
+//
+// Formulas: EFD dbl-2009-l and add-2007-bl. Every tier goes through these
+// exact bodies, so cross-tier byte-identity holds by construction — there is
+// no second copy of a formula to keep in lockstep.
+
+namespace zk_dtypes {
+namespace ec_law {
+
+// Jacobian doubling (EFD dbl-2009-l, a == 0). out may alias in.
+template <typename C, typename Ops>
+void EcDoubleT(const Ops& f, const C in[3], C out[3]) {
+  const C& X = in[0];
+  const C& Y = in[1];
+  const C& Z = in[2];
+  C xx = f.Mul(X, X);
+  C yy = f.Mul(Y, Y);
+  C yyyy = f.Mul(yy, yy);
+  C dd = f.MulInt(f.Mul(X, yy), 4);
+  C e = f.MulInt(xx, 3);
+  C X2 = f.Sub(f.Mul(e, e), f.MulInt(dd, 2));
+  C Y2 = f.Sub(f.Mul(e, f.Sub(dd, X2)), f.MulInt(yyyy, 8));
+  C Z2 = f.MulInt(f.Mul(Y, Z), 2);
+  out[0] = X2;
+  out[1] = Y2;
+  out[2] = Z2;
+}
+
+// Jacobian addition (EFD add-2007-bl, a == 0). out may alias an input.
+template <typename C, typename Ops>
+void EcAddT(const Ops& f, const C P[3], const C Q[3], C out[3]) {
+  if (f.IsZero(P[2])) {
+    out[0] = Q[0];
+    out[1] = Q[1];
+    out[2] = Q[2];
+    return;
+  }
+  if (f.IsZero(Q[2])) {
+    out[0] = P[0];
+    out[1] = P[1];
+    out[2] = P[2];
+    return;
+  }
+  C z1z1 = f.Mul(P[2], P[2]);
+  C z2z2 = f.Mul(Q[2], Q[2]);
+  C u1 = f.Mul(P[0], z2z2);
+  C u2 = f.Mul(Q[0], z1z1);
+  C s1 = f.Mul(f.Mul(P[1], Q[2]), z2z2);
+  C s2 = f.Mul(f.Mul(Q[1], P[2]), z1z1);
+  if (f.Equal(u1, u2) && f.Equal(s1, s2)) {  // P == Q
+    EcDoubleT<C, Ops>(f, P, out);
+    return;
+  }
+  C h = f.Sub(u2, u1);
+  C ii = f.Mul(f.MulInt(h, 2), f.MulInt(h, 2));
+  C j = f.Neg(f.Mul(h, ii));
+  C r = f.MulInt(f.Sub(s2, s1), 2);
+  C v = f.Mul(u1, ii);
+  C X3 = f.Sub(f.Add(f.Mul(r, r), j), f.MulInt(v, 2));  // r^2 + j - 2v
+  C Y3 = f.Add(f.Mul(r, f.Sub(v, X3)),
+               f.MulInt(f.Mul(s1, j), 2));          // r(v - X3) + 2 s1 j
+  C Z3 = f.MulInt(f.Mul(f.Mul(P[2], Q[2]), h), 2);  // 2 Z1 Z2 h
+  out[0] = X3;
+  out[1] = Y3;
+  out[2] = Z3;
+}
+
+// Cross-representative group equality of two Jacobian points; 1 / 0.
+template <typename C, typename Ops>
+int EcEqualT(const Ops& f, const C P[3], const C Q[3]) {
+  bool pz = f.IsZero(P[2]);
+  bool qz = f.IsZero(Q[2]);
+  if (pz || qz) return (pz && qz) ? 1 : 0;
+  C z1s = f.Mul(P[2], P[2]);
+  C z2s = f.Mul(Q[2], Q[2]);
+  bool xe = f.Equal(f.Mul(P[0], z2s), f.Mul(Q[0], z1s));
+  bool ye =
+      f.Equal(f.Mul(P[1], f.Mul(z2s, Q[2])), f.Mul(Q[1], f.Mul(z1s, P[2])));
+  return (xe && ye) ? 1 : 0;
+}
+
+// ret = scalar * point, MSB-first double-and-add; scalar as little-endian
+// bytes. ret must not alias point (ret is the running accumulator).
+template <typename C, typename Ops>
+void EcScalarMulT(const Ops& f, const C point[3], const unsigned char* sbytes,
+                  int nbits, C ret[3]) {
+  ret[0] = f.One();  // Jacobian zero = (1, 1, 0)
+  ret[1] = f.One();
+  ret[2] = f.Zero();
+  for (int i = nbits - 1; i >= 0; --i) {
+    EcDoubleT<C, Ops>(f, ret, ret);
+    if ((sbytes[i >> 3] >> (i & 7)) & 1) EcAddT<C, Ops>(f, ret, point, ret);
+  }
+}
+
+}  // namespace ec_law
+}  // namespace zk_dtypes
+
+#endif  // ZK_DTYPES__SRC_EC_GROUP_LAW_H_

--- a/zk_dtypes/_src/ec_point_dtype.cc
+++ b/zk_dtypes/_src/ec_point_dtype.cc
@@ -37,6 +37,7 @@ limitations under the License.
 #include <cstring>
 
 #include "zk_dtypes/_src/numpy.h"
+#include "zk_dtypes/_src/field_dtype.h"
 #include "numpy/dtype_api.h"
 #include "numpy/ndarraytypes.h"
 // clang-format on
@@ -361,6 +362,57 @@ int JacEqual(PyObject* p, PyObject* const* P, PyObject* const* Q) {
   Py_XDECREF(ly);
   Py_XDECREF(ry);
   return result;
+}
+
+void MovePoint(PyObject** dst, PyObject* const* src, int n) {
+  for (int i = 0; i < n; ++i) {
+    Py_DECREF(dst[i]);
+    dst[i] = src[i];
+  }
+}
+
+// MSB-first double-and-add: ret = scalar * point (canonical Jacobian coords).
+// The scalar is a canonical integer (Montgomery already decoded by the caller),
+// matching the legacy curve operator* which de-Montgomery's the scalar first.
+int JacScalarMul(PyObject* p, PyObject* scalar, PyObject* const* point,
+                 PyObject** out) {
+  PyObject* ret[3] = {PyLong_FromLong(1), PyLong_FromLong(1),
+                      PyLong_FromLong(0)};  // Zero = (1, 1, 0)
+  if (!ret[0] || !ret[1] || !ret[2]) {
+    for (int j = 0; j < 3; ++j) Py_XDECREF(ret[j]);
+    return -1;
+  }
+  size_t nbits = _PyLong_NumBits(scalar);
+  size_t nbytes = (nbits + 7) / 8;
+  unsigned char buf[64] = {0};
+  if (nbytes > sizeof(buf)) {
+    for (int j = 0; j < 3; ++j) Py_DECREF(ret[j]);
+    PyErr_SetString(PyExc_OverflowError, "EC scalar too large");
+    return -1;
+  }
+  if (nbytes > 0) {
+    _PyLong_AsByteArray(reinterpret_cast<PyLongObject*>(scalar), buf, nbytes, 1,
+                        0);
+  }
+  for (Py_ssize_t i = static_cast<Py_ssize_t>(nbits) - 1; i >= 0; --i) {
+    PyObject* tmp[3];
+    if (JacDouble(p, ret, tmp) < 0) {
+      for (int j = 0; j < 3; ++j) Py_DECREF(ret[j]);
+      return -1;
+    }
+    MovePoint(ret, tmp, 3);
+    if ((buf[i >> 3] >> (i & 7)) & 1) {
+      if (JacAdd(p, ret, point, tmp) < 0) {
+        for (int j = 0; j < 3; ++j) Py_DECREF(ret[j]);
+        return -1;
+      }
+      MovePoint(ret, tmp, 3);
+    }
+  }
+  out[0] = ret[0];
+  out[1] = ret[1];
+  out[2] = ret[2];
+  return 0;
 }
 
 // --- descriptor lifecycle ------------------------------------------------
@@ -844,6 +896,102 @@ bool AddCmpLoop(PyObject* numpy, const char* name,
   return rc >= 0;
 }
 
+// Scalar multiplication: np.multiply(scalar_field, point) and the reverse. The
+// output is the point's Ec dtype; the scalar field is the other operand.
+NPY_CASTING ScalarMulResolve(struct PyArrayMethodObject_tag* /*method*/,
+                             PyArray_DTypeMeta* const* /*dtypes*/,
+                             PyArray_Descr* const* given, PyArray_Descr** loop,
+                             npy_intp* view_offset) {
+  PyArray_Descr* point =
+      Py_TYPE(given[0]) == reinterpret_cast<PyTypeObject*>(&EcPointDType)
+          ? given[0]
+          : given[1];
+  Py_INCREF(given[0]);
+  loop[0] = given[0];
+  Py_INCREF(given[1]);
+  loop[1] = given[1];
+  loop[2] = given[2] != nullptr ? given[2] : point;
+  Py_INCREF(loop[2]);
+  *view_offset = NPY_MIN_INTP;
+  return NPY_NO_CASTING;
+}
+
+template <bool scalar_first>
+int ScalarMulLoop(PyArrayMethod_Context* context, char* const* data,
+                  const npy_intp* dimensions, const npy_intp* strides,
+                  NpyAuxData* /*aux*/) {
+  PyArray_Descr* scalar_descr = context->descriptors[scalar_first ? 0 : 1];
+  EcPointDescr* d = AsEc(context->descriptors[scalar_first ? 1 : 0]);
+  EcPointDescr* od = AsEc(context->descriptors[2]);
+  PyObject* p = d->modulus;
+  npy_intp n = dimensions[0];
+  char* s = data[scalar_first ? 0 : 1];
+  char* pt = data[scalar_first ? 1 : 0];
+  char* o = data[2];
+  npy_intp s_stride = strides[scalar_first ? 0 : 1];
+  npy_intp pt_stride = strides[scalar_first ? 1 : 0];
+  for (npy_intp i = 0; i < n; ++i) {
+    PyObject* scalar =
+        PrimeFieldValue(reinterpret_cast<PyObject*>(scalar_descr), s);
+    if (scalar == nullptr) return -1;
+    PyObject* P[kMaxCoords];
+    if (DecodePoint(d, pt, P) < 0) {
+      Py_DECREF(scalar);
+      return -1;
+    }
+    PyObject* R[3];
+    int rc = JacScalarMul(p, scalar, P, R);
+    Py_DECREF(scalar);
+    for (int j = 0; j < d->num_coords; ++j) Py_DECREF(P[j]);
+    if (rc < 0) return -1;
+    int erc = EncodePoint(od, o, R);
+    for (int j = 0; j < 3; ++j) Py_DECREF(R[j]);
+    if (erc < 0) return -1;
+    s += s_stride;
+    pt += pt_stride;
+    o += strides[2];
+  }
+  return 0;
+}
+
+bool AddScalarMulLoops(PyObject* numpy) {
+  PyObject* ufunc = PyObject_GetAttrString(numpy, "multiply");
+  if (ufunc == nullptr) return false;
+  PyArray_DTypeMeta* field =
+      reinterpret_cast<PyArray_DTypeMeta*>(FieldDTypeMetaObject());
+  bool ok = true;
+  for (int order = 0; order < 2 && ok; ++order) {
+    PyArray_DTypeMeta* dtypes[3];
+    PyType_Slot slots[] = {
+        {NPY_METH_resolve_descriptors,
+         reinterpret_cast<void*>(ScalarMulResolve)},
+        {NPY_METH_strided_loop,
+         reinterpret_cast<void*>(order == 0 ? ScalarMulLoop<true>
+                                            : ScalarMulLoop<false>)},
+        {0, nullptr},
+    };
+    if (order == 0) {  // scalar * point
+      dtypes[0] = field;
+      dtypes[1] = &EcPointDType;
+    } else {  // point * scalar
+      dtypes[0] = &EcPointDType;
+      dtypes[1] = field;
+    }
+    dtypes[2] = &EcPointDType;
+    PyArrayMethod_Spec spec = {};
+    spec.name = "ec_point_scalar_mul";
+    spec.nin = 2;
+    spec.nout = 1;
+    spec.casting = NPY_NO_CASTING;
+    spec.flags = NPY_METH_REQUIRES_PYAPI;
+    spec.dtypes = dtypes;
+    spec.slots = slots;
+    ok = PyUFunc_AddLoopFromSpec(ufunc, &spec) >= 0;
+  }
+  Py_DECREF(ufunc);
+  return ok;
+}
+
 }  // namespace
 
 bool RegisterEcPointDType(PyObject* /*numpy*/, PyObject* module) {
@@ -939,7 +1087,8 @@ bool RegisterEcPointDType(PyObject* /*numpy*/, PyObject* module) {
   bool ok = AddBinLoop(numpy, "add", BinLoop<BinOp::kAdd>) &&
             AddBinLoop(numpy, "subtract", BinLoop<BinOp::kSub>) &&
             AddNegLoop(numpy) && AddCmpLoop(numpy, "equal", CmpLoop<false>) &&
-            AddCmpLoop(numpy, "not_equal", CmpLoop<true>);
+            AddCmpLoop(numpy, "not_equal", CmpLoop<true>) &&
+            AddScalarMulLoops(numpy);
   Py_DECREF(numpy);
   return ok;
 }

--- a/zk_dtypes/_src/ec_point_dtype.cc
+++ b/zk_dtypes/_src/ec_point_dtype.cc
@@ -533,6 +533,25 @@ void MovePoint(PyObject** dst, PyObject* const* src, int n) {
   }
 }
 
+// Decodes a canonical scalar int into `buf` (little-endian, zero-padded) and
+// returns its bit length, or -1 (with an exception set) if it needs more than
+// buf_size bytes.
+Py_ssize_t ScalarToBytesLE(PyObject* scalar, unsigned char* buf,
+                           size_t buf_size) {
+  size_t nbits = _PyLong_NumBits(scalar);
+  size_t nbytes = (nbits + 7) / 8;
+  if (nbytes > buf_size) {
+    PyErr_SetString(PyExc_OverflowError, "EC scalar too large");
+    return -1;
+  }
+  std::memset(buf, 0, buf_size);
+  if (nbytes > 0) {
+    _PyLong_AsByteArray(reinterpret_cast<PyLongObject*>(scalar), buf, nbytes, 1,
+                        0);
+  }
+  return static_cast<Py_ssize_t>(nbits);
+}
+
 // MSB-first double-and-add: ret = scalar * point (canonical Jacobian coords).
 // The scalar is a canonical integer (Montgomery already decoded by the caller),
 // matching the legacy curve operator* which de-Montgomery's the scalar first.
@@ -543,19 +562,13 @@ int JacScalarMul(EcPointDescr* ec, PyObject* scalar, PyObject* const* point,
     for (int j = 0; j < 3; ++j) Py_XDECREF(ret[j]);
     return -1;
   }
-  size_t nbits = _PyLong_NumBits(scalar);
-  size_t nbytes = (nbits + 7) / 8;
-  unsigned char buf[64] = {0};
-  if (nbytes > sizeof(buf)) {
+  unsigned char buf[64];
+  Py_ssize_t nbits = ScalarToBytesLE(scalar, buf, sizeof(buf));
+  if (nbits < 0) {
     for (int j = 0; j < 3; ++j) Py_DECREF(ret[j]);
-    PyErr_SetString(PyExc_OverflowError, "EC scalar too large");
     return -1;
   }
-  if (nbytes > 0) {
-    _PyLong_AsByteArray(reinterpret_cast<PyLongObject*>(scalar), buf, nbytes, 1,
-                        0);
-  }
-  for (Py_ssize_t i = static_cast<Py_ssize_t>(nbits) - 1; i >= 0; --i) {
+  for (Py_ssize_t i = nbits - 1; i >= 0; --i) {
     PyObject* tmp[3];
     if (JacDouble(ec, ret, tmp) < 0) {
       for (int j = 0; j < 3; ++j) Py_DECREF(ret[j]);
@@ -583,6 +596,13 @@ int JacScalarMul(EcPointDescr* ec, PyObject* scalar, PyObject* const* point,
 // Montgomery space directly on the stored bytes (mont(x)*mont(y)*R^-1 =
 // mont(x*y); add/sub are linear; X^... = non_residue folds with mont(nr)), so
 // no decode/encode and no Python ints — byte-identical to the path above.
+//
+// These are byte-space twins of the PyObject Jac* functions: EcDouble<->
+// JacDouble, EcAdd<->JacAdd, EcNegate<->JacNegate, EcEqual<->JacEqual,
+// EcScalarMul<->JacScalarMul, CoordField::Mul (Fp2) <-> CMul. The two MUST stay
+// in lockstep — the Jac* versions are the canonical spec; a formula change must
+// be made in both (the byte-identity tests only catch divergence on the cases
+// they exercise).
 
 constexpr int kCoordBytes = 64;  // max coordinate: Fp2 over 256-bit base
 
@@ -611,6 +631,10 @@ struct CoordField {
     }
     cf.fq = modarith::PrimeField::Make(mod_le, cf.wb, /*is_mont=*/true);
     if (!cf.fq.native) return cf;
+    // The native EC temporaries are fixed kCoordBytes stack buffers (= 2*32,
+    // the Fp2-over-256-bit max). degree<=2 and a native base width<=32 keep cb
+    // in range; bail to the Python path otherwise rather than overflow.
+    if (cf.cb > kCoordBytes) return cf;
     if (_PyLong_AsByteArray(reinterpret_cast<PyLongObject*>(d->r_mod_p),
                             cf.one_le, cf.wb, 1, 0) < 0) {
       PyErr_Clear();
@@ -833,16 +857,15 @@ void EcScalarMul(const CoordField& cf, const unsigned char* point,
                  const unsigned char* sbytes, int nbits, unsigned char* out) {
   const int cb = cf.cb;
   unsigned char ret[3 * kCoordBytes];
-  unsigned char tmp[3 * kCoordBytes];
   cf.SetOne(ret);  // Jacobian zero = (1, 1, 0)
   cf.SetOne(ret + cb);
   cf.SetZero(ret + 2 * cb);
+  // EcDouble/EcAdd read all of their inputs before writing the result, so they
+  // accept out == in1 in place; no scratch point is needed.
   for (int i = nbits - 1; i >= 0; --i) {
-    EcDouble(cf, ret, tmp);
-    std::memcpy(ret, tmp, 3 * cb);
+    EcDouble(cf, ret, ret);
     if ((sbytes[i >> 3] >> (i & 7)) & 1) {
-      EcAdd(cf, ret, point, tmp);
-      std::memcpy(ret, tmp, 3 * cb);
+      EcAdd(cf, ret, point, ret);
     }
   }
   std::memcpy(out, ret, 3 * cb);
@@ -1621,19 +1644,10 @@ int ScalarMulLoop(PyArrayMethod_Context* context, char* const* data,
       PyObject* scalar =
           PrimeFieldValue(reinterpret_cast<PyObject*>(scalar_descr), s);
       if (scalar == nullptr) return -1;
-      size_t nbits = _PyLong_NumBits(scalar);
-      size_t nbytes = (nbits + 7) / 8;
-      unsigned char buf[64] = {0};
-      if (nbytes > sizeof(buf)) {
-        Py_DECREF(scalar);
-        PyErr_SetString(PyExc_OverflowError, "EC scalar too large");
-        return -1;
-      }
-      if (nbytes > 0) {
-        _PyLong_AsByteArray(reinterpret_cast<PyLongObject*>(scalar), buf,
-                            nbytes, 1, 0);
-      }
+      unsigned char buf[64];
+      Py_ssize_t nbits = ScalarToBytesLE(scalar, buf, sizeof(buf));
       Py_DECREF(scalar);
+      if (nbits < 0) return -1;
       EcScalarMul(cf, reinterpret_cast<const unsigned char*>(pt), buf,
                   static_cast<int>(nbits), reinterpret_cast<unsigned char*>(o));
       s += s_stride;

--- a/zk_dtypes/_src/ec_point_dtype.cc
+++ b/zk_dtypes/_src/ec_point_dtype.cc
@@ -36,8 +36,9 @@ limitations under the License.
 #include <cstdint>
 #include <cstring>
 
-#include "zk_dtypes/_src/numpy.h"
 #include "zk_dtypes/_src/field_dtype.h"
+#include "zk_dtypes/_src/field_modarith.h"
+#include "zk_dtypes/_src/numpy.h"
 #include "numpy/dtype_api.h"
 #include "numpy/ndarraytypes.h"
 // clang-format on
@@ -575,6 +576,276 @@ int JacScalarMul(EcPointDescr* ec, PyObject* scalar, PyObject* const* point,
   return 0;
 }
 
+// --- native fixed-width group law ----------------------------------------
+// The Python-int group law above is correct but allocates a CPython int per
+// coordinate operation. For Montgomery-stored points over a coordinate field
+// whose base width the native kernels handle, run the identical EFD formulas in
+// Montgomery space directly on the stored bytes (mont(x)*mont(y)*R^-1 =
+// mont(x*y); add/sub are linear; X^... = non_residue folds with mont(nr)), so
+// no decode/encode and no Python ints — byte-identical to the path above.
+
+constexpr int kCoordBytes = 64;  // max coordinate: Fp2 over 256-bit base
+
+// One coordinate field (Fq for G1, Fp2 for G2) over a Montgomery base field.
+struct CoordField {
+  modarith::PrimeField fq;
+  int degree = 1;                   // 1 = Fq, 2 = Fp2
+  int wb = 0;                       // base-field width in bytes
+  int cb = 0;                       // coordinate width = degree * wb
+  bool ok = false;                  // native path usable for this descriptor
+  unsigned char one_le[32] = {0};   // mont(1) = R mod p
+  unsigned char mont_nr[32] = {0};  // mont(non_residue), Fp2 only
+
+  static CoordField Make(EcPointDescr* d) {
+    CoordField cf;
+    if (!d->is_montgomery) return cf;  // native group law is Montgomery-only
+    cf.wb = d->base_width_bytes;
+    cf.degree = d->coord_degree;
+    cf.cb = cf.degree * cf.wb;
+    if (cf.degree < 1 || cf.degree > 2) return cf;
+    unsigned char mod_le[32];
+    if (_PyLong_AsByteArray(reinterpret_cast<PyLongObject*>(d->modulus), mod_le,
+                            cf.wb, 1, 0) < 0) {
+      PyErr_Clear();
+      return cf;
+    }
+    cf.fq = modarith::PrimeField::Make(mod_le, cf.wb, /*is_mont=*/true);
+    if (!cf.fq.native) return cf;
+    if (_PyLong_AsByteArray(reinterpret_cast<PyLongObject*>(d->r_mod_p),
+                            cf.one_le, cf.wb, 1, 0) < 0) {
+      PyErr_Clear();
+      return cf;
+    }
+    if (cf.degree == 2) {
+      // mont(nr) = nr * R mod p; computed once here in Python, then native.
+      PyObject* scaled = PyNumber_Multiply(d->non_residue, d->r_mod_p);
+      PyObject* mn = scaled ? PyNumber_Remainder(scaled, d->modulus) : nullptr;
+      Py_XDECREF(scaled);
+      if (mn == nullptr ||
+          _PyLong_AsByteArray(reinterpret_cast<PyLongObject*>(mn), cf.mont_nr,
+                              cf.wb, 1, 0) < 0) {
+        Py_XDECREF(mn);
+        PyErr_Clear();
+        return cf;
+      }
+      Py_DECREF(mn);
+    }
+    cf.ok = true;
+    return cf;
+  }
+
+  bool IsZero(const unsigned char* a) const {
+    for (int i = 0; i < cb; ++i) {
+      if (a[i] != 0) return false;
+    }
+    return true;
+  }
+  bool Equal(const unsigned char* a, const unsigned char* b) const {
+    return std::memcmp(a, b, cb) == 0;
+  }
+  void SetZero(unsigned char* o) const { std::memset(o, 0, cb); }
+  void SetOne(unsigned char* o) const {  // (mont(1), 0)
+    std::memset(o, 0, cb);
+    std::memcpy(o, one_le, wb);
+  }
+  void Add(const unsigned char* a, const unsigned char* b,
+           unsigned char* o) const {
+    for (int k = 0; k < degree; ++k) {
+      fq.Add(a + k * wb, b + k * wb, o + k * wb);
+    }
+  }
+  void Sub(const unsigned char* a, const unsigned char* b,
+           unsigned char* o) const {
+    for (int k = 0; k < degree; ++k) {
+      fq.Sub(a + k * wb, b + k * wb, o + k * wb);
+    }
+  }
+  void Neg(const unsigned char* a, unsigned char* o) const {  // p - a per coeff
+    unsigned char zero[32] = {0};
+    for (int k = 0; k < degree; ++k) {
+      fq.Sub(zero, a + k * wb, o + k * wb);
+    }
+  }
+  void Mul(const unsigned char* a, const unsigned char* b,
+           unsigned char* o) const {
+    if (degree == 1) {
+      fq.Mul(a, b, o);
+      return;
+    }
+    // Fp2: (a0+a1 u)(b0+b1 u) = (a0 b0 + nr a1 b1) + (a0 b1 + a1 b0) u.
+    const unsigned char* a0 = a;
+    const unsigned char* a1 = a + wb;
+    const unsigned char* b0 = b;
+    const unsigned char* b1 = b + wb;
+    unsigned char a0b0[32], a1b1[32], nra1b1[32], a0b1[32], a1b0[32];
+    unsigned char c0[32], c1[32];
+    fq.Mul(a0, b0, a0b0);
+    fq.Mul(a1, b1, a1b1);
+    fq.Mul(mont_nr, a1b1, nra1b1);
+    fq.Add(a0b0, nra1b1, c0);
+    fq.Mul(a0, b1, a0b1);
+    fq.Mul(a1, b0, a1b0);
+    fq.Add(a0b1, a1b0, c1);
+    std::memcpy(o, c0, wb);
+    std::memcpy(o + wb, c1, wb);
+  }
+  void MulInt(const unsigned char* a, int k, unsigned char* o) const {
+    std::memcpy(o, a, cb);  // 1*a
+    for (int j = 1; j < k; ++j) Add(o, a, o);
+  }
+};
+
+// Jacobian doubling (EFD dbl-2009-l, a == 0); 3 coords. out may alias in.
+void EcDouble(const CoordField& cf, const unsigned char* in,
+              unsigned char* out) {
+  const int cb = cf.cb;
+  const unsigned char* X = in;
+  const unsigned char* Y = in + cb;
+  const unsigned char* Z = in + 2 * cb;
+  unsigned char xx[kCoordBytes], yy[kCoordBytes], yyyy[kCoordBytes];
+  unsigned char xyy[kCoordBytes], dd[kCoordBytes], e[kCoordBytes];
+  unsigned char ee[kCoordBytes], twod[kCoordBytes], X2[kCoordBytes];
+  unsigned char dmx[kCoordBytes], edmx[kCoordBytes], eightyyyy[kCoordBytes];
+  unsigned char Y2[kCoordBytes], yz[kCoordBytes], Z2[kCoordBytes];
+  cf.Mul(X, X, xx);
+  cf.Mul(Y, Y, yy);
+  cf.Mul(yy, yy, yyyy);
+  cf.Mul(X, yy, xyy);
+  cf.MulInt(xyy, 4, dd);
+  cf.MulInt(xx, 3, e);
+  cf.Mul(e, e, ee);
+  cf.MulInt(dd, 2, twod);
+  cf.Sub(ee, twod, X2);
+  cf.Sub(dd, X2, dmx);
+  cf.Mul(e, dmx, edmx);
+  cf.MulInt(yyyy, 8, eightyyyy);
+  cf.Sub(edmx, eightyyyy, Y2);
+  cf.Mul(Y, Z, yz);
+  cf.MulInt(yz, 2, Z2);
+  std::memcpy(out, X2, cb);
+  std::memcpy(out + cb, Y2, cb);
+  std::memcpy(out + 2 * cb, Z2, cb);
+}
+
+// Jacobian addition (EFD add-2007-bl, a == 0); 3 coords. out must not alias.
+void EcAdd(const CoordField& cf, const unsigned char* P, const unsigned char* Q,
+           unsigned char* out) {
+  const int cb = cf.cb;
+  const unsigned char* Z1 = P + 2 * cb;
+  const unsigned char* Z2 = Q + 2 * cb;
+  if (cf.IsZero(Z1)) {
+    std::memcpy(out, Q, 3 * cb);
+    return;
+  }
+  if (cf.IsZero(Z2)) {
+    std::memcpy(out, P, 3 * cb);
+    return;
+  }
+  const unsigned char* X1 = P;
+  const unsigned char* Y1 = P + cb;
+  const unsigned char* X2 = Q;
+  const unsigned char* Y2 = Q + cb;
+  unsigned char z1z1[kCoordBytes], z2z2[kCoordBytes], u1[kCoordBytes];
+  unsigned char u2[kCoordBytes], yz2[kCoordBytes], s1[kCoordBytes];
+  unsigned char yz1[kCoordBytes], s2[kCoordBytes];
+  cf.Mul(Z1, Z1, z1z1);
+  cf.Mul(Z2, Z2, z2z2);
+  cf.Mul(X1, z2z2, u1);
+  cf.Mul(X2, z1z1, u2);
+  cf.Mul(Y1, Z2, yz2);
+  cf.Mul(yz2, z2z2, s1);
+  cf.Mul(Y2, Z1, yz1);
+  cf.Mul(yz1, z1z1, s2);
+  if (cf.Equal(u1, u2) && cf.Equal(s1, s2)) {  // P == Q
+    EcDouble(cf, P, out);
+    return;
+  }
+  unsigned char h[kCoordBytes], twoh[kCoordBytes], ii[kCoordBytes];
+  unsigned char hi[kCoordBytes], j[kCoordBytes], sdiff[kCoordBytes];
+  unsigned char r[kCoordBytes], v[kCoordBytes], rr[kCoordBytes];
+  unsigned char twov[kCoordBytes], rrj[kCoordBytes], X3[kCoordBytes];
+  unsigned char vmx[kCoordBytes], rvmx[kCoordBytes], s1j[kCoordBytes];
+  unsigned char twos1j[kCoordBytes], Y3[kCoordBytes], z1z2[kCoordBytes];
+  unsigned char z1z2h[kCoordBytes], Z3[kCoordBytes];
+  cf.Sub(u2, u1, h);
+  cf.MulInt(h, 2, twoh);
+  cf.Mul(twoh, twoh, ii);
+  cf.Mul(h, ii, hi);
+  cf.Neg(hi, j);
+  cf.Sub(s2, s1, sdiff);
+  cf.MulInt(sdiff, 2, r);
+  cf.Mul(u1, ii, v);
+  cf.Mul(r, r, rr);
+  cf.MulInt(v, 2, twov);
+  cf.Add(rr, j, rrj);
+  cf.Sub(rrj, twov, X3);  // r^2 + j - 2v
+  cf.Sub(v, X3, vmx);
+  cf.Mul(r, vmx, rvmx);
+  cf.Mul(s1, j, s1j);
+  cf.MulInt(s1j, 2, twos1j);
+  cf.Add(rvmx, twos1j, Y3);  // r(v - X3) + 2 s1 j
+  cf.Mul(Z1, Z2, z1z2);
+  cf.Mul(z1z2, h, z1z2h);
+  cf.MulInt(z1z2h, 2, Z3);  // 2 Z1 Z2 h
+  std::memcpy(out, X3, cb);
+  std::memcpy(out + cb, Y3, cb);
+  std::memcpy(out + 2 * cb, Z3, cb);
+}
+
+void EcNegate(const CoordField& cf, const unsigned char* in, unsigned char* out,
+              int num_coords) {
+  const int cb = cf.cb;
+  for (int i = 0; i < num_coords; ++i) {
+    if (i == 1) {
+      cf.Neg(in + cb, out + cb);
+    } else {
+      std::memcpy(out + i * cb, in + i * cb, cb);
+    }
+  }
+}
+
+// Cross-representative group equality of two Jacobian points; 1 / 0.
+int EcEqual(const CoordField& cf, const unsigned char* P,
+            const unsigned char* Q) {
+  const int cb = cf.cb;
+  bool pz = cf.IsZero(P + 2 * cb);
+  bool qz = cf.IsZero(Q + 2 * cb);
+  if (pz || qz) return (pz && qz) ? 1 : 0;
+  unsigned char z1s[kCoordBytes], z2s[kCoordBytes], lx[kCoordBytes];
+  unsigned char rx[kCoordBytes], z1c[kCoordBytes], z2c[kCoordBytes];
+  unsigned char ly[kCoordBytes], ry[kCoordBytes];
+  cf.Mul(P + 2 * cb, P + 2 * cb, z1s);
+  cf.Mul(Q + 2 * cb, Q + 2 * cb, z2s);
+  cf.Mul(P, z2s, lx);
+  cf.Mul(Q, z1s, rx);
+  cf.Mul(z1s, P + 2 * cb, z1c);
+  cf.Mul(z2s, Q + 2 * cb, z2c);
+  cf.Mul(P + cb, z2c, ly);
+  cf.Mul(Q + cb, z1c, ry);
+  return (cf.Equal(lx, rx) && cf.Equal(ly, ry)) ? 1 : 0;
+}
+
+// ret = scalar * point, MSB-first double-and-add; scalar as little-endian
+// bytes.
+void EcScalarMul(const CoordField& cf, const unsigned char* point,
+                 const unsigned char* sbytes, int nbits, unsigned char* out) {
+  const int cb = cf.cb;
+  unsigned char ret[3 * kCoordBytes];
+  unsigned char tmp[3 * kCoordBytes];
+  cf.SetOne(ret);  // Jacobian zero = (1, 1, 0)
+  cf.SetOne(ret + cb);
+  cf.SetZero(ret + 2 * cb);
+  for (int i = nbits - 1; i >= 0; --i) {
+    EcDouble(cf, ret, tmp);
+    std::memcpy(ret, tmp, 3 * cb);
+    if ((sbytes[i >> 3] >> (i & 7)) & 1) {
+      EcAdd(cf, ret, point, tmp);
+      std::memcpy(ret, tmp, 3 * cb);
+    }
+  }
+  std::memcpy(out, ret, 3 * cb);
+}
+
 // --- descriptor lifecycle ------------------------------------------------
 
 PyArray_Descr* MakeDescr(PyObject* modulus, int base_width_bytes,
@@ -1041,6 +1312,25 @@ int BinLoop(PyArrayMethod_Context* context, char* const* data,
   char* a = data[0];
   char* b = data[1];
   char* o = data[2];
+  CoordField cf = CoordField::Make(d);
+  if (cf.ok) {  // num_coords == 3 guaranteed by BinResolve
+    unsigned char neg_q[3 * kCoordBytes];
+    for (npy_intp i = 0; i < n; ++i) {
+      const auto* ua = reinterpret_cast<const unsigned char*>(a);
+      const auto* ub = reinterpret_cast<const unsigned char*>(b);
+      auto* uo = reinterpret_cast<unsigned char*>(o);
+      if (op == BinOp::kSub) {
+        EcNegate(cf, ub, neg_q, 3);
+        EcAdd(cf, ua, neg_q, uo);
+      } else {
+        EcAdd(cf, ua, ub, uo);
+      }
+      a += strides[0];
+      b += strides[1];
+      o += strides[2];
+    }
+    return 0;
+  }
   for (npy_intp i = 0; i < n; ++i) {
     PyObject* P[kMaxCoords];
     PyObject* Q[kMaxCoords];
@@ -1083,6 +1373,16 @@ int NegLoop(PyArrayMethod_Context* context, char* const* data,
   npy_intp n = dimensions[0];
   char* a = data[0];
   char* o = data[1];
+  CoordField cf = CoordField::Make(d);
+  if (cf.ok) {
+    for (npy_intp i = 0; i < n; ++i) {
+      EcNegate(cf, reinterpret_cast<const unsigned char*>(a),
+               reinterpret_cast<unsigned char*>(o), d->num_coords);
+      a += strides[0];
+      o += strides[1];
+    }
+    return 0;
+  }
   for (npy_intp i = 0; i < n; ++i) {
     PyObject* P[kMaxCoords];
     PyObject* R[kMaxCoords];
@@ -1184,6 +1484,18 @@ int CmpLoop(PyArrayMethod_Context* context, char* const* data,
   char* a = data[0];
   char* b = data[1];
   char* o = data[2];
+  CoordField cf = CoordField::Make(d);
+  if (cf.ok) {  // num_coords == 3 guaranteed by CmpResolve
+    for (npy_intp i = 0; i < n; ++i) {
+      int eq = EcEqual(cf, reinterpret_cast<const unsigned char*>(a),
+                       reinterpret_cast<const unsigned char*>(b));
+      *reinterpret_cast<npy_bool*>(o) = (negate ? !eq : eq) ? 1 : 0;
+      a += strides[0];
+      b += strides[1];
+      o += strides[2];
+    }
+    return 0;
+  }
   for (npy_intp i = 0; i < n; ++i) {
     PyObject* P[kMaxCoords];
     PyObject* Q[kMaxCoords];
@@ -1271,6 +1583,33 @@ int ScalarMulLoop(PyArrayMethod_Context* context, char* const* data,
   char* o = data[2];
   npy_intp s_stride = strides[scalar_first ? 0 : 1];
   npy_intp pt_stride = strides[scalar_first ? 1 : 0];
+  CoordField cf = CoordField::Make(d);
+  if (cf.ok && d->num_coords == 3) {
+    for (npy_intp i = 0; i < n; ++i) {
+      PyObject* scalar =
+          PrimeFieldValue(reinterpret_cast<PyObject*>(scalar_descr), s);
+      if (scalar == nullptr) return -1;
+      size_t nbits = _PyLong_NumBits(scalar);
+      size_t nbytes = (nbits + 7) / 8;
+      unsigned char buf[64] = {0};
+      if (nbytes > sizeof(buf)) {
+        Py_DECREF(scalar);
+        PyErr_SetString(PyExc_OverflowError, "EC scalar too large");
+        return -1;
+      }
+      if (nbytes > 0) {
+        _PyLong_AsByteArray(reinterpret_cast<PyLongObject*>(scalar), buf,
+                            nbytes, 1, 0);
+      }
+      Py_DECREF(scalar);
+      EcScalarMul(cf, reinterpret_cast<const unsigned char*>(pt), buf,
+                  static_cast<int>(nbits), reinterpret_cast<unsigned char*>(o));
+      s += s_stride;
+      pt += pt_stride;
+      o += strides[2];
+    }
+    return 0;
+  }
   for (npy_intp i = 0; i < n; ++i) {
     PyObject* scalar =
         PrimeFieldValue(reinterpret_cast<PyObject*>(scalar_descr), s);

--- a/zk_dtypes/_src/ec_point_dtype.cc
+++ b/zk_dtypes/_src/ec_point_dtype.cc
@@ -326,6 +326,43 @@ int JacNegate(PyObject* p, PyObject* const* in, PyObject** out) {
   return 0;
 }
 
+// Group equality (cross-representative): a Jacobian point has many byte
+// encodings for one group element. Returns 1 if P == Q as group elements,
+// 0 if not, -1 on error. Both infinity -> equal; one infinity -> not equal;
+// else x1*z2^2 == x2*z1^2 and y1*z2^3 == y2*z1^3.
+int JacEqual(PyObject* p, PyObject* const* P, PyObject* const* Q) {
+  bool pz = IsZeroCoord(P[2]);
+  bool qz = IsZeroCoord(Q[2]);
+  if (pz || qz) {
+    return (pz && qz) ? 1 : 0;
+  }
+  int result = -1;
+  PyObject* z1s = FMul(p, P[2], P[2]);  // z1^2
+  PyObject* z2s = FMul(p, Q[2], Q[2]);  // z2^2
+  PyObject* lx = z2s ? FMul(p, P[0], z2s) : nullptr;
+  PyObject* rx = z1s ? FMul(p, Q[0], z1s) : nullptr;
+  PyObject* z1c = z1s ? FMul(p, z1s, P[2]) : nullptr;  // z1^3
+  PyObject* z2c = z2s ? FMul(p, z2s, Q[2]) : nullptr;  // z2^3
+  PyObject* ly = z2c ? FMul(p, P[1], z2c) : nullptr;
+  PyObject* ry = z1c ? FMul(p, Q[1], z1c) : nullptr;
+  if (lx && rx && ly && ry) {
+    int xe = PyObject_RichCompareBool(lx, rx, Py_EQ);
+    int ye = PyObject_RichCompareBool(ly, ry, Py_EQ);
+    if (xe >= 0 && ye >= 0) {
+      result = (xe == 1 && ye == 1) ? 1 : 0;
+    }
+  }
+  Py_XDECREF(z1s);
+  Py_XDECREF(z2s);
+  Py_XDECREF(lx);
+  Py_XDECREF(rx);
+  Py_XDECREF(z1c);
+  Py_XDECREF(z2c);
+  Py_XDECREF(ly);
+  Py_XDECREF(ry);
+  return result;
+}
+
 // --- descriptor lifecycle ------------------------------------------------
 
 PyArray_Descr* MakeDescr(PyObject* modulus, int base_width_bytes,
@@ -724,6 +761,89 @@ bool AddNegLoop(PyObject* numpy) {
   return rc >= 0;
 }
 
+// Comparison: (point, point) -> bool. Inputs share a curve; output is bool.
+NPY_CASTING CmpResolve(struct PyArrayMethodObject_tag* /*method*/,
+                       PyArray_DTypeMeta* const* /*dtypes*/,
+                       PyArray_Descr* const* given, PyArray_Descr** loop,
+                       npy_intp* view_offset) {
+  if (!SameCurve(AsEc(given[0]), AsEc(given[1]))) {
+    PyErr_SetString(PyExc_TypeError,
+                    "point comparison requires the same curve");
+    return static_cast<NPY_CASTING>(-1);
+  }
+  Py_INCREF(given[0]);
+  loop[0] = given[0];
+  Py_INCREF(given[1]);
+  loop[1] = given[1];
+  loop[2] = given[2] != nullptr ? given[2] : PyArray_DescrFromType(NPY_BOOL);
+  if (loop[2] == nullptr) {
+    return static_cast<NPY_CASTING>(-1);
+  }
+  if (given[2] != nullptr) {
+    Py_INCREF(loop[2]);
+  }
+  *view_offset = NPY_MIN_INTP;
+  return NPY_NO_CASTING;
+}
+
+template <bool negate>
+int CmpLoop(PyArrayMethod_Context* context, char* const* data,
+            const npy_intp* dimensions, const npy_intp* strides,
+            NpyAuxData* /*aux*/) {
+  EcPointDescr* d = AsEc(context->descriptors[0]);
+  PyObject* p = d->modulus;
+  npy_intp n = dimensions[0];
+  char* a = data[0];
+  char* b = data[1];
+  char* o = data[2];
+  for (npy_intp i = 0; i < n; ++i) {
+    PyObject* P[kMaxCoords];
+    PyObject* Q[kMaxCoords];
+    if (DecodePoint(d, a, P) < 0) return -1;
+    if (DecodePoint(d, b, Q) < 0) {
+      for (int j = 0; j < d->num_coords; ++j) Py_DECREF(P[j]);
+      return -1;
+    }
+    int eq = JacEqual(p, P, Q);
+    for (int j = 0; j < d->num_coords; ++j) {
+      Py_DECREF(P[j]);
+      Py_DECREF(Q[j]);
+    }
+    if (eq < 0) return -1;
+    *reinterpret_cast<npy_bool*>(o) = (negate ? !eq : eq) ? 1 : 0;
+    a += strides[0];
+    b += strides[1];
+    o += strides[2];
+  }
+  return 0;
+}
+
+bool AddCmpLoop(PyObject* numpy, const char* name,
+                PyArrayMethod_StridedLoop* loop) {
+  PyObject* ufunc = PyObject_GetAttrString(numpy, name);
+  if (ufunc == nullptr) return false;
+  PyArray_DTypeMeta* booldt =
+      reinterpret_cast<PyArray_DTypeMeta*>(Py_TYPE(PyArray_DescrFromType(
+          NPY_BOOL)));  // borrowed: builtin bool descr/DType are immortal
+  PyArray_DTypeMeta* dtypes[3] = {&EcPointDType, &EcPointDType, booldt};
+  PyType_Slot slots[] = {
+      {NPY_METH_resolve_descriptors, reinterpret_cast<void*>(CmpResolve)},
+      {NPY_METH_strided_loop, reinterpret_cast<void*>(loop)},
+      {0, nullptr},
+  };
+  PyArrayMethod_Spec spec = {};
+  spec.name = "ec_point_compare";
+  spec.nin = 2;
+  spec.nout = 1;
+  spec.casting = NPY_NO_CASTING;
+  spec.flags = NPY_METH_REQUIRES_PYAPI;
+  spec.dtypes = dtypes;
+  spec.slots = slots;
+  int rc = PyUFunc_AddLoopFromSpec(ufunc, &spec);
+  Py_DECREF(ufunc);
+  return rc >= 0;
+}
+
 }  // namespace
 
 bool RegisterEcPointDType(PyObject* /*numpy*/, PyObject* module) {
@@ -818,7 +938,8 @@ bool RegisterEcPointDType(PyObject* /*numpy*/, PyObject* module) {
   }
   bool ok = AddBinLoop(numpy, "add", BinLoop<BinOp::kAdd>) &&
             AddBinLoop(numpy, "subtract", BinLoop<BinOp::kSub>) &&
-            AddNegLoop(numpy);
+            AddNegLoop(numpy) && AddCmpLoop(numpy, "equal", CmpLoop<false>) &&
+            AddCmpLoop(numpy, "not_equal", CmpLoop<true>);
   Py_DECREF(numpy);
   return ok;
 }

--- a/zk_dtypes/_src/ec_point_dtype.cc
+++ b/zk_dtypes/_src/ec_point_dtype.cc
@@ -162,6 +162,17 @@ PyObject* FMulInt(PyObject* p, PyObject* a, long k) {
   return r;
 }
 
+// Field inverse via Fermat: x^(p-2) mod p (p prime). x must be nonzero.
+PyObject* FInv(PyObject* p, PyObject* x) {
+  PyObject* two = PyLong_FromLong(2);
+  PyObject* pm2 = two ? PyNumber_Subtract(p, two) : nullptr;
+  Py_XDECREF(two);
+  if (pm2 == nullptr) return nullptr;
+  PyObject* r = PyNumber_Power(x, pm2, p);  // 3-arg pow == modular exponent
+  Py_DECREF(pm2);
+  return r;
+}
+
 bool IsZeroCoord(PyObject* x) { return PyObject_IsTrue(x) == 0; }
 
 // Jacobian doubling, a == 0 (EFD dbl-2009-l). in/out: 3 canonical coords.
@@ -564,7 +575,138 @@ PyObject* GetItem(PyArray_Descr* descr, char* dataptr) {
   return tuple;
 }
 
-// --- within-DType copy cast ---------------------------------------------
+// Same curve and coordinate field, ignoring the representation (coord count).
+bool SameCurveField(EcPointDescr* a, EcPointDescr* b) {
+  return a->base_width_bytes == b->base_width_bytes &&
+         a->is_montgomery == b->is_montgomery &&
+         PyObject_RichCompareBool(a->modulus, b->modulus, Py_EQ) == 1;
+}
+
+PyObject* One() { return PyLong_FromLong(1); }
+PyObject* ZeroL() { return PyLong_FromLong(0); }
+
+// Converts a point between coordinate representations (canonical coords
+// in/out). num_coords: affine 2, Jacobian 3, xyzz 4. Jacobian<->xyzz keep the
+// projective coordinates (legacy direct formulas); the rest go through affine
+// (needs a field inverse), matching the legacy registered casts byte-for-byte.
+int ConvertRep(PyObject* p, int fn, int tn, PyObject* const* in,
+               PyObject** out) {
+  if (fn == tn) {
+    CopyPoint(in, out, fn);
+    return 0;
+  }
+  if (fn == 3 && tn == 4) {  // jac (X,Y,Z) -> xyzz (X,Y,Z^2,Z^3)
+    PyObject* z2 = FMul(p, in[2], in[2]);
+    PyObject* z3 = z2 ? FMul(p, z2, in[2]) : nullptr;
+    if (!z2 || !z3) {
+      Py_XDECREF(z2);
+      Py_XDECREF(z3);
+      return -1;
+    }
+    Py_INCREF(in[0]);
+    out[0] = in[0];
+    Py_INCREF(in[1]);
+    out[1] = in[1];
+    out[2] = z2;
+    out[3] = z3;
+    return 0;
+  }
+  if (fn == 4 && tn == 3) {  // xyzz (X,Y,ZZ,ZZZ) -> jac (X,Y,ZZZ/ZZ)
+    if (IsZeroCoord(in[2])) {
+      out[0] = One();
+      out[1] = One();
+      out[2] = ZeroL();
+      if (!out[0] || !out[1] || !out[2]) {
+        Py_XDECREF(out[0]);
+        Py_XDECREF(out[1]);
+        Py_XDECREF(out[2]);
+        return -1;
+      }
+      return 0;
+    }
+    PyObject* zzinv = FInv(p, in[2]);
+    PyObject* z = zzinv ? FMul(p, in[3], zzinv) : nullptr;
+    Py_XDECREF(zzinv);
+    if (!z) return -1;
+    Py_INCREF(in[0]);
+    out[0] = in[0];
+    Py_INCREF(in[1]);
+    out[1] = in[1];
+    out[2] = z;
+    return 0;
+  }
+  // Remaining pairs route through affine (x, y).
+  PyObject* ax = nullptr;
+  PyObject* ay = nullptr;
+  bool inf = false;
+  if (fn == 2) {
+    inf = IsZeroCoord(in[0]) && IsZeroCoord(in[1]);
+    Py_INCREF(in[0]);
+    ax = in[0];
+    Py_INCREF(in[1]);
+    ay = in[1];
+  } else if (fn == 3) {  // jac -> affine
+    if (IsZeroCoord(in[2])) {
+      inf = true;
+    } else {
+      PyObject* zi = FInv(p, in[2]);
+      PyObject* z2 = zi ? FMul(p, zi, zi) : nullptr;
+      PyObject* z3 = z2 ? FMul(p, z2, zi) : nullptr;
+      ax = z2 ? FMul(p, in[0], z2) : nullptr;
+      ay = z3 ? FMul(p, in[1], z3) : nullptr;
+      Py_XDECREF(zi);
+      Py_XDECREF(z2);
+      Py_XDECREF(z3);
+    }
+  } else {  // xyzz -> affine
+    if (IsZeroCoord(in[2])) {
+      inf = true;
+    } else {
+      PyObject* zzi = FInv(p, in[2]);
+      PyObject* zzzi = FInv(p, in[3]);
+      ax = zzi ? FMul(p, in[0], zzi) : nullptr;
+      ay = zzzi ? FMul(p, in[1], zzzi) : nullptr;
+      Py_XDECREF(zzi);
+      Py_XDECREF(zzzi);
+    }
+  }
+  if (!inf && (!ax || !ay)) {
+    Py_XDECREF(ax);
+    Py_XDECREF(ay);
+    return -1;
+  }
+  int rc = 0;
+  if (inf) {
+    Py_XDECREF(ax);
+    Py_XDECREF(ay);
+    if (tn == 2) {
+      out[0] = ZeroL();
+      out[1] = ZeroL();
+    } else {
+      out[0] = One();
+      out[1] = One();
+      out[2] = ZeroL();
+      if (tn == 4) out[3] = ZeroL();
+    }
+    for (int i = 0; i < tn; ++i) {
+      if (!out[i]) rc = -1;
+    }
+  } else {
+    out[0] = ax;
+    out[1] = ay;
+    if (tn >= 3) out[2] = One();
+    if (tn == 4) out[3] = One();
+    for (int i = 2; i < tn; ++i) {
+      if (!out[i]) rc = -1;
+    }
+  }
+  if (rc < 0) {
+    for (int i = 0; i < tn; ++i) Py_XDECREF(out[i]);
+  }
+  return rc;
+}
+
+// --- within-DType cast (copy + representation conversion) ----------------
 
 NPY_CASTING CastResolve(struct PyArrayMethodObject_tag* /*method*/,
                         PyArray_DTypeMeta* const* /*dtypes*/,
@@ -586,18 +728,37 @@ NPY_CASTING CastResolve(struct PyArrayMethodObject_tag* /*method*/,
     *view_offset = 0;
     return NPY_NO_CASTING;
   }
-  return NPY_UNSAFE_CASTING;
+  return NPY_UNSAFE_CASTING;  // same field, different representation
 }
 
 int CastLoop(PyArrayMethod_Context* context, char* const* data,
              const npy_intp* dimensions, const npy_intp* strides,
              NpyAuxData* /*aux*/) {
+  EcPointDescr* from = AsEc(context->descriptors[0]);
+  EcPointDescr* to = AsEc(context->descriptors[1]);
   npy_intp n = dimensions[0];
   char* in = data[0];
   char* out = data[1];
-  npy_intp elsize = context->descriptors[0]->elsize;
+  if (from->num_coords == to->num_coords) {
+    npy_intp elsize = context->descriptors[0]->elsize;
+    for (npy_intp i = 0; i < n; ++i) {
+      std::memcpy(out, in, elsize);
+      in += strides[0];
+      out += strides[1];
+    }
+    return 0;
+  }
+  PyObject* p = from->modulus;
   for (npy_intp i = 0; i < n; ++i) {
-    std::memcpy(out, in, elsize);
+    PyObject* src[kMaxCoords];
+    PyObject* dst[kMaxCoords];
+    if (DecodePoint(from, in, src) < 0) return -1;
+    int rc = ConvertRep(p, from->num_coords, to->num_coords, src, dst);
+    for (int j = 0; j < from->num_coords; ++j) Py_DECREF(src[j]);
+    if (rc < 0) return -1;
+    int erc = EncodePoint(to, out, dst);
+    for (int j = 0; j < to->num_coords; ++j) Py_DECREF(dst[j]);
+    if (erc < 0) return -1;
     in += strides[0];
     out += strides[1];
   }

--- a/zk_dtypes/_src/ec_point_dtype.cc
+++ b/zk_dtypes/_src/ec_point_dtype.cc
@@ -49,11 +49,14 @@ constexpr int kMaxCoords = 4;
 
 struct EcPointDescr {
   PyArray_Descr base;
-  PyObject* modulus;  // owned: coordinate prime field modulus
+  PyObject* modulus;  // owned: base prime field modulus
   PyObject* r_mod_p;  // owned (Montgomery): R = 2^base_width mod p; else NULL
   PyObject* rinv_mod_p;  // owned (Montgomery): R^-1 mod p; else NULL
+  // Coordinate field: prime (G1, degree 1) or Fp2 (G2, degree 2, u^2 = nr).
+  PyObject* non_residue;  // owned (degree 2): the Fp2 non-residue; else NULL
+  uint8_t coord_degree;   // 1 = G1 (Fq), 2 = G2 (Fp2)
   uint8_t base_width_bytes;
-  uint8_t num_coords;  // 3 for Jacobian (X, Y, Z)
+  uint8_t num_coords;  // 2 affine, 3 Jacobian, 4 xyzz
   uint8_t is_montgomery;
 };
 
@@ -64,9 +67,12 @@ EcPointDescr* AsEc(PyArray_Descr* d) {
   return reinterpret_cast<EcPointDescr*>(d);
 }
 
-// --- coordinate (prime field) encode / decode ---------------------------
+// --- coordinate encode / decode -----------------------------------------
+// A coordinate is one base-field element (G1) or `coord_degree` of them packed
+// low-to-high (G2 Fp2 = c0,c1). Its decoded value is a canonical int (degree 1)
+// or a tuple of canonical ints (degree > 1).
 
-PyObject* DecodeCoord(EcPointDescr* d, const char* slot) {
+PyObject* DecodeBase(EcPointDescr* d, const char* slot) {
   PyObject* stored = _PyLong_FromByteArray(
       reinterpret_cast<const unsigned char*>(slot), d->base_width_bytes, 1, 0);
   if (stored == nullptr || !d->is_montgomery) {
@@ -82,7 +88,7 @@ PyObject* DecodeCoord(EcPointDescr* d, const char* slot) {
   return canonical;
 }
 
-int EncodeCoord(EcPointDescr* d, char* slot, PyObject* value) {
+int EncodeBase(EcPointDescr* d, char* slot, PyObject* value) {
   PyObject* rem = PyNumber_Remainder(value, d->modulus);
   if (rem == nullptr) {
     return -1;
@@ -106,9 +112,42 @@ int EncodeCoord(EcPointDescr* d, char* slot, PyObject* value) {
   return rc < 0 ? -1 : 0;
 }
 
+PyObject* DecodeCoord(EcPointDescr* d, const char* slot) {
+  if (d->coord_degree == 1) {
+    return DecodeBase(d, slot);
+  }
+  PyObject* tuple = PyTuple_New(d->coord_degree);
+  if (tuple == nullptr) {
+    return nullptr;
+  }
+  for (int k = 0; k < d->coord_degree; ++k) {
+    PyObject* c = DecodeBase(d, slot + k * d->base_width_bytes);
+    if (c == nullptr) {
+      Py_DECREF(tuple);
+      return nullptr;
+    }
+    PyTuple_SET_ITEM(tuple, k, c);
+  }
+  return tuple;
+}
+
+int EncodeCoord(EcPointDescr* d, char* slot, PyObject* coord) {
+  if (d->coord_degree == 1) {
+    return EncodeBase(d, slot, coord);
+  }
+  for (int k = 0; k < d->coord_degree; ++k) {
+    if (EncodeBase(d, slot + k * d->base_width_bytes,
+                   PyTuple_GET_ITEM(coord, k)) < 0) {
+      return -1;
+    }
+  }
+  return 0;
+}
+
 int DecodePoint(EcPointDescr* d, const char* ptr, PyObject** out) {
+  int stride = d->coord_degree * d->base_width_bytes;
   for (int i = 0; i < d->num_coords; ++i) {
-    out[i] = DecodeCoord(d, ptr + i * d->base_width_bytes);
+    out[i] = DecodeCoord(d, ptr + i * stride);
     if (out[i] == nullptr) {
       for (int j = 0; j < i; ++j) Py_DECREF(out[j]);
       return -1;
@@ -118,8 +157,9 @@ int DecodePoint(EcPointDescr* d, const char* ptr, PyObject** out) {
 }
 
 int EncodePoint(EcPointDescr* d, char* ptr, PyObject* const* coords) {
+  int stride = d->coord_degree * d->base_width_bytes;
   for (int i = 0; i < d->num_coords; ++i) {
-    if (EncodeCoord(d, ptr + i * d->base_width_bytes, coords[i]) < 0) {
+    if (EncodeCoord(d, ptr + i * stride, coords[i]) < 0) {
       return -1;
     }
   }
@@ -127,8 +167,6 @@ int EncodePoint(EcPointDescr* d, char* ptr, PyObject* const* coords) {
 }
 
 // --- prime-field helpers on canonical Python ints -----------------------
-
-PyObject* FMod(PyObject* p, PyObject* x) { return PyNumber_Remainder(x, p); }
 
 PyObject* FAdd(PyObject* p, PyObject* a, PyObject* b) {
   PyObject* s = PyNumber_Add(a, b);
@@ -175,26 +213,139 @@ PyObject* FInv(PyObject* p, PyObject* x) {
 
 bool IsZeroCoord(PyObject* x) { return PyObject_IsTrue(x) == 0; }
 
+// --- coordinate-field ops (prime Fq for G1; Fp2 for G2, u^2 = non_residue) --
+// A coordinate value is a canonical Python int (degree 1) or a 2-tuple of
+// canonical ints (a0, a1) for Fp2. The C* helpers dispatch on coord_degree and
+// build on the base-field F* helpers, so the group-law formulas are written
+// once and work over either coordinate field.
+
+PyObject* MakeFp2(PyObject* c0, PyObject* c1) {  // steals c0, c1
+  if (!c0 || !c1) {
+    Py_XDECREF(c0);
+    Py_XDECREF(c1);
+    return nullptr;
+  }
+  PyObject* t = PyTuple_New(2);
+  if (!t) {
+    Py_DECREF(c0);
+    Py_DECREF(c1);
+    return nullptr;
+  }
+  PyTuple_SET_ITEM(t, 0, c0);
+  PyTuple_SET_ITEM(t, 1, c1);
+  return t;
+}
+
+PyObject* CZero(EcPointDescr* d) {
+  if (d->coord_degree == 1) return PyLong_FromLong(0);
+  return MakeFp2(PyLong_FromLong(0), PyLong_FromLong(0));
+}
+
+PyObject* COne(EcPointDescr* d) {
+  if (d->coord_degree == 1) return PyLong_FromLong(1);
+  return MakeFp2(PyLong_FromLong(1), PyLong_FromLong(0));
+}
+
+bool CIsZero(EcPointDescr* d, PyObject* a) {
+  if (d->coord_degree == 1) return IsZeroCoord(a);
+  return IsZeroCoord(PyTuple_GET_ITEM(a, 0)) &&
+         IsZeroCoord(PyTuple_GET_ITEM(a, 1));
+}
+
+PyObject* CAdd(EcPointDescr* d, PyObject* a, PyObject* b) {
+  if (d->coord_degree == 1) return FAdd(d->modulus, a, b);
+  return MakeFp2(
+      FAdd(d->modulus, PyTuple_GET_ITEM(a, 0), PyTuple_GET_ITEM(b, 0)),
+      FAdd(d->modulus, PyTuple_GET_ITEM(a, 1), PyTuple_GET_ITEM(b, 1)));
+}
+
+PyObject* CSub(EcPointDescr* d, PyObject* a, PyObject* b) {
+  if (d->coord_degree == 1) return FSub(d->modulus, a, b);
+  return MakeFp2(
+      FSub(d->modulus, PyTuple_GET_ITEM(a, 0), PyTuple_GET_ITEM(b, 0)),
+      FSub(d->modulus, PyTuple_GET_ITEM(a, 1), PyTuple_GET_ITEM(b, 1)));
+}
+
+PyObject* CNeg(EcPointDescr* d, PyObject* a) {
+  PyObject* m = d->modulus;
+  if (d->coord_degree == 1) return FSub(m, m, a);  // (p - a) mod p
+  return MakeFp2(FSub(m, m, PyTuple_GET_ITEM(a, 0)),
+                 FSub(m, m, PyTuple_GET_ITEM(a, 1)));
+}
+
+PyObject* CMulInt(EcPointDescr* d, PyObject* a, long k) {
+  if (d->coord_degree == 1) return FMulInt(d->modulus, a, k);
+  return MakeFp2(FMulInt(d->modulus, PyTuple_GET_ITEM(a, 0), k),
+                 FMulInt(d->modulus, PyTuple_GET_ITEM(a, 1), k));
+}
+
+PyObject* CMul(EcPointDescr* d, PyObject* a, PyObject* b) {
+  PyObject* m = d->modulus;
+  if (d->coord_degree == 1) return FMul(m, a, b);
+  PyObject* a0 = PyTuple_GET_ITEM(a, 0);
+  PyObject* a1 = PyTuple_GET_ITEM(a, 1);
+  PyObject* b0 = PyTuple_GET_ITEM(b, 0);
+  PyObject* b1 = PyTuple_GET_ITEM(b, 1);
+  // (a0 + a1 u)(b0 + b1 u) = (a0 b0 + nr a1 b1) + (a0 b1 + a1 b0) u
+  PyObject* a0b0 = FMul(m, a0, b0);
+  PyObject* a1b1 = FMul(m, a1, b1);
+  PyObject* nra1b1 = a1b1 ? FMul(m, d->non_residue, a1b1) : nullptr;
+  PyObject* c0 = (a0b0 && nra1b1) ? FAdd(m, a0b0, nra1b1) : nullptr;
+  PyObject* a0b1 = FMul(m, a0, b1);
+  PyObject* a1b0 = FMul(m, a1, b0);
+  PyObject* c1 = (a0b1 && a1b0) ? FAdd(m, a0b1, a1b0) : nullptr;
+  Py_XDECREF(a0b0);
+  Py_XDECREF(a1b1);
+  Py_XDECREF(nra1b1);
+  Py_XDECREF(a0b1);
+  Py_XDECREF(a1b0);
+  return MakeFp2(c0, c1);
+}
+
+// Coordinate-field inverse (used by representation casts).
+PyObject* CInv(EcPointDescr* d, PyObject* a) {
+  PyObject* m = d->modulus;
+  if (d->coord_degree == 1) return FInv(m, a);
+  PyObject* a0 = PyTuple_GET_ITEM(a, 0);
+  PyObject* a1 = PyTuple_GET_ITEM(a, 1);
+  // norm = a0^2 - nr a1^2 ; a^-1 = (a0 - a1 u) / norm
+  PyObject* a0sq = FMul(m, a0, a0);
+  PyObject* a1sq = FMul(m, a1, a1);
+  PyObject* nra1sq = a1sq ? FMul(m, d->non_residue, a1sq) : nullptr;
+  PyObject* norm = (a0sq && nra1sq) ? FSub(m, a0sq, nra1sq) : nullptr;
+  PyObject* ninv = norm ? FInv(m, norm) : nullptr;
+  PyObject* c0 = ninv ? FMul(m, a0, ninv) : nullptr;
+  PyObject* na1 = FSub(m, m, a1);
+  PyObject* c1 = (ninv && na1) ? FMul(m, na1, ninv) : nullptr;
+  Py_XDECREF(a0sq);
+  Py_XDECREF(a1sq);
+  Py_XDECREF(nra1sq);
+  Py_XDECREF(norm);
+  Py_XDECREF(ninv);
+  Py_XDECREF(na1);
+  return MakeFp2(c0, c1);
+}
+
 // Jacobian doubling, a == 0 (EFD dbl-2009-l). in/out: 3 canonical coords.
-int JacDouble(PyObject* p, PyObject* const* in, PyObject** out) {
+int JacDouble(EcPointDescr* ec, PyObject* const* in, PyObject** out) {
   PyObject* X = in[0];
   PyObject* Y = in[1];
   PyObject* Z = in[2];
-  PyObject* xx = FMul(p, X, X);
-  PyObject* yy = FMul(p, Y, Y);
-  PyObject* yyyy = yy ? FMul(p, yy, yy) : nullptr;
-  PyObject* xyy = (xx && yy) ? FMul(p, X, yy) : nullptr;
-  PyObject* d = xyy ? FMulInt(p, xyy, 4) : nullptr;  // d = 4*X*yy
-  PyObject* e = xx ? FMulInt(p, xx, 3) : nullptr;    // e = 3*xx
-  PyObject* ee = e ? FMul(p, e, e) : nullptr;
-  PyObject* twod = d ? FMulInt(p, d, 2) : nullptr;
-  PyObject* X2 = (ee && twod) ? FSub(p, ee, twod) : nullptr;  // e^2 - 2d
-  PyObject* dmx = (d && X2) ? FSub(p, d, X2) : nullptr;
-  PyObject* edmx = (e && dmx) ? FMul(p, e, dmx) : nullptr;
-  PyObject* eightyyyy = yyyy ? FMulInt(p, yyyy, 8) : nullptr;
-  PyObject* Y2 = (edmx && eightyyyy) ? FSub(p, edmx, eightyyyy) : nullptr;
-  PyObject* yz = FMul(p, Y, Z);
-  PyObject* Z2 = yz ? FMulInt(p, yz, 2) : nullptr;
+  PyObject* xx = CMul(ec, X, X);
+  PyObject* yy = CMul(ec, Y, Y);
+  PyObject* yyyy = yy ? CMul(ec, yy, yy) : nullptr;
+  PyObject* xyy = (xx && yy) ? CMul(ec, X, yy) : nullptr;
+  PyObject* d = xyy ? CMulInt(ec, xyy, 4) : nullptr;  // d = 4*X*yy
+  PyObject* e = xx ? CMulInt(ec, xx, 3) : nullptr;    // e = 3*xx
+  PyObject* ee = e ? CMul(ec, e, e) : nullptr;
+  PyObject* twod = d ? CMulInt(ec, d, 2) : nullptr;
+  PyObject* X2 = (ee && twod) ? CSub(ec, ee, twod) : nullptr;  // e^2 - 2d
+  PyObject* dmx = (d && X2) ? CSub(ec, d, X2) : nullptr;
+  PyObject* edmx = (e && dmx) ? CMul(ec, e, dmx) : nullptr;
+  PyObject* eightyyyy = yyyy ? CMulInt(ec, yyyy, 8) : nullptr;
+  PyObject* Y2 = (edmx && eightyyyy) ? CSub(ec, edmx, eightyyyy) : nullptr;
+  PyObject* yz = CMul(ec, Y, Z);
+  PyObject* Z2 = yz ? CMulInt(ec, yz, 2) : nullptr;
   Py_XDECREF(xx);
   Py_XDECREF(yy);
   Py_XDECREF(yyyy);
@@ -227,57 +378,56 @@ void CopyPoint(PyObject* const* in, PyObject** out, int n) {
 }
 
 // Jacobian addition (EFD add-2007-bl), a == 0. in1/in2/out: 3 canonical coords.
-int JacAdd(PyObject* p, PyObject* const* P, PyObject* const* Q,
+int JacAdd(EcPointDescr* ec, PyObject* const* P, PyObject* const* Q,
            PyObject** out) {
-  if (IsZeroCoord(P[2])) {  // P is infinity
+  if (CIsZero(ec, P[2])) {  // P is infinity
     CopyPoint(Q, out, 3);
     return 0;
   }
-  if (IsZeroCoord(Q[2])) {  // Q is infinity
+  if (CIsZero(ec, Q[2])) {  // Q is infinity
     CopyPoint(P, out, 3);
     return 0;
   }
   PyObject *X1 = P[0], *Y1 = P[1], *Z1 = P[2];
   PyObject *X2 = Q[0], *Y2 = Q[1], *Z2 = Q[2];
-  PyObject* z1z1 = FMul(p, Z1, Z1);
-  PyObject* z2z2 = FMul(p, Z2, Z2);
-  PyObject* u1 = z2z2 ? FMul(p, X1, z2z2) : nullptr;
-  PyObject* u2 = z1z1 ? FMul(p, X2, z1z1) : nullptr;
-  PyObject* yz2 = z2z2 ? FMul(p, Y1, Z2) : nullptr;
-  PyObject* s1 = yz2 ? FMul(p, yz2, z2z2) : nullptr;
-  PyObject* yz1 = z1z1 ? FMul(p, Y2, Z1) : nullptr;
-  PyObject* s2 = yz1 ? FMul(p, yz1, z1z1) : nullptr;
+  PyObject* z1z1 = CMul(ec, Z1, Z1);
+  PyObject* z2z2 = CMul(ec, Z2, Z2);
+  PyObject* u1 = z2z2 ? CMul(ec, X1, z2z2) : nullptr;
+  PyObject* u2 = z1z1 ? CMul(ec, X2, z1z1) : nullptr;
+  PyObject* yz2 = z2z2 ? CMul(ec, Y1, Z2) : nullptr;
+  PyObject* s1 = yz2 ? CMul(ec, yz2, z2z2) : nullptr;
+  PyObject* yz1 = z1z1 ? CMul(ec, Y2, Z1) : nullptr;
+  PyObject* s2 = yz1 ? CMul(ec, yz1, z1z1) : nullptr;
   int rc = -1;
   if (!u1 || !u2 || !s1 || !s2) goto cleanup;
   if (PyObject_RichCompareBool(u1, u2, Py_EQ) == 1 &&
       PyObject_RichCompareBool(s1, s2, Py_EQ) == 1) {
-    rc = JacDouble(p, P, out);
+    rc = JacDouble(ec, P, out);
     goto cleanup;
   }
   {
-    PyObject* h = FSub(p, u2, u1);
-    PyObject* twoh = h ? FMulInt(p, h, 2) : nullptr;
-    PyObject* i = twoh ? FMul(p, twoh, twoh) : nullptr;  // (2h)^2
-    PyObject* hi = (h && i) ? FMul(p, h, i) : nullptr;
-    PyObject* j =
-        hi ? FSub(p, p, hi) : nullptr;  // j = -(h*i) = p - h*i (then mod)
-    PyObject* sdiff = FSub(p, s2, s1);
-    PyObject* r = sdiff ? FMulInt(p, sdiff, 2) : nullptr;  // 2(s2-s1)
-    PyObject* v = i ? FMul(p, u1, i) : nullptr;
-    PyObject* rr = r ? FMul(p, r, r) : nullptr;
-    PyObject* twov = v ? FMulInt(p, v, 2) : nullptr;
-    PyObject* rrj = (rr && j) ? FAdd(p, rr, j) : nullptr;
+    PyObject* h = CSub(ec, u2, u1);
+    PyObject* twoh = h ? CMulInt(ec, h, 2) : nullptr;
+    PyObject* i = twoh ? CMul(ec, twoh, twoh) : nullptr;  // (2h)^2
+    PyObject* hi = (h && i) ? CMul(ec, h, i) : nullptr;
+    PyObject* j = hi ? CNeg(ec, hi) : nullptr;  // j = -(h*i)
+    PyObject* sdiff = CSub(ec, s2, s1);
+    PyObject* r = sdiff ? CMulInt(ec, sdiff, 2) : nullptr;  // 2(s2-s1)
+    PyObject* v = i ? CMul(ec, u1, i) : nullptr;
+    PyObject* rr = r ? CMul(ec, r, r) : nullptr;
+    PyObject* twov = v ? CMulInt(ec, v, 2) : nullptr;
+    PyObject* rrj = (rr && j) ? CAdd(ec, rr, j) : nullptr;
     PyObject* X3 =
-        (rrj && twov) ? FSub(p, rrj, twov) : nullptr;  // r^2 + j - 2v
-    PyObject* vmx = (v && X3) ? FSub(p, v, X3) : nullptr;
-    PyObject* rvmx = (r && vmx) ? FMul(p, r, vmx) : nullptr;
-    PyObject* s1j = (s1 && j) ? FMul(p, s1, j) : nullptr;
-    PyObject* twos1j = s1j ? FMulInt(p, s1j, 2) : nullptr;
+        (rrj && twov) ? CSub(ec, rrj, twov) : nullptr;  // r^2 + j - 2v
+    PyObject* vmx = (v && X3) ? CSub(ec, v, X3) : nullptr;
+    PyObject* rvmx = (r && vmx) ? CMul(ec, r, vmx) : nullptr;
+    PyObject* s1j = (s1 && j) ? CMul(ec, s1, j) : nullptr;
+    PyObject* twos1j = s1j ? CMulInt(ec, s1j, 2) : nullptr;
     PyObject* Y3 =
-        (rvmx && twos1j) ? FAdd(p, rvmx, twos1j) : nullptr;  // r(v-X3) + 2*s1*j
-    PyObject* z1z2 = FMul(p, Z1, Z2);
-    PyObject* z1z2h = (z1z2 && h) ? FMul(p, z1z2, h) : nullptr;
-    PyObject* Z3 = z1z2h ? FMulInt(p, z1z2h, 2) : nullptr;  // 2*Z1*Z2*h
+        (rvmx && twos1j) ? CAdd(ec, rvmx, twos1j) : nullptr;  // r(v-X3)+2*s1*j
+    PyObject* z1z2 = CMul(ec, Z1, Z2);
+    PyObject* z1z2h = (z1z2 && h) ? CMul(ec, z1z2, h) : nullptr;
+    PyObject* Z3 = z1z2h ? CMulInt(ec, z1z2h, 2) : nullptr;  // 2*Z1*Z2*h
     Py_XDECREF(h);
     Py_XDECREF(twoh);
     Py_XDECREF(i);
@@ -320,21 +470,21 @@ cleanup:
 }
 
 // Negate: flip Y only.
-int JacNegate(PyObject* p, PyObject* const* in, PyObject** out) {
-  PyObject* negY = FSub(p, p, in[1]);  // -Y = p - Y (then mod)
+// Negate flips Y (coordinate 1) and copies the rest — rep-safe for affine /
+// Jacobian / xyzz alike (Y is coordinate 1 in every representation).
+int JacNegate(EcPointDescr* ec, PyObject* const* in, PyObject** out) {
+  PyObject* negY = CNeg(ec, in[1]);
   if (negY == nullptr) {
     return -1;
   }
-  PyObject* y = FMod(p, negY);
-  Py_DECREF(negY);
-  if (y == nullptr) {
-    return -1;
+  for (int i = 0; i < ec->num_coords; ++i) {
+    if (i == 1) {
+      out[i] = negY;
+    } else {
+      Py_INCREF(in[i]);
+      out[i] = in[i];
+    }
   }
-  Py_INCREF(in[0]);
-  out[0] = in[0];
-  out[1] = y;
-  Py_INCREF(in[2]);
-  out[2] = in[2];
   return 0;
 }
 
@@ -342,21 +492,21 @@ int JacNegate(PyObject* p, PyObject* const* in, PyObject** out) {
 // encodings for one group element. Returns 1 if P == Q as group elements,
 // 0 if not, -1 on error. Both infinity -> equal; one infinity -> not equal;
 // else x1*z2^2 == x2*z1^2 and y1*z2^3 == y2*z1^3.
-int JacEqual(PyObject* p, PyObject* const* P, PyObject* const* Q) {
-  bool pz = IsZeroCoord(P[2]);
-  bool qz = IsZeroCoord(Q[2]);
+int JacEqual(EcPointDescr* ec, PyObject* const* P, PyObject* const* Q) {
+  bool pz = CIsZero(ec, P[2]);
+  bool qz = CIsZero(ec, Q[2]);
   if (pz || qz) {
     return (pz && qz) ? 1 : 0;
   }
   int result = -1;
-  PyObject* z1s = FMul(p, P[2], P[2]);  // z1^2
-  PyObject* z2s = FMul(p, Q[2], Q[2]);  // z2^2
-  PyObject* lx = z2s ? FMul(p, P[0], z2s) : nullptr;
-  PyObject* rx = z1s ? FMul(p, Q[0], z1s) : nullptr;
-  PyObject* z1c = z1s ? FMul(p, z1s, P[2]) : nullptr;  // z1^3
-  PyObject* z2c = z2s ? FMul(p, z2s, Q[2]) : nullptr;  // z2^3
-  PyObject* ly = z2c ? FMul(p, P[1], z2c) : nullptr;
-  PyObject* ry = z1c ? FMul(p, Q[1], z1c) : nullptr;
+  PyObject* z1s = CMul(ec, P[2], P[2]);
+  PyObject* z2s = CMul(ec, Q[2], Q[2]);
+  PyObject* lx = z2s ? CMul(ec, P[0], z2s) : nullptr;
+  PyObject* rx = z1s ? CMul(ec, Q[0], z1s) : nullptr;
+  PyObject* z1c = z1s ? CMul(ec, z1s, P[2]) : nullptr;
+  PyObject* z2c = z2s ? CMul(ec, z2s, Q[2]) : nullptr;
+  PyObject* ly = z2c ? CMul(ec, P[1], z2c) : nullptr;
+  PyObject* ry = z1c ? CMul(ec, Q[1], z1c) : nullptr;
   if (lx && rx && ly && ry) {
     int xe = PyObject_RichCompareBool(lx, rx, Py_EQ);
     int ye = PyObject_RichCompareBool(ly, ry, Py_EQ);
@@ -385,10 +535,9 @@ void MovePoint(PyObject** dst, PyObject* const* src, int n) {
 // MSB-first double-and-add: ret = scalar * point (canonical Jacobian coords).
 // The scalar is a canonical integer (Montgomery already decoded by the caller),
 // matching the legacy curve operator* which de-Montgomery's the scalar first.
-int JacScalarMul(PyObject* p, PyObject* scalar, PyObject* const* point,
+int JacScalarMul(EcPointDescr* ec, PyObject* scalar, PyObject* const* point,
                  PyObject** out) {
-  PyObject* ret[3] = {PyLong_FromLong(1), PyLong_FromLong(1),
-                      PyLong_FromLong(0)};  // Zero = (1, 1, 0)
+  PyObject* ret[3] = {COne(ec), COne(ec), CZero(ec)};  // Zero = (1, 1, 0)
   if (!ret[0] || !ret[1] || !ret[2]) {
     for (int j = 0; j < 3; ++j) Py_XDECREF(ret[j]);
     return -1;
@@ -407,13 +556,13 @@ int JacScalarMul(PyObject* p, PyObject* scalar, PyObject* const* point,
   }
   for (Py_ssize_t i = static_cast<Py_ssize_t>(nbits) - 1; i >= 0; --i) {
     PyObject* tmp[3];
-    if (JacDouble(p, ret, tmp) < 0) {
+    if (JacDouble(ec, ret, tmp) < 0) {
       for (int j = 0; j < 3; ++j) Py_DECREF(ret[j]);
       return -1;
     }
     MovePoint(ret, tmp, 3);
     if ((buf[i >> 3] >> (i & 7)) & 1) {
-      if (JacAdd(p, ret, point, tmp) < 0) {
+      if (JacAdd(ec, ret, point, tmp) < 0) {
         for (int j = 0; j < 3; ++j) Py_DECREF(ret[j]);
         return -1;
       }
@@ -430,7 +579,8 @@ int JacScalarMul(PyObject* p, PyObject* scalar, PyObject* const* point,
 
 PyArray_Descr* MakeDescr(PyObject* modulus, int base_width_bytes,
                          int num_coords, int is_montgomery, PyObject* r,
-                         PyObject* rinv) {
+                         PyObject* rinv, int coord_degree,
+                         PyObject* non_residue) {
   auto* d = reinterpret_cast<EcPointDescr*>(PyArrayDescr_Type.tp_new(
       reinterpret_cast<PyTypeObject*>(&EcPointDType), nullptr, nullptr));
   if (d == nullptr) {
@@ -442,6 +592,9 @@ PyArray_Descr* MakeDescr(PyObject* modulus, int base_width_bytes,
   d->r_mod_p = r;
   Py_XINCREF(rinv);
   d->rinv_mod_p = rinv;
+  Py_XINCREF(non_residue);
+  d->non_residue = non_residue;
+  d->coord_degree = static_cast<uint8_t>(coord_degree);
   d->base_width_bytes = static_cast<uint8_t>(base_width_bytes);
   d->num_coords = static_cast<uint8_t>(num_coords);
   d->is_montgomery = static_cast<uint8_t>(is_montgomery ? 1 : 0);
@@ -450,7 +603,7 @@ PyArray_Descr* MakeDescr(PyObject* modulus, int base_width_bytes,
   base->type = 'j';
   base->byteorder = '=';
   base->flags = NPY_USE_GETITEM | NPY_USE_SETITEM;
-  base->elsize = base_width_bytes * num_coords;
+  base->elsize = base_width_bytes * coord_degree * num_coords;
   base->alignment = base_width_bytes <= 8 ? base_width_bytes : 8;
   return base;
 }
@@ -460,6 +613,7 @@ void Descr_dealloc(PyObject* self) {
   Py_XDECREF(d->modulus);
   Py_XDECREF(d->r_mod_p);
   Py_XDECREF(d->rinv_mod_p);
+  Py_XDECREF(d->non_residue);
   PyArrayDescr_Type.tp_dealloc(self);
 }
 
@@ -487,7 +641,7 @@ PyArray_Descr* DefaultDescr(PyArray_DTypeMeta* /*cls*/) {
   if (two == nullptr) {
     return nullptr;
   }
-  PyArray_Descr* d = MakeDescr(two, 4, 3, 0, nullptr, nullptr);
+  PyArray_Descr* d = MakeDescr(two, 4, 3, 0, nullptr, nullptr, 1, nullptr);
   Py_DECREF(two);
   return d;
 }
@@ -503,7 +657,7 @@ PyArray_DTypeMeta* CommonDType(PyArray_DTypeMeta* a, PyArray_DTypeMeta* b) {
 
 bool SameCurve(EcPointDescr* a, EcPointDescr* b) {
   return a->base_width_bytes == b->base_width_bytes &&
-         a->num_coords == b->num_coords &&
+         a->num_coords == b->num_coords && a->coord_degree == b->coord_degree &&
          a->is_montgomery == b->is_montgomery &&
          PyObject_RichCompareBool(a->modulus, b->modulus, Py_EQ) == 1;
 }
@@ -575,29 +729,19 @@ PyObject* GetItem(PyArray_Descr* descr, char* dataptr) {
   return tuple;
 }
 
-// Same curve and coordinate field, ignoring the representation (coord count).
-bool SameCurveField(EcPointDescr* a, EcPointDescr* b) {
-  return a->base_width_bytes == b->base_width_bytes &&
-         a->is_montgomery == b->is_montgomery &&
-         PyObject_RichCompareBool(a->modulus, b->modulus, Py_EQ) == 1;
-}
-
-PyObject* One() { return PyLong_FromLong(1); }
-PyObject* ZeroL() { return PyLong_FromLong(0); }
-
 // Converts a point between coordinate representations (canonical coords
 // in/out). num_coords: affine 2, Jacobian 3, xyzz 4. Jacobian<->xyzz keep the
 // projective coordinates (legacy direct formulas); the rest go through affine
 // (needs a field inverse), matching the legacy registered casts byte-for-byte.
-int ConvertRep(PyObject* p, int fn, int tn, PyObject* const* in,
+int ConvertRep(EcPointDescr* ec, int fn, int tn, PyObject* const* in,
                PyObject** out) {
   if (fn == tn) {
     CopyPoint(in, out, fn);
     return 0;
   }
   if (fn == 3 && tn == 4) {  // jac (X,Y,Z) -> xyzz (X,Y,Z^2,Z^3)
-    PyObject* z2 = FMul(p, in[2], in[2]);
-    PyObject* z3 = z2 ? FMul(p, z2, in[2]) : nullptr;
+    PyObject* z2 = CMul(ec, in[2], in[2]);
+    PyObject* z3 = z2 ? CMul(ec, z2, in[2]) : nullptr;
     if (!z2 || !z3) {
       Py_XDECREF(z2);
       Py_XDECREF(z3);
@@ -612,10 +756,10 @@ int ConvertRep(PyObject* p, int fn, int tn, PyObject* const* in,
     return 0;
   }
   if (fn == 4 && tn == 3) {  // xyzz (X,Y,ZZ,ZZZ) -> jac (X,Y,ZZZ/ZZ)
-    if (IsZeroCoord(in[2])) {
-      out[0] = One();
-      out[1] = One();
-      out[2] = ZeroL();
+    if (CIsZero(ec, in[2])) {
+      out[0] = COne(ec);
+      out[1] = COne(ec);
+      out[2] = CZero(ec);
       if (!out[0] || !out[1] || !out[2]) {
         Py_XDECREF(out[0]);
         Py_XDECREF(out[1]);
@@ -624,8 +768,8 @@ int ConvertRep(PyObject* p, int fn, int tn, PyObject* const* in,
       }
       return 0;
     }
-    PyObject* zzinv = FInv(p, in[2]);
-    PyObject* z = zzinv ? FMul(p, in[3], zzinv) : nullptr;
+    PyObject* zzinv = CInv(ec, in[2]);
+    PyObject* z = zzinv ? CMul(ec, in[3], zzinv) : nullptr;
     Py_XDECREF(zzinv);
     if (!z) return -1;
     Py_INCREF(in[0]);
@@ -640,32 +784,32 @@ int ConvertRep(PyObject* p, int fn, int tn, PyObject* const* in,
   PyObject* ay = nullptr;
   bool inf = false;
   if (fn == 2) {
-    inf = IsZeroCoord(in[0]) && IsZeroCoord(in[1]);
+    inf = CIsZero(ec, in[0]) && CIsZero(ec, in[1]);
     Py_INCREF(in[0]);
     ax = in[0];
     Py_INCREF(in[1]);
     ay = in[1];
   } else if (fn == 3) {  // jac -> affine
-    if (IsZeroCoord(in[2])) {
+    if (CIsZero(ec, in[2])) {
       inf = true;
     } else {
-      PyObject* zi = FInv(p, in[2]);
-      PyObject* z2 = zi ? FMul(p, zi, zi) : nullptr;
-      PyObject* z3 = z2 ? FMul(p, z2, zi) : nullptr;
-      ax = z2 ? FMul(p, in[0], z2) : nullptr;
-      ay = z3 ? FMul(p, in[1], z3) : nullptr;
+      PyObject* zi = CInv(ec, in[2]);
+      PyObject* z2 = zi ? CMul(ec, zi, zi) : nullptr;
+      PyObject* z3 = z2 ? CMul(ec, z2, zi) : nullptr;
+      ax = z2 ? CMul(ec, in[0], z2) : nullptr;
+      ay = z3 ? CMul(ec, in[1], z3) : nullptr;
       Py_XDECREF(zi);
       Py_XDECREF(z2);
       Py_XDECREF(z3);
     }
   } else {  // xyzz -> affine
-    if (IsZeroCoord(in[2])) {
+    if (CIsZero(ec, in[2])) {
       inf = true;
     } else {
-      PyObject* zzi = FInv(p, in[2]);
-      PyObject* zzzi = FInv(p, in[3]);
-      ax = zzi ? FMul(p, in[0], zzi) : nullptr;
-      ay = zzzi ? FMul(p, in[1], zzzi) : nullptr;
+      PyObject* zzi = CInv(ec, in[2]);
+      PyObject* zzzi = CInv(ec, in[3]);
+      ax = zzi ? CMul(ec, in[0], zzi) : nullptr;
+      ay = zzzi ? CMul(ec, in[1], zzzi) : nullptr;
       Py_XDECREF(zzi);
       Py_XDECREF(zzzi);
     }
@@ -680,13 +824,13 @@ int ConvertRep(PyObject* p, int fn, int tn, PyObject* const* in,
     Py_XDECREF(ax);
     Py_XDECREF(ay);
     if (tn == 2) {
-      out[0] = ZeroL();
-      out[1] = ZeroL();
+      out[0] = CZero(ec);
+      out[1] = CZero(ec);
     } else {
-      out[0] = One();
-      out[1] = One();
-      out[2] = ZeroL();
-      if (tn == 4) out[3] = ZeroL();
+      out[0] = COne(ec);
+      out[1] = COne(ec);
+      out[2] = CZero(ec);
+      if (tn == 4) out[3] = CZero(ec);
     }
     for (int i = 0; i < tn; ++i) {
       if (!out[i]) rc = -1;
@@ -694,8 +838,8 @@ int ConvertRep(PyObject* p, int fn, int tn, PyObject* const* in,
   } else {
     out[0] = ax;
     out[1] = ay;
-    if (tn >= 3) out[2] = One();
-    if (tn == 4) out[3] = One();
+    if (tn >= 3) out[2] = COne(ec);
+    if (tn == 4) out[3] = COne(ec);
     for (int i = 2; i < tn; ++i) {
       if (!out[i]) rc = -1;
     }
@@ -748,12 +892,11 @@ int CastLoop(PyArrayMethod_Context* context, char* const* data,
     }
     return 0;
   }
-  PyObject* p = from->modulus;
   for (npy_intp i = 0; i < n; ++i) {
     PyObject* src[kMaxCoords];
     PyObject* dst[kMaxCoords];
     if (DecodePoint(from, in, src) < 0) return -1;
-    int rc = ConvertRep(p, from->num_coords, to->num_coords, src, dst);
+    int rc = ConvertRep(from, from->num_coords, to->num_coords, src, dst);
     for (int j = 0; j < from->num_coords; ++j) Py_DECREF(src[j]);
     if (rc < 0) return -1;
     int erc = EncodePoint(to, out, dst);
@@ -774,8 +917,11 @@ PyObject* MakeEcPointDescrPy(PyObject* /*self*/, PyObject* args) {
   int is_montgomery;
   PyObject* r_obj = nullptr;
   PyObject* rinv_obj = nullptr;
-  if (!PyArg_ParseTuple(args, "Oiii|OO", &modulus_obj, &base_width_bits,
-                        &num_coords, &is_montgomery, &r_obj, &rinv_obj)) {
+  int coord_degree = 1;
+  PyObject* nr_obj = nullptr;
+  if (!PyArg_ParseTuple(args, "Oiii|OOiO", &modulus_obj, &base_width_bits,
+                        &num_coords, &is_montgomery, &r_obj, &rinv_obj,
+                        &coord_degree, &nr_obj)) {
     return nullptr;
   }
   if (base_width_bits != 32 && base_width_bits != 64 &&
@@ -786,6 +932,15 @@ PyObject* MakeEcPointDescrPy(PyObject* /*self*/, PyObject* args) {
   }
   if (num_coords < 2 || num_coords > kMaxCoords) {
     PyErr_Format(PyExc_ValueError, "num_coords must be in [2, %d]", kMaxCoords);
+    return nullptr;
+  }
+  if (coord_degree < 1 || coord_degree > 2) {
+    PyErr_SetString(PyExc_ValueError, "coord_degree must be 1 (G1) or 2 (G2)");
+    return nullptr;
+  }
+  if (coord_degree == 2 && nr_obj == nullptr) {
+    PyErr_SetString(PyExc_ValueError,
+                    "coord_degree 2 (Fp2) requires a non_residue");
     return nullptr;
   }
   if (is_montgomery && (r_obj == nullptr || rinv_obj == nullptr)) {
@@ -808,11 +963,22 @@ PyObject* MakeEcPointDescrPy(PyObject* /*self*/, PyObject* args) {
       return nullptr;
     }
   }
+  PyObject* nr = nullptr;
+  if (coord_degree == 2) {
+    nr = PyNumber_Index(nr_obj);
+    if (nr == nullptr) {
+      Py_DECREF(modulus);
+      Py_XDECREF(r);
+      Py_XDECREF(rinv);
+      return nullptr;
+    }
+  }
   PyArray_Descr* d = MakeDescr(modulus, base_width_bits / 8, num_coords,
-                               is_montgomery, r, rinv);
+                               is_montgomery, r, rinv, coord_degree, nr);
   Py_DECREF(modulus);
   Py_XDECREF(r);
   Py_XDECREF(rinv);
+  Py_XDECREF(nr);
   return reinterpret_cast<PyObject*>(d);
 }
 
@@ -871,7 +1037,6 @@ int BinLoop(PyArrayMethod_Context* context, char* const* data,
             const npy_intp* dimensions, const npy_intp* strides,
             NpyAuxData* /*aux*/) {
   EcPointDescr* d = AsEc(context->descriptors[0]);
-  PyObject* p = d->modulus;
   npy_intp n = dimensions[0];
   char* a = data[0];
   char* b = data[1];
@@ -888,13 +1053,13 @@ int BinLoop(PyArrayMethod_Context* context, char* const* data,
     int rc;
     if (op == BinOp::kSub) {
       PyObject* negQ[kMaxCoords];
-      rc = JacNegate(p, Q, negQ);
+      rc = JacNegate(d, Q, negQ);
       if (rc == 0) {
-        rc = JacAdd(p, P, negQ, R);
+        rc = JacAdd(d, P, negQ, R);
         for (int j = 0; j < d->num_coords; ++j) Py_DECREF(negQ[j]);
       }
     } else {
-      rc = JacAdd(p, P, Q, R);
+      rc = JacAdd(d, P, Q, R);
     }
     for (int j = 0; j < d->num_coords; ++j) {
       Py_DECREF(P[j]);
@@ -915,7 +1080,6 @@ int NegLoop(PyArrayMethod_Context* context, char* const* data,
             const npy_intp* dimensions, const npy_intp* strides,
             NpyAuxData* /*aux*/) {
   EcPointDescr* d = AsEc(context->descriptors[0]);
-  PyObject* p = d->modulus;
   npy_intp n = dimensions[0];
   char* a = data[0];
   char* o = data[1];
@@ -923,7 +1087,7 @@ int NegLoop(PyArrayMethod_Context* context, char* const* data,
     PyObject* P[kMaxCoords];
     PyObject* R[kMaxCoords];
     if (DecodePoint(d, a, P) < 0) return -1;
-    int rc = JacNegate(p, P, R);
+    int rc = JacNegate(d, P, R);
     for (int j = 0; j < d->num_coords; ++j) Py_DECREF(P[j]);
     if (rc < 0) return -1;
     int erc = EncodePoint(d, o, R);
@@ -1016,7 +1180,6 @@ int CmpLoop(PyArrayMethod_Context* context, char* const* data,
             const npy_intp* dimensions, const npy_intp* strides,
             NpyAuxData* /*aux*/) {
   EcPointDescr* d = AsEc(context->descriptors[0]);
-  PyObject* p = d->modulus;
   npy_intp n = dimensions[0];
   char* a = data[0];
   char* b = data[1];
@@ -1029,7 +1192,7 @@ int CmpLoop(PyArrayMethod_Context* context, char* const* data,
       for (int j = 0; j < d->num_coords; ++j) Py_DECREF(P[j]);
       return -1;
     }
-    int eq = JacEqual(p, P, Q);
+    int eq = JacEqual(d, P, Q);
     for (int j = 0; j < d->num_coords; ++j) {
       Py_DECREF(P[j]);
       Py_DECREF(Q[j]);
@@ -1102,7 +1265,6 @@ int ScalarMulLoop(PyArrayMethod_Context* context, char* const* data,
   PyArray_Descr* scalar_descr = context->descriptors[scalar_first ? 0 : 1];
   EcPointDescr* d = AsEc(context->descriptors[scalar_first ? 1 : 0]);
   EcPointDescr* od = AsEc(context->descriptors[2]);
-  PyObject* p = d->modulus;
   npy_intp n = dimensions[0];
   char* s = data[scalar_first ? 0 : 1];
   char* pt = data[scalar_first ? 1 : 0];
@@ -1119,7 +1281,7 @@ int ScalarMulLoop(PyArrayMethod_Context* context, char* const* data,
       return -1;
     }
     PyObject* R[3];
-    int rc = JacScalarMul(p, scalar, P, R);
+    int rc = JacScalarMul(d, scalar, P, R);
     Py_DECREF(scalar);
     for (int j = 0; j < d->num_coords; ++j) Py_DECREF(P[j]);
     if (rc < 0) return -1;

--- a/zk_dtypes/_src/ec_point_dtype.cc
+++ b/zk_dtypes/_src/ec_point_dtype.cc
@@ -834,6 +834,12 @@ NPY_CASTING BinResolve(struct PyArrayMethodObject_tag* /*method*/,
     PyErr_SetString(PyExc_TypeError, "point op requires the same curve");
     return static_cast<NPY_CASTING>(-1);
   }
+  if (AsEc(given[0])->num_coords != 3) {
+    PyErr_SetString(PyExc_TypeError,
+                    "EC arithmetic requires the Jacobian representation; cast "
+                    "affine/xyzz points to Jacobian first");
+    return static_cast<NPY_CASTING>(-1);
+  }
   Py_INCREF(given[0]);
   loop[0] = given[0];
   Py_INCREF(given[1]);
@@ -984,6 +990,12 @@ NPY_CASTING CmpResolve(struct PyArrayMethodObject_tag* /*method*/,
                     "point comparison requires the same curve");
     return static_cast<NPY_CASTING>(-1);
   }
+  if (AsEc(given[0])->num_coords != 3) {
+    PyErr_SetString(PyExc_TypeError,
+                    "EC comparison requires the Jacobian representation; cast "
+                    "affine/xyzz points to Jacobian first");
+    return static_cast<NPY_CASTING>(-1);
+  }
   Py_INCREF(given[0]);
   loop[0] = given[0];
   Py_INCREF(given[1]);
@@ -1067,6 +1079,12 @@ NPY_CASTING ScalarMulResolve(struct PyArrayMethodObject_tag* /*method*/,
       Py_TYPE(given[0]) == reinterpret_cast<PyTypeObject*>(&EcPointDType)
           ? given[0]
           : given[1];
+  if (AsEc(point)->num_coords != 3) {
+    PyErr_SetString(PyExc_TypeError,
+                    "EC scalar multiplication requires the Jacobian "
+                    "representation; cast the point to Jacobian first");
+    return static_cast<NPY_CASTING>(-1);
+  }
   Py_INCREF(given[0]);
   loop[0] = given[0];
   Py_INCREF(given[1]);

--- a/zk_dtypes/_src/ec_point_dtype.cc
+++ b/zk_dtypes/_src/ec_point_dtype.cc
@@ -727,18 +727,20 @@ void EcDouble(const CoordField& cf, const unsigned char* in,
   std::memcpy(out + 2 * cb, Z2, cb);
 }
 
-// Jacobian addition (EFD add-2007-bl, a == 0); 3 coords. out must not alias.
+// Jacobian addition (EFD add-2007-bl, a == 0); 3 coords. `out` may alias an
+// input: every read of P/Q completes into stack temporaries before the result
+// is written, and the infinity copies below skip a no-op self-copy.
 void EcAdd(const CoordField& cf, const unsigned char* P, const unsigned char* Q,
            unsigned char* out) {
   const int cb = cf.cb;
   const unsigned char* Z1 = P + 2 * cb;
   const unsigned char* Z2 = Q + 2 * cb;
   if (cf.IsZero(Z1)) {
-    std::memcpy(out, Q, 3 * cb);
+    if (out != Q) std::memcpy(out, Q, 3 * cb);
     return;
   }
   if (cf.IsZero(Z2)) {
-    std::memcpy(out, P, 3 * cb);
+    if (out != P) std::memcpy(out, P, 3 * cb);
     return;
   }
   const unsigned char* X1 = P;
@@ -927,10 +929,18 @@ PyArray_DTypeMeta* CommonDType(PyArray_DTypeMeta* a, PyArray_DTypeMeta* b) {
 }
 
 bool SameCurve(EcPointDescr* a, EcPointDescr* b) {
-  return a->base_width_bytes == b->base_width_bytes &&
-         a->num_coords == b->num_coords && a->coord_degree == b->coord_degree &&
-         a->is_montgomery == b->is_montgomery &&
-         PyObject_RichCompareBool(a->modulus, b->modulus, Py_EQ) == 1;
+  if (a->base_width_bytes != b->base_width_bytes ||
+      a->num_coords != b->num_coords || a->coord_degree != b->coord_degree ||
+      a->is_montgomery != b->is_montgomery ||
+      PyObject_RichCompareBool(a->modulus, b->modulus, Py_EQ) != 1) {
+    return false;
+  }
+  // Fp2 (G2) is parameterized by the non-residue; distinct non-residues are
+  // distinct fields even at the same prime.
+  if (a->coord_degree == 2) {
+    return PyObject_RichCompareBool(a->non_residue, b->non_residue, Py_EQ) == 1;
+  }
+  return true;
 }
 
 PyArray_Descr* CommonInstance(PyArray_Descr* a, PyArray_Descr* b) {
@@ -1154,7 +1164,10 @@ int CastLoop(PyArrayMethod_Context* context, char* const* data,
   npy_intp n = dimensions[0];
   char* in = data[0];
   char* out = data[1];
-  if (from->num_coords == to->num_coords) {
+  // Only a byte-identical field is a raw copy; anything else (a coordinate-rep
+  // change OR a Montgomery<->canonical re-encoding at the same shape) must go
+  // through decode/encode below.
+  if (SameCurve(from, to)) {
     npy_intp elsize = context->descriptors[0]->elsize;
     for (npy_intp i = 0; i < n; ++i) {
       std::memcpy(out, in, elsize);
@@ -1522,9 +1535,16 @@ bool AddCmpLoop(PyObject* numpy, const char* name,
                 PyArrayMethod_StridedLoop* loop) {
   PyObject* ufunc = PyObject_GetAttrString(numpy, name);
   if (ufunc == nullptr) return false;
+  // PyArray_DescrFromType returns a new reference; we only need its DType meta
+  // (Py_TYPE, borrowed and immortal), so drop the descr ref.
+  PyArray_Descr* bool_descr = PyArray_DescrFromType(NPY_BOOL);
+  if (bool_descr == nullptr) {
+    Py_DECREF(ufunc);
+    return false;
+  }
   PyArray_DTypeMeta* booldt =
-      reinterpret_cast<PyArray_DTypeMeta*>(Py_TYPE(PyArray_DescrFromType(
-          NPY_BOOL)));  // borrowed: builtin bool descr/DType are immortal
+      reinterpret_cast<PyArray_DTypeMeta*>(Py_TYPE(bool_descr));
+  Py_DECREF(bool_descr);
   PyArray_DTypeMeta* dtypes[3] = {&EcPointDType, &EcPointDType, booldt};
   PyType_Slot slots[] = {
       {NPY_METH_resolve_descriptors, reinterpret_cast<void*>(CmpResolve)},
@@ -1560,12 +1580,24 @@ NPY_CASTING ScalarMulResolve(struct PyArrayMethodObject_tag* /*method*/,
                     "representation; cast the point to Jacobian first");
     return static_cast<NPY_CASTING>(-1);
   }
+  // The output is a Jacobian point on the same curve. A user-supplied out= of a
+  // different curve/representation would be written with the input point's
+  // width (the loop sizes its store from the input) — reject it instead of an
+  // out-of-bounds / wrong-width write.
+  PyArray_Descr* out = given[2] != nullptr ? given[2] : point;
+  if (given[2] != nullptr && !SameCurve(AsEc(out), AsEc(point))) {
+    PyErr_SetString(
+        PyExc_TypeError,
+        "EC scalar multiplication output must be the same curve and "
+        "representation as the point");
+    return static_cast<NPY_CASTING>(-1);
+  }
   Py_INCREF(given[0]);
   loop[0] = given[0];
   Py_INCREF(given[1]);
   loop[1] = given[1];
-  loop[2] = given[2] != nullptr ? given[2] : point;
-  Py_INCREF(loop[2]);
+  Py_INCREF(out);
+  loop[2] = out;
   *view_offset = NPY_MIN_INTP;
   return NPY_NO_CASTING;
 }

--- a/zk_dtypes/_src/ec_point_dtype.cc
+++ b/zk_dtypes/_src/ec_point_dtype.cc
@@ -871,6 +871,286 @@ void EcScalarMul(const CoordField& cf, const unsigned char* point,
   std::memcpy(out, ret, 3 * cb);
 }
 
+// --- typed-limb group law (256-bit coordinate field) ---------------------
+// The byte-space Ec* above re-memcpy every coordinate in and out of every field
+// operation. For the dominant case — a 256-bit Montgomery coordinate field
+// (bn254 / bls12-381 / secp256k1 Fq, G1 and G2) — run the *same* formulas on
+// BigInt<4> values held in locals: load each coordinate from the stored bytes
+// once, compute, store once. Same MontMul<4>/ModAdd/ModSub kernels as the byte
+// path, so the result is byte-identical. Twins of the Jac*/Ec* spec — keep in
+// lockstep.
+
+template <size_t N>
+struct FqOpsBig {
+  BigInt<N> p;
+  BigInt<N> one_mont;  // mont(1) = R mod p
+  uint64_t nprime = 0;
+  bool spare = false;
+  bool no_carry = false;
+  BigInt<N> One() const { return one_mont; }
+  BigInt<N> Zero() const { return BigInt<N>(0); }
+  BigInt<N> Mul(const BigInt<N>& a, const BigInt<N>& b) const {
+    BigInt<N> c;
+    MontMul<N>(a, b, c, p, nprime, spare, no_carry);
+    return c;
+  }
+  BigInt<N> Add(const BigInt<N>& a, const BigInt<N>& b) const {
+    BigInt<N> c;
+    ModAdd<BigInt<N>>(a, b, c, p, spare);
+    return c;
+  }
+  BigInt<N> Sub(const BigInt<N>& a, const BigInt<N>& b) const {
+    BigInt<N> c;
+    ModSub<BigInt<N>>(a, b, c, p, spare);
+    return c;
+  }
+  BigInt<N> Neg(const BigInt<N>& a) const { return Sub(BigInt<N>(0), a); }
+  BigInt<N> MulInt(const BigInt<N>& a, int k) const {
+    BigInt<N> c = a;
+    for (int j = 1; j < k; ++j) c = Add(c, a);
+    return c;
+  }
+  bool IsZero(const BigInt<N>& a) const { return a == BigInt<N>(0); }
+  bool Equal(const BigInt<N>& a, const BigInt<N>& b) const { return a == b; }
+};
+
+template <size_t N>
+struct Fp2 {
+  BigInt<N> c0, c1;
+};
+
+template <size_t N>
+struct Fp2OpsBig {
+  FqOpsBig<N> fq;
+  BigInt<N> mont_nr;
+  Fp2<N> One() const { return {fq.One(), BigInt<N>(0)}; }
+  Fp2<N> Zero() const { return {BigInt<N>(0), BigInt<N>(0)}; }
+  Fp2<N> Add(const Fp2<N>& a, const Fp2<N>& b) const {
+    return {fq.Add(a.c0, b.c0), fq.Add(a.c1, b.c1)};
+  }
+  Fp2<N> Sub(const Fp2<N>& a, const Fp2<N>& b) const {
+    return {fq.Sub(a.c0, b.c0), fq.Sub(a.c1, b.c1)};
+  }
+  Fp2<N> Neg(const Fp2<N>& a) const { return {fq.Neg(a.c0), fq.Neg(a.c1)}; }
+  Fp2<N> MulInt(const Fp2<N>& a, int k) const {
+    return {fq.MulInt(a.c0, k), fq.MulInt(a.c1, k)};
+  }
+  Fp2<N> Mul(const Fp2<N>& a, const Fp2<N>& b) const {
+    // (a0 + a1 u)(b0 + b1 u) = (a0 b0 + nr a1 b1) + (a0 b1 + a1 b0) u.
+    BigInt<N> a0b0 = fq.Mul(a.c0, b.c0);
+    BigInt<N> a1b1 = fq.Mul(a.c1, b.c1);
+    BigInt<N> c0 = fq.Add(a0b0, fq.Mul(mont_nr, a1b1));
+    BigInt<N> c1 = fq.Add(fq.Mul(a.c0, b.c1), fq.Mul(a.c1, b.c0));
+    return {c0, c1};
+  }
+  bool IsZero(const Fp2<N>& a) const {
+    return fq.IsZero(a.c0) && fq.IsZero(a.c1);
+  }
+  bool Equal(const Fp2<N>& a, const Fp2<N>& b) const {
+    return fq.Equal(a.c0, b.c0) && fq.Equal(a.c1, b.c1);
+  }
+};
+
+template <size_t N>
+void LoadCoord(BigInt<N>& c, const unsigned char* p) {
+  std::memcpy(&c[0], p, N * 8);
+}
+template <size_t N>
+void StoreCoord(unsigned char* p, const BigInt<N>& c) {
+  std::memcpy(p, &c[0], N * 8);
+}
+template <size_t N>
+void LoadCoord(Fp2<N>& c, const unsigned char* p) {
+  LoadCoord(c.c0, p);
+  LoadCoord(c.c1, p + N * 8);
+}
+template <size_t N>
+void StoreCoord(unsigned char* p, const Fp2<N>& c) {
+  StoreCoord(p, c.c0);
+  StoreCoord(p + N * 8, c.c1);
+}
+template <typename C>
+void LoadPt(C out[3], const unsigned char* p, int cb) {
+  for (int i = 0; i < 3; ++i) LoadCoord(out[i], p + i * cb);
+}
+template <typename C>
+void StorePt(unsigned char* p, const C in[3], int cb) {
+  for (int i = 0; i < 3; ++i) StoreCoord(p + i * cb, in[i]);
+}
+
+// Jacobian doubling (EFD dbl-2009-l, a == 0). out may alias in.
+template <typename C, typename Ops>
+void EcDoubleT(const Ops& f, const C in[3], C out[3]) {
+  const C& X = in[0];
+  const C& Y = in[1];
+  const C& Z = in[2];
+  C xx = f.Mul(X, X);
+  C yy = f.Mul(Y, Y);
+  C yyyy = f.Mul(yy, yy);
+  C dd = f.MulInt(f.Mul(X, yy), 4);
+  C e = f.MulInt(xx, 3);
+  C X2 = f.Sub(f.Mul(e, e), f.MulInt(dd, 2));
+  C Y2 = f.Sub(f.Mul(e, f.Sub(dd, X2)), f.MulInt(yyyy, 8));
+  C Z2 = f.MulInt(f.Mul(Y, Z), 2);
+  out[0] = X2;
+  out[1] = Y2;
+  out[2] = Z2;
+}
+
+// Jacobian addition (EFD add-2007-bl, a == 0). out may alias an input.
+template <typename C, typename Ops>
+void EcAddT(const Ops& f, const C P[3], const C Q[3], C out[3]) {
+  if (f.IsZero(P[2])) {
+    out[0] = Q[0];
+    out[1] = Q[1];
+    out[2] = Q[2];
+    return;
+  }
+  if (f.IsZero(Q[2])) {
+    out[0] = P[0];
+    out[1] = P[1];
+    out[2] = P[2];
+    return;
+  }
+  C z1z1 = f.Mul(P[2], P[2]);
+  C z2z2 = f.Mul(Q[2], Q[2]);
+  C u1 = f.Mul(P[0], z2z2);
+  C u2 = f.Mul(Q[0], z1z1);
+  C s1 = f.Mul(f.Mul(P[1], Q[2]), z2z2);
+  C s2 = f.Mul(f.Mul(Q[1], P[2]), z1z1);
+  if (f.Equal(u1, u2) && f.Equal(s1, s2)) {  // P == Q
+    EcDoubleT<C, Ops>(f, P, out);
+    return;
+  }
+  C h = f.Sub(u2, u1);
+  C ii = f.Mul(f.MulInt(h, 2), f.MulInt(h, 2));
+  C j = f.Neg(f.Mul(h, ii));
+  C r = f.MulInt(f.Sub(s2, s1), 2);
+  C v = f.Mul(u1, ii);
+  C X3 = f.Sub(f.Add(f.Mul(r, r), j), f.MulInt(v, 2));  // r^2 + j - 2v
+  C Y3 = f.Add(f.Mul(r, f.Sub(v, X3)),
+               f.MulInt(f.Mul(s1, j), 2));          // r(v - X3) + 2 s1 j
+  C Z3 = f.MulInt(f.Mul(f.Mul(P[2], Q[2]), h), 2);  // 2 Z1 Z2 h
+  out[0] = X3;
+  out[1] = Y3;
+  out[2] = Z3;
+}
+
+// Cross-representative group equality; 1 / 0.
+template <typename C, typename Ops>
+int EcEqualT(const Ops& f, const C P[3], const C Q[3]) {
+  bool pz = f.IsZero(P[2]);
+  bool qz = f.IsZero(Q[2]);
+  if (pz || qz) return (pz && qz) ? 1 : 0;
+  C z1s = f.Mul(P[2], P[2]);
+  C z2s = f.Mul(Q[2], Q[2]);
+  bool xe = f.Equal(f.Mul(P[0], z2s), f.Mul(Q[0], z1s));
+  bool ye =
+      f.Equal(f.Mul(P[1], f.Mul(z2s, Q[2])), f.Mul(Q[1], f.Mul(z1s, P[2])));
+  return (xe && ye) ? 1 : 0;
+}
+
+// ret = scalar * point, MSB-first double-and-add (point/ret as typed coords).
+template <typename C, typename Ops>
+void EcScalarMulT(const Ops& f, const C point[3], const unsigned char* sbytes,
+                  int nbits, C ret[3]) {
+  ret[0] = f.One();  // Jacobian zero = (1, 1, 0)
+  ret[1] = f.One();
+  ret[2] = f.Zero();
+  for (int i = nbits - 1; i >= 0; --i) {
+    EcDoubleT<C, Ops>(f, ret, ret);
+    if ((sbytes[i >> 3] >> (i & 7)) & 1) EcAddT<C, Ops>(f, ret, point, ret);
+  }
+}
+
+// Build the typed 256-bit ops from the already-extracted CoordField constants.
+FqOpsBig<4> MakeFqOps(const CoordField& cf) {
+  FqOpsBig<4> f;
+  f.p = cf.fq.p256;
+  LoadCoord(f.one_mont, cf.one_le);
+  f.nprime = cf.fq.nprime_neg;
+  f.spare = cf.fq.spare;
+  f.no_carry = cf.fq.no_carry;
+  return f;
+}
+Fp2OpsBig<4> MakeFp2Ops(const CoordField& cf) {
+  Fp2OpsBig<4> f;
+  f.fq = MakeFqOps(cf);
+  LoadCoord(f.mont_nr, cf.mont_nr);
+  return f;
+}
+
+// Typed loop bodies (256-bit Jacobian). C = BigInt<4> (G1) or Fp2<4> (G2).
+template <typename C, typename Ops>
+void RunBinT(const Ops& f, bool sub, char* a, char* b, char* o, npy_intp n,
+             const npy_intp* st, int cb) {
+  for (npy_intp i = 0; i < n; ++i) {
+    C P[3], Q[3], R[3];
+    LoadPt<C>(P, reinterpret_cast<const unsigned char*>(a), cb);
+    LoadPt<C>(Q, reinterpret_cast<const unsigned char*>(b), cb);
+    if (sub) {
+      C nq[3] = {Q[0], f.Neg(Q[1]), Q[2]};
+      EcAddT<C, Ops>(f, P, nq, R);
+    } else {
+      EcAddT<C, Ops>(f, P, Q, R);
+    }
+    StorePt<C>(reinterpret_cast<unsigned char*>(o), R, cb);
+    a += st[0];
+    b += st[1];
+    o += st[2];
+  }
+}
+template <typename C, typename Ops>
+void RunNegT(const Ops& f, char* a, char* o, npy_intp n, const npy_intp* st,
+             int cb, int num_coords) {
+  for (npy_intp i = 0; i < n; ++i) {
+    for (int k = 0; k < num_coords; ++k) {
+      C c;
+      LoadCoord(c, reinterpret_cast<const unsigned char*>(a) + k * cb);
+      if (k == 1) c = f.Neg(c);
+      StoreCoord(reinterpret_cast<unsigned char*>(o) + k * cb, c);
+    }
+    a += st[0];
+    o += st[1];
+  }
+}
+template <typename C, typename Ops>
+void RunCmpT(const Ops& f, bool negate, char* a, char* b, char* o, npy_intp n,
+             const npy_intp* st, int cb) {
+  for (npy_intp i = 0; i < n; ++i) {
+    C P[3], Q[3];
+    LoadPt<C>(P, reinterpret_cast<const unsigned char*>(a), cb);
+    LoadPt<C>(Q, reinterpret_cast<const unsigned char*>(b), cb);
+    int eq = EcEqualT<C, Ops>(f, P, Q);
+    *reinterpret_cast<npy_bool*>(o) = (negate ? !eq : eq) ? 1 : 0;
+    a += st[0];
+    b += st[1];
+    o += st[2];
+  }
+}
+template <typename C, typename Ops>
+int RunScalarT(const Ops& f, PyArray_Descr* scalar_descr, char* s, char* pt,
+               char* o, npy_intp n, npy_intp s_stride, npy_intp pt_stride,
+               npy_intp o_stride, int cb) {
+  for (npy_intp i = 0; i < n; ++i) {
+    PyObject* scalar =
+        PrimeFieldValue(reinterpret_cast<PyObject*>(scalar_descr), s);
+    if (scalar == nullptr) return -1;
+    unsigned char buf[64];
+    Py_ssize_t nbits = ScalarToBytesLE(scalar, buf, sizeof(buf));
+    Py_DECREF(scalar);
+    if (nbits < 0) return -1;
+    C point[3], ret[3];
+    LoadPt<C>(point, reinterpret_cast<const unsigned char*>(pt), cb);
+    EcScalarMulT<C, Ops>(f, point, buf, static_cast<int>(nbits), ret);
+    StorePt<C>(reinterpret_cast<unsigned char*>(o), ret, cb);
+    s += s_stride;
+    pt += pt_stride;
+    o += o_stride;
+  }
+  return 0;
+}
+
 // --- descriptor lifecycle ------------------------------------------------
 
 PyArray_Descr* MakeDescr(PyObject* modulus, int base_width_bytes,
@@ -1349,6 +1629,17 @@ int BinLoop(PyArrayMethod_Context* context, char* const* data,
   char* b = data[1];
   char* o = data[2];
   CoordField cf = CoordField::Make(d);
+  if (cf.ok &&
+      cf.wb == 32) {  // typed-limb fast path (256-bit coordinate field)
+    if (cf.degree == 1) {
+      RunBinT<BigInt<4>>(MakeFqOps(cf), op == BinOp::kSub, a, b, o, n, strides,
+                         cf.cb);
+    } else {
+      RunBinT<Fp2<4>>(MakeFp2Ops(cf), op == BinOp::kSub, a, b, o, n, strides,
+                      cf.cb);
+    }
+    return 0;
+  }
   if (cf.ok) {  // num_coords == 3 guaranteed by BinResolve
     unsigned char neg_q[3 * kCoordBytes];
     for (npy_intp i = 0; i < n; ++i) {
@@ -1410,6 +1701,15 @@ int NegLoop(PyArrayMethod_Context* context, char* const* data,
   char* a = data[0];
   char* o = data[1];
   CoordField cf = CoordField::Make(d);
+  if (cf.ok &&
+      cf.wb == 32) {  // typed-limb fast path (negate flips Y per coord)
+    if (cf.degree == 1) {
+      RunNegT<BigInt<4>>(MakeFqOps(cf), a, o, n, strides, cf.cb, d->num_coords);
+    } else {
+      RunNegT<Fp2<4>>(MakeFp2Ops(cf), a, o, n, strides, cf.cb, d->num_coords);
+    }
+    return 0;
+  }
   if (cf.ok) {
     for (npy_intp i = 0; i < n; ++i) {
       EcNegate(cf, reinterpret_cast<const unsigned char*>(a),
@@ -1521,6 +1821,14 @@ int CmpLoop(PyArrayMethod_Context* context, char* const* data,
   char* b = data[1];
   char* o = data[2];
   CoordField cf = CoordField::Make(d);
+  if (cf.ok && cf.wb == 32) {  // typed-limb fast path (256-bit)
+    if (cf.degree == 1) {
+      RunCmpT<BigInt<4>>(MakeFqOps(cf), negate, a, b, o, n, strides, cf.cb);
+    } else {
+      RunCmpT<Fp2<4>>(MakeFp2Ops(cf), negate, a, b, o, n, strides, cf.cb);
+    }
+    return 0;
+  }
   if (cf.ok) {  // num_coords == 3 guaranteed by CmpResolve
     for (npy_intp i = 0; i < n; ++i) {
       int eq = EcEqual(cf, reinterpret_cast<const unsigned char*>(a),
@@ -1639,6 +1947,14 @@ int ScalarMulLoop(PyArrayMethod_Context* context, char* const* data,
   npy_intp s_stride = strides[scalar_first ? 0 : 1];
   npy_intp pt_stride = strides[scalar_first ? 1 : 0];
   CoordField cf = CoordField::Make(d);
+  if (cf.ok && d->num_coords == 3 && cf.wb == 32) {  // typed-limb fast path
+    if (cf.degree == 1) {
+      return RunScalarT<BigInt<4>>(MakeFqOps(cf), scalar_descr, s, pt, o, n,
+                                   s_stride, pt_stride, strides[2], cf.cb);
+    }
+    return RunScalarT<Fp2<4>>(MakeFp2Ops(cf), scalar_descr, s, pt, o, n,
+                              s_stride, pt_stride, strides[2], cf.cb);
+  }
   if (cf.ok && d->num_coords == 3) {
     for (npy_intp i = 0; i < n; ++i) {
       PyObject* scalar =

--- a/zk_dtypes/_src/ec_point_dtype.cc
+++ b/zk_dtypes/_src/ec_point_dtype.cc
@@ -1,0 +1,826 @@
+/* Copyright 2025 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Parametric elliptic-curve point numpy DType (NEP-42). An EC point group is a
+// Module, not a Field: the ops are point add / subtract / negate (and, later,
+// scalar multiplication) — there is no point*point. This first cut covers
+// short-Weierstrass G1 (a=0) Jacobian points over a prime coordinate field.
+//
+// A point is `num_coords` coordinate-field elements (X, Y, Z for Jacobian),
+// stored exactly as the coordinate field stores them (canonical or per-coord
+// Montgomery, little-endian). The add/double formulas (EFD add-2007-bl /
+// dbl-2009-l) are R-linear, so we decode coordinates to canonical, run the
+// group law with prime-field arithmetic, and re-encode — byte-identical to the
+// legacy Montgomery formulas because the resulting representative is the same.
+
+// numpy.h must precede every other numpy header (it sets the API symbol) and
+// NPY_TARGET_VERSION must precede numpyconfig.h; the associated header pulls in
+// only <Python.h>, so it can lead. Keep this order — do not let clang-format
+// sort it.
+// clang-format off
+#define NPY_TARGET_VERSION NPY_2_0_API_VERSION
+#include "zk_dtypes/_src/ec_point_dtype.h"
+
+#include <cstdint>
+#include <cstring>
+
+#include "zk_dtypes/_src/numpy.h"
+#include "numpy/dtype_api.h"
+#include "numpy/ndarraytypes.h"
+// clang-format on
+
+namespace zk_dtypes {
+namespace {
+
+constexpr int kMaxCoords = 4;
+
+struct EcPointDescr {
+  PyArray_Descr base;
+  PyObject* modulus;  // owned: coordinate prime field modulus
+  PyObject* r_mod_p;  // owned (Montgomery): R = 2^base_width mod p; else NULL
+  PyObject* rinv_mod_p;  // owned (Montgomery): R^-1 mod p; else NULL
+  uint8_t base_width_bytes;
+  uint8_t num_coords;  // 3 for Jacobian (X, Y, Z)
+  uint8_t is_montgomery;
+};
+
+PyArray_DTypeMeta EcPointDType = {};
+PyTypeObject EcPointScalar_Type = {};
+
+EcPointDescr* AsEc(PyArray_Descr* d) {
+  return reinterpret_cast<EcPointDescr*>(d);
+}
+
+// --- coordinate (prime field) encode / decode ---------------------------
+
+PyObject* DecodeCoord(EcPointDescr* d, const char* slot) {
+  PyObject* stored = _PyLong_FromByteArray(
+      reinterpret_cast<const unsigned char*>(slot), d->base_width_bytes, 1, 0);
+  if (stored == nullptr || !d->is_montgomery) {
+    return stored;
+  }
+  PyObject* scaled = PyNumber_Multiply(stored, d->rinv_mod_p);
+  Py_DECREF(stored);
+  if (scaled == nullptr) {
+    return nullptr;
+  }
+  PyObject* canonical = PyNumber_Remainder(scaled, d->modulus);
+  Py_DECREF(scaled);
+  return canonical;
+}
+
+int EncodeCoord(EcPointDescr* d, char* slot, PyObject* value) {
+  PyObject* rem = PyNumber_Remainder(value, d->modulus);
+  if (rem == nullptr) {
+    return -1;
+  }
+  if (d->is_montgomery) {
+    PyObject* scaled = PyNumber_Multiply(rem, d->r_mod_p);
+    Py_DECREF(rem);
+    if (scaled == nullptr) {
+      return -1;
+    }
+    rem = PyNumber_Remainder(scaled, d->modulus);
+    Py_DECREF(scaled);
+    if (rem == nullptr) {
+      return -1;
+    }
+  }
+  int rc = _PyLong_AsByteArray(reinterpret_cast<PyLongObject*>(rem),
+                               reinterpret_cast<unsigned char*>(slot),
+                               d->base_width_bytes, 1, 0);
+  Py_DECREF(rem);
+  return rc < 0 ? -1 : 0;
+}
+
+int DecodePoint(EcPointDescr* d, const char* ptr, PyObject** out) {
+  for (int i = 0; i < d->num_coords; ++i) {
+    out[i] = DecodeCoord(d, ptr + i * d->base_width_bytes);
+    if (out[i] == nullptr) {
+      for (int j = 0; j < i; ++j) Py_DECREF(out[j]);
+      return -1;
+    }
+  }
+  return 0;
+}
+
+int EncodePoint(EcPointDescr* d, char* ptr, PyObject* const* coords) {
+  for (int i = 0; i < d->num_coords; ++i) {
+    if (EncodeCoord(d, ptr + i * d->base_width_bytes, coords[i]) < 0) {
+      return -1;
+    }
+  }
+  return 0;
+}
+
+// --- prime-field helpers on canonical Python ints -----------------------
+
+PyObject* FMod(PyObject* p, PyObject* x) { return PyNumber_Remainder(x, p); }
+
+PyObject* FAdd(PyObject* p, PyObject* a, PyObject* b) {
+  PyObject* s = PyNumber_Add(a, b);
+  if (!s) return nullptr;
+  PyObject* r = PyNumber_Remainder(s, p);
+  Py_DECREF(s);
+  return r;
+}
+
+PyObject* FSub(PyObject* p, PyObject* a, PyObject* b) {
+  PyObject* s = PyNumber_Subtract(a, b);
+  if (!s) return nullptr;
+  PyObject* r = PyNumber_Remainder(s, p);  // Python % is non-negative
+  Py_DECREF(s);
+  return r;
+}
+
+PyObject* FMul(PyObject* p, PyObject* a, PyObject* b) {
+  PyObject* s = PyNumber_Multiply(a, b);
+  if (!s) return nullptr;
+  PyObject* r = PyNumber_Remainder(s, p);
+  Py_DECREF(s);
+  return r;
+}
+
+PyObject* FMulInt(PyObject* p, PyObject* a, long k) {
+  PyObject* kk = PyLong_FromLong(k);
+  if (!kk) return nullptr;
+  PyObject* r = FMul(p, a, kk);
+  Py_DECREF(kk);
+  return r;
+}
+
+bool IsZeroCoord(PyObject* x) { return PyObject_IsTrue(x) == 0; }
+
+// Jacobian doubling, a == 0 (EFD dbl-2009-l). in/out: 3 canonical coords.
+int JacDouble(PyObject* p, PyObject* const* in, PyObject** out) {
+  PyObject* X = in[0];
+  PyObject* Y = in[1];
+  PyObject* Z = in[2];
+  PyObject* xx = FMul(p, X, X);
+  PyObject* yy = FMul(p, Y, Y);
+  PyObject* yyyy = yy ? FMul(p, yy, yy) : nullptr;
+  PyObject* xyy = (xx && yy) ? FMul(p, X, yy) : nullptr;
+  PyObject* d = xyy ? FMulInt(p, xyy, 4) : nullptr;  // d = 4*X*yy
+  PyObject* e = xx ? FMulInt(p, xx, 3) : nullptr;    // e = 3*xx
+  PyObject* ee = e ? FMul(p, e, e) : nullptr;
+  PyObject* twod = d ? FMulInt(p, d, 2) : nullptr;
+  PyObject* X2 = (ee && twod) ? FSub(p, ee, twod) : nullptr;  // e^2 - 2d
+  PyObject* dmx = (d && X2) ? FSub(p, d, X2) : nullptr;
+  PyObject* edmx = (e && dmx) ? FMul(p, e, dmx) : nullptr;
+  PyObject* eightyyyy = yyyy ? FMulInt(p, yyyy, 8) : nullptr;
+  PyObject* Y2 = (edmx && eightyyyy) ? FSub(p, edmx, eightyyyy) : nullptr;
+  PyObject* yz = FMul(p, Y, Z);
+  PyObject* Z2 = yz ? FMulInt(p, yz, 2) : nullptr;
+  Py_XDECREF(xx);
+  Py_XDECREF(yy);
+  Py_XDECREF(yyyy);
+  Py_XDECREF(xyy);
+  Py_XDECREF(d);
+  Py_XDECREF(e);
+  Py_XDECREF(ee);
+  Py_XDECREF(twod);
+  Py_XDECREF(dmx);
+  Py_XDECREF(edmx);
+  Py_XDECREF(eightyyyy);
+  Py_XDECREF(yz);
+  if (!X2 || !Y2 || !Z2) {
+    Py_XDECREF(X2);
+    Py_XDECREF(Y2);
+    Py_XDECREF(Z2);
+    return -1;
+  }
+  out[0] = X2;
+  out[1] = Y2;
+  out[2] = Z2;
+  return 0;
+}
+
+void CopyPoint(PyObject* const* in, PyObject** out, int n) {
+  for (int i = 0; i < n; ++i) {
+    Py_INCREF(in[i]);
+    out[i] = in[i];
+  }
+}
+
+// Jacobian addition (EFD add-2007-bl), a == 0. in1/in2/out: 3 canonical coords.
+int JacAdd(PyObject* p, PyObject* const* P, PyObject* const* Q,
+           PyObject** out) {
+  if (IsZeroCoord(P[2])) {  // P is infinity
+    CopyPoint(Q, out, 3);
+    return 0;
+  }
+  if (IsZeroCoord(Q[2])) {  // Q is infinity
+    CopyPoint(P, out, 3);
+    return 0;
+  }
+  PyObject *X1 = P[0], *Y1 = P[1], *Z1 = P[2];
+  PyObject *X2 = Q[0], *Y2 = Q[1], *Z2 = Q[2];
+  PyObject* z1z1 = FMul(p, Z1, Z1);
+  PyObject* z2z2 = FMul(p, Z2, Z2);
+  PyObject* u1 = z2z2 ? FMul(p, X1, z2z2) : nullptr;
+  PyObject* u2 = z1z1 ? FMul(p, X2, z1z1) : nullptr;
+  PyObject* yz2 = z2z2 ? FMul(p, Y1, Z2) : nullptr;
+  PyObject* s1 = yz2 ? FMul(p, yz2, z2z2) : nullptr;
+  PyObject* yz1 = z1z1 ? FMul(p, Y2, Z1) : nullptr;
+  PyObject* s2 = yz1 ? FMul(p, yz1, z1z1) : nullptr;
+  int rc = -1;
+  if (!u1 || !u2 || !s1 || !s2) goto cleanup;
+  if (PyObject_RichCompareBool(u1, u2, Py_EQ) == 1 &&
+      PyObject_RichCompareBool(s1, s2, Py_EQ) == 1) {
+    rc = JacDouble(p, P, out);
+    goto cleanup;
+  }
+  {
+    PyObject* h = FSub(p, u2, u1);
+    PyObject* twoh = h ? FMulInt(p, h, 2) : nullptr;
+    PyObject* i = twoh ? FMul(p, twoh, twoh) : nullptr;  // (2h)^2
+    PyObject* hi = (h && i) ? FMul(p, h, i) : nullptr;
+    PyObject* j =
+        hi ? FSub(p, p, hi) : nullptr;  // j = -(h*i) = p - h*i (then mod)
+    PyObject* sdiff = FSub(p, s2, s1);
+    PyObject* r = sdiff ? FMulInt(p, sdiff, 2) : nullptr;  // 2(s2-s1)
+    PyObject* v = i ? FMul(p, u1, i) : nullptr;
+    PyObject* rr = r ? FMul(p, r, r) : nullptr;
+    PyObject* twov = v ? FMulInt(p, v, 2) : nullptr;
+    PyObject* rrj = (rr && j) ? FAdd(p, rr, j) : nullptr;
+    PyObject* X3 =
+        (rrj && twov) ? FSub(p, rrj, twov) : nullptr;  // r^2 + j - 2v
+    PyObject* vmx = (v && X3) ? FSub(p, v, X3) : nullptr;
+    PyObject* rvmx = (r && vmx) ? FMul(p, r, vmx) : nullptr;
+    PyObject* s1j = (s1 && j) ? FMul(p, s1, j) : nullptr;
+    PyObject* twos1j = s1j ? FMulInt(p, s1j, 2) : nullptr;
+    PyObject* Y3 =
+        (rvmx && twos1j) ? FAdd(p, rvmx, twos1j) : nullptr;  // r(v-X3) + 2*s1*j
+    PyObject* z1z2 = FMul(p, Z1, Z2);
+    PyObject* z1z2h = (z1z2 && h) ? FMul(p, z1z2, h) : nullptr;
+    PyObject* Z3 = z1z2h ? FMulInt(p, z1z2h, 2) : nullptr;  // 2*Z1*Z2*h
+    Py_XDECREF(h);
+    Py_XDECREF(twoh);
+    Py_XDECREF(i);
+    Py_XDECREF(hi);
+    Py_XDECREF(sdiff);
+    Py_XDECREF(r);
+    Py_XDECREF(v);
+    Py_XDECREF(rr);
+    Py_XDECREF(twov);
+    Py_XDECREF(rrj);
+    Py_XDECREF(vmx);
+    Py_XDECREF(rvmx);
+    Py_XDECREF(s1j);
+    Py_XDECREF(twos1j);
+    Py_XDECREF(z1z2);
+    Py_XDECREF(z1z2h);
+    if (!X3 || !Y3 || !Z3 || !j) {
+      Py_XDECREF(X3);
+      Py_XDECREF(Y3);
+      Py_XDECREF(Z3);
+      Py_XDECREF(j);
+      goto cleanup;
+    }
+    Py_DECREF(j);
+    out[0] = X3;
+    out[1] = Y3;
+    out[2] = Z3;
+    rc = 0;
+  }
+cleanup:
+  Py_XDECREF(z1z1);
+  Py_XDECREF(z2z2);
+  Py_XDECREF(u1);
+  Py_XDECREF(u2);
+  Py_XDECREF(yz2);
+  Py_XDECREF(s1);
+  Py_XDECREF(yz1);
+  Py_XDECREF(s2);
+  return rc;
+}
+
+// Negate: flip Y only.
+int JacNegate(PyObject* p, PyObject* const* in, PyObject** out) {
+  PyObject* negY = FSub(p, p, in[1]);  // -Y = p - Y (then mod)
+  if (negY == nullptr) {
+    return -1;
+  }
+  PyObject* y = FMod(p, negY);
+  Py_DECREF(negY);
+  if (y == nullptr) {
+    return -1;
+  }
+  Py_INCREF(in[0]);
+  out[0] = in[0];
+  out[1] = y;
+  Py_INCREF(in[2]);
+  out[2] = in[2];
+  return 0;
+}
+
+// --- descriptor lifecycle ------------------------------------------------
+
+PyArray_Descr* MakeDescr(PyObject* modulus, int base_width_bytes,
+                         int num_coords, int is_montgomery, PyObject* r,
+                         PyObject* rinv) {
+  auto* d = reinterpret_cast<EcPointDescr*>(PyArrayDescr_Type.tp_new(
+      reinterpret_cast<PyTypeObject*>(&EcPointDType), nullptr, nullptr));
+  if (d == nullptr) {
+    return nullptr;
+  }
+  Py_INCREF(modulus);
+  d->modulus = modulus;
+  Py_XINCREF(r);
+  d->r_mod_p = r;
+  Py_XINCREF(rinv);
+  d->rinv_mod_p = rinv;
+  d->base_width_bytes = static_cast<uint8_t>(base_width_bytes);
+  d->num_coords = static_cast<uint8_t>(num_coords);
+  d->is_montgomery = static_cast<uint8_t>(is_montgomery ? 1 : 0);
+  PyArray_Descr* base = &d->base;
+  base->kind = 'V';
+  base->type = 'j';
+  base->byteorder = '=';
+  base->flags = NPY_USE_GETITEM | NPY_USE_SETITEM;
+  base->elsize = base_width_bytes * num_coords;
+  base->alignment = base_width_bytes <= 8 ? base_width_bytes : 8;
+  return base;
+}
+
+void Descr_dealloc(PyObject* self) {
+  EcPointDescr* d = AsEc(reinterpret_cast<PyArray_Descr*>(self));
+  Py_XDECREF(d->modulus);
+  Py_XDECREF(d->r_mod_p);
+  Py_XDECREF(d->rinv_mod_p);
+  PyArrayDescr_Type.tp_dealloc(self);
+}
+
+PyObject* DType_new(PyTypeObject* /*cls*/, PyObject* /*args*/,
+                    PyObject* /*kwds*/) {
+  PyErr_SetString(
+      PyExc_TypeError,
+      "construct an EC point dtype via zk_dtypes.ec_point(...), not "
+      "EcPointDType(...) directly");
+  return nullptr;
+}
+
+PyObject* Descr_repr(PyObject* self) {
+  EcPointDescr* d = AsEc(reinterpret_cast<PyArray_Descr*>(self));
+  return PyUnicode_FromFormat(
+      "EcPointDType(modulus=%R, coords=%d, base_width=%d, mont=%d)", d->modulus,
+      static_cast<int>(d->num_coords), d->base_width_bytes * 8,
+      static_cast<int>(d->is_montgomery));
+}
+
+// --- NEP-42 DType slots --------------------------------------------------
+
+PyArray_Descr* DefaultDescr(PyArray_DTypeMeta* /*cls*/) {
+  PyObject* two = PyLong_FromLong(2);
+  if (two == nullptr) {
+    return nullptr;
+  }
+  PyArray_Descr* d = MakeDescr(two, 4, 3, 0, nullptr, nullptr);
+  Py_DECREF(two);
+  return d;
+}
+
+PyArray_DTypeMeta* CommonDType(PyArray_DTypeMeta* a, PyArray_DTypeMeta* b) {
+  if (a == b) {
+    Py_INCREF(a);
+    return a;
+  }
+  Py_INCREF(Py_NotImplemented);
+  return reinterpret_cast<PyArray_DTypeMeta*>(Py_NotImplemented);
+}
+
+bool SameCurve(EcPointDescr* a, EcPointDescr* b) {
+  return a->base_width_bytes == b->base_width_bytes &&
+         a->num_coords == b->num_coords &&
+         a->is_montgomery == b->is_montgomery &&
+         PyObject_RichCompareBool(a->modulus, b->modulus, Py_EQ) == 1;
+}
+
+PyArray_Descr* CommonInstance(PyArray_Descr* a, PyArray_Descr* b) {
+  if (SameCurve(AsEc(a), AsEc(b))) {
+    Py_INCREF(a);
+    return a;
+  }
+  PyErr_SetString(PyExc_TypeError, "cannot combine points of different curves");
+  return nullptr;
+}
+
+PyArray_Descr* EnsureCanonical(PyArray_Descr* self) {
+  Py_INCREF(self);
+  return self;
+}
+
+PyArray_Descr* DiscoverDescrFromPyobject(PyArray_DTypeMeta* /*cls*/,
+                                         PyObject* /*obj*/) {
+  PyErr_SetString(PyExc_TypeError,
+                  "cannot infer an EC point dtype from a scalar; pass an "
+                  "explicit dtype=zk_dtypes.ec_point(...)");
+  return nullptr;
+}
+
+// setitem accepts a length-num_coords sequence of coordinate integers.
+int SetItem(PyArray_Descr* descr, PyObject* obj, char* dataptr) {
+  EcPointDescr* d = AsEc(descr);
+  PyObject* seq = PySequence_Fast(obj, "EC point needs a coordinate sequence");
+  if (seq == nullptr) {
+    return -1;
+  }
+  if (PySequence_Fast_GET_SIZE(seq) != d->num_coords) {
+    PyErr_Format(PyExc_ValueError, "EC point needs %d coordinates, got %zd",
+                 d->num_coords, PySequence_Fast_GET_SIZE(seq));
+    Py_DECREF(seq);
+    return -1;
+  }
+  PyObject* coords[kMaxCoords] = {nullptr};
+  int rc = -1;
+  for (int i = 0; i < d->num_coords; ++i) {
+    coords[i] = PyNumber_Index(PySequence_Fast_GET_ITEM(seq, i));
+    if (coords[i] == nullptr) {
+      goto done;
+    }
+  }
+  rc = EncodePoint(d, dataptr, coords);
+done:
+  Py_DECREF(seq);
+  for (int i = 0; i < d->num_coords; ++i) Py_XDECREF(coords[i]);
+  return rc;
+}
+
+PyObject* GetItem(PyArray_Descr* descr, char* dataptr) {
+  EcPointDescr* d = AsEc(descr);
+  PyObject* coords[kMaxCoords] = {nullptr};
+  if (DecodePoint(d, dataptr, coords) < 0) {
+    return nullptr;
+  }
+  PyObject* tuple = PyTuple_New(d->num_coords);
+  if (tuple == nullptr) {
+    for (int i = 0; i < d->num_coords; ++i) Py_DECREF(coords[i]);
+    return nullptr;
+  }
+  for (int i = 0; i < d->num_coords; ++i) {
+    PyTuple_SET_ITEM(tuple, i, coords[i]);
+  }
+  return tuple;
+}
+
+// --- within-DType copy cast ---------------------------------------------
+
+NPY_CASTING CastResolve(struct PyArrayMethodObject_tag* /*method*/,
+                        PyArray_DTypeMeta* const* /*dtypes*/,
+                        PyArray_Descr* const* given, PyArray_Descr** loop,
+                        npy_intp* view_offset) {
+  PyArray_Descr* from = given[0];
+  Py_INCREF(from);
+  loop[0] = from;
+  PyArray_Descr* to = given[1];
+  if (to == nullptr) {
+    Py_INCREF(from);
+    loop[1] = from;
+    *view_offset = 0;
+    return NPY_NO_CASTING;
+  }
+  Py_INCREF(to);
+  loop[1] = to;
+  if (SameCurve(AsEc(from), AsEc(to))) {
+    *view_offset = 0;
+    return NPY_NO_CASTING;
+  }
+  return NPY_UNSAFE_CASTING;
+}
+
+int CastLoop(PyArrayMethod_Context* context, char* const* data,
+             const npy_intp* dimensions, const npy_intp* strides,
+             NpyAuxData* /*aux*/) {
+  npy_intp n = dimensions[0];
+  char* in = data[0];
+  char* out = data[1];
+  npy_intp elsize = context->descriptors[0]->elsize;
+  for (npy_intp i = 0; i < n; ++i) {
+    std::memcpy(out, in, elsize);
+    in += strides[0];
+    out += strides[1];
+  }
+  return 0;
+}
+
+// --- factory -------------------------------------------------------------
+
+PyObject* MakeEcPointDescrPy(PyObject* /*self*/, PyObject* args) {
+  PyObject* modulus_obj;
+  int base_width_bits;
+  int num_coords;
+  int is_montgomery;
+  PyObject* r_obj = nullptr;
+  PyObject* rinv_obj = nullptr;
+  if (!PyArg_ParseTuple(args, "Oiii|OO", &modulus_obj, &base_width_bits,
+                        &num_coords, &is_montgomery, &r_obj, &rinv_obj)) {
+    return nullptr;
+  }
+  if (base_width_bits != 32 && base_width_bits != 64 &&
+      base_width_bits != 128 && base_width_bits != 256) {
+    PyErr_SetString(PyExc_ValueError,
+                    "base_width_bits must be one of 32, 64, 128, 256");
+    return nullptr;
+  }
+  if (num_coords < 2 || num_coords > kMaxCoords) {
+    PyErr_Format(PyExc_ValueError, "num_coords must be in [2, %d]", kMaxCoords);
+    return nullptr;
+  }
+  if (is_montgomery && (r_obj == nullptr || rinv_obj == nullptr)) {
+    PyErr_SetString(PyExc_ValueError,
+                    "Montgomery storage requires r_mod_p and rinv_mod_p");
+    return nullptr;
+  }
+  PyObject* modulus = PyNumber_Index(modulus_obj);
+  if (modulus == nullptr) {
+    return nullptr;
+  }
+  PyObject* r = nullptr;
+  PyObject* rinv = nullptr;
+  if (is_montgomery) {
+    r = PyNumber_Index(r_obj);
+    rinv = (r == nullptr) ? nullptr : PyNumber_Index(rinv_obj);
+    if (r == nullptr || rinv == nullptr) {
+      Py_DECREF(modulus);
+      Py_XDECREF(r);
+      return nullptr;
+    }
+  }
+  PyArray_Descr* d = MakeDescr(modulus, base_width_bits / 8, num_coords,
+                               is_montgomery, r, rinv);
+  Py_DECREF(modulus);
+  Py_XDECREF(r);
+  Py_XDECREF(rinv);
+  return reinterpret_cast<PyObject*>(d);
+}
+
+PyMethodDef kModuleMethods[] = {
+    {"ec_point_descr", MakeEcPointDescrPy, METH_VARARGS,
+     "ec_point_descr(modulus, base_width_bits, num_coords, is_montgomery"
+     "[, r_mod_p, rinv_mod_p]) -> dtype\n\n"
+     "Build a parametric G1 Jacobian EC-point descriptor."},
+    {nullptr, nullptr, 0, nullptr},
+};
+
+// --- group-law ufunc loops ----------------------------------------------
+
+NPY_CASTING BinResolve(struct PyArrayMethodObject_tag* /*method*/,
+                       PyArray_DTypeMeta* const* /*dtypes*/,
+                       PyArray_Descr* const* given, PyArray_Descr** loop,
+                       npy_intp* view_offset) {
+  if (!SameCurve(AsEc(given[0]), AsEc(given[1]))) {
+    PyErr_SetString(PyExc_TypeError, "point op requires the same curve");
+    return static_cast<NPY_CASTING>(-1);
+  }
+  Py_INCREF(given[0]);
+  loop[0] = given[0];
+  Py_INCREF(given[1]);
+  loop[1] = given[1];
+  PyArray_Descr* out = given[2] == nullptr ? given[0] : given[2];
+  Py_INCREF(out);
+  loop[2] = out;
+  *view_offset = NPY_MIN_INTP;
+  return NPY_NO_CASTING;
+}
+
+NPY_CASTING UnaryResolve(struct PyArrayMethodObject_tag* /*method*/,
+                         PyArray_DTypeMeta* const* /*dtypes*/,
+                         PyArray_Descr* const* given, PyArray_Descr** loop,
+                         npy_intp* view_offset) {
+  Py_INCREF(given[0]);
+  loop[0] = given[0];
+  PyArray_Descr* out = given[1] == nullptr ? given[0] : given[1];
+  Py_INCREF(out);
+  loop[1] = out;
+  *view_offset = NPY_MIN_INTP;
+  return NPY_NO_CASTING;
+}
+
+enum class BinOp { kAdd, kSub };
+
+template <BinOp op>
+int BinLoop(PyArrayMethod_Context* context, char* const* data,
+            const npy_intp* dimensions, const npy_intp* strides,
+            NpyAuxData* /*aux*/) {
+  EcPointDescr* d = AsEc(context->descriptors[0]);
+  PyObject* p = d->modulus;
+  npy_intp n = dimensions[0];
+  char* a = data[0];
+  char* b = data[1];
+  char* o = data[2];
+  for (npy_intp i = 0; i < n; ++i) {
+    PyObject* P[kMaxCoords];
+    PyObject* Q[kMaxCoords];
+    PyObject* R[kMaxCoords];
+    if (DecodePoint(d, a, P) < 0) return -1;
+    if (DecodePoint(d, b, Q) < 0) {
+      for (int j = 0; j < d->num_coords; ++j) Py_DECREF(P[j]);
+      return -1;
+    }
+    int rc;
+    if (op == BinOp::kSub) {
+      PyObject* negQ[kMaxCoords];
+      rc = JacNegate(p, Q, negQ);
+      if (rc == 0) {
+        rc = JacAdd(p, P, negQ, R);
+        for (int j = 0; j < d->num_coords; ++j) Py_DECREF(negQ[j]);
+      }
+    } else {
+      rc = JacAdd(p, P, Q, R);
+    }
+    for (int j = 0; j < d->num_coords; ++j) {
+      Py_DECREF(P[j]);
+      Py_DECREF(Q[j]);
+    }
+    if (rc < 0) return -1;
+    int erc = EncodePoint(d, o, R);
+    for (int j = 0; j < d->num_coords; ++j) Py_DECREF(R[j]);
+    if (erc < 0) return -1;
+    a += strides[0];
+    b += strides[1];
+    o += strides[2];
+  }
+  return 0;
+}
+
+int NegLoop(PyArrayMethod_Context* context, char* const* data,
+            const npy_intp* dimensions, const npy_intp* strides,
+            NpyAuxData* /*aux*/) {
+  EcPointDescr* d = AsEc(context->descriptors[0]);
+  PyObject* p = d->modulus;
+  npy_intp n = dimensions[0];
+  char* a = data[0];
+  char* o = data[1];
+  for (npy_intp i = 0; i < n; ++i) {
+    PyObject* P[kMaxCoords];
+    PyObject* R[kMaxCoords];
+    if (DecodePoint(d, a, P) < 0) return -1;
+    int rc = JacNegate(p, P, R);
+    for (int j = 0; j < d->num_coords; ++j) Py_DECREF(P[j]);
+    if (rc < 0) return -1;
+    int erc = EncodePoint(d, o, R);
+    for (int j = 0; j < d->num_coords; ++j) Py_DECREF(R[j]);
+    if (erc < 0) return -1;
+    a += strides[0];
+    o += strides[1];
+  }
+  return 0;
+}
+
+bool AddBinLoop(PyObject* numpy, const char* name,
+                PyArrayMethod_StridedLoop* loop) {
+  PyObject* ufunc = PyObject_GetAttrString(numpy, name);
+  if (ufunc == nullptr) return false;
+  PyArray_DTypeMeta* dtypes[3] = {&EcPointDType, &EcPointDType, &EcPointDType};
+  PyType_Slot slots[] = {
+      {NPY_METH_resolve_descriptors, reinterpret_cast<void*>(BinResolve)},
+      {NPY_METH_strided_loop, reinterpret_cast<void*>(loop)},
+      {0, nullptr},
+  };
+  PyArrayMethod_Spec spec = {};
+  spec.name = "ec_point_binop";
+  spec.nin = 2;
+  spec.nout = 1;
+  spec.casting = NPY_NO_CASTING;
+  spec.flags = NPY_METH_REQUIRES_PYAPI;
+  spec.dtypes = dtypes;
+  spec.slots = slots;
+  int rc = PyUFunc_AddLoopFromSpec(ufunc, &spec);
+  Py_DECREF(ufunc);
+  return rc >= 0;
+}
+
+bool AddNegLoop(PyObject* numpy) {
+  PyObject* ufunc = PyObject_GetAttrString(numpy, "negative");
+  if (ufunc == nullptr) return false;
+  PyArray_DTypeMeta* dtypes[2] = {&EcPointDType, &EcPointDType};
+  PyType_Slot slots[] = {
+      {NPY_METH_resolve_descriptors, reinterpret_cast<void*>(UnaryResolve)},
+      {NPY_METH_strided_loop, reinterpret_cast<void*>(NegLoop)},
+      {0, nullptr},
+  };
+  PyArrayMethod_Spec spec = {};
+  spec.name = "ec_point_negate";
+  spec.nin = 1;
+  spec.nout = 1;
+  spec.casting = NPY_NO_CASTING;
+  spec.flags = NPY_METH_REQUIRES_PYAPI;
+  spec.dtypes = dtypes;
+  spec.slots = slots;
+  int rc = PyUFunc_AddLoopFromSpec(ufunc, &spec);
+  Py_DECREF(ufunc);
+  return rc >= 0;
+}
+
+}  // namespace
+
+bool RegisterEcPointDType(PyObject* /*numpy*/, PyObject* module) {
+  EcPointScalar_Type.tp_name = "zk_dtypes._zk_dtypes_ext.EcPointScalar";
+  EcPointScalar_Type.tp_basicsize = 0;
+  EcPointScalar_Type.tp_flags = Py_TPFLAGS_DEFAULT;
+  EcPointScalar_Type.tp_base = &PyGenericArrType_Type;
+  if (PyType_Ready(&EcPointScalar_Type) < 0) {
+    return false;
+  }
+
+  PyTypeObject* type = reinterpret_cast<PyTypeObject*>(&EcPointDType);
+  Py_SET_TYPE(reinterpret_cast<PyObject*>(&EcPointDType),
+              &PyArrayDTypeMeta_Type);
+  Py_SET_REFCNT(reinterpret_cast<PyObject*>(&EcPointDType), 1);
+  type->tp_name = "zk_dtypes._zk_dtypes_ext.EcPointDType";
+  type->tp_basicsize = sizeof(EcPointDescr);
+  type->tp_flags = Py_TPFLAGS_DEFAULT;
+  type->tp_base = &PyArrayDescr_Type;
+  type->tp_dealloc = Descr_dealloc;
+  type->tp_repr = Descr_repr;
+  type->tp_str = Descr_repr;
+  type->tp_new = DType_new;
+  if (PyType_Ready(type) < 0) {
+    return false;
+  }
+
+  PyArray_DTypeMeta* cast_dtypes[2] = {nullptr, nullptr};
+  PyType_Slot cast_slots[] = {
+      {NPY_METH_resolve_descriptors, reinterpret_cast<void*>(CastResolve)},
+      {NPY_METH_strided_loop, reinterpret_cast<void*>(CastLoop)},
+      {NPY_METH_unaligned_strided_loop, reinterpret_cast<void*>(CastLoop)},
+      {0, nullptr},
+  };
+  PyArrayMethod_Spec copy_cast = {};
+  copy_cast.name = "ec_point_copy";
+  copy_cast.nin = 1;
+  copy_cast.nout = 1;
+  copy_cast.casting = NPY_UNSAFE_CASTING;
+  copy_cast.flags = NPY_METH_SUPPORTS_UNALIGNED;
+  copy_cast.dtypes = cast_dtypes;
+  copy_cast.slots = cast_slots;
+  PyArrayMethod_Spec* casts[] = {&copy_cast, nullptr};
+
+  PyType_Slot dtype_slots[] = {
+      {NPY_DT_default_descr, reinterpret_cast<void*>(DefaultDescr)},
+      {NPY_DT_common_dtype, reinterpret_cast<void*>(CommonDType)},
+      {NPY_DT_common_instance, reinterpret_cast<void*>(CommonInstance)},
+      {NPY_DT_ensure_canonical, reinterpret_cast<void*>(EnsureCanonical)},
+      {NPY_DT_discover_descr_from_pyobject,
+       reinterpret_cast<void*>(DiscoverDescrFromPyobject)},
+      {NPY_DT_setitem, reinterpret_cast<void*>(SetItem)},
+      {NPY_DT_getitem, reinterpret_cast<void*>(GetItem)},
+      {0, nullptr},
+  };
+
+  PyArrayDTypeMeta_Spec spec = {};
+  spec.typeobj = &EcPointScalar_Type;
+  spec.flags = NPY_DT_PARAMETRIC;
+  spec.casts = casts;
+  spec.slots = dtype_slots;
+  spec.baseclass = nullptr;
+  if (PyArrayInitDTypeMeta_FromSpec(&EcPointDType, &spec) < 0) {
+    return false;
+  }
+  EcPointDType.singleton = PyArray_GetDefaultDescr(&EcPointDType);
+  if (EcPointDType.singleton == nullptr) {
+    return false;
+  }
+
+  if (PyModule_AddObject(module, "EcPointDType",
+                         reinterpret_cast<PyObject*>(&EcPointDType)) < 0) {
+    return false;
+  }
+  Py_INCREF(reinterpret_cast<PyObject*>(&EcPointDType));
+
+  PyObject* fn = PyCFunction_New(&kModuleMethods[0], nullptr);
+  if (fn == nullptr) {
+    return false;
+  }
+  if (PyModule_AddObject(module, "ec_point_descr", fn) < 0) {
+    Py_DECREF(fn);
+    return false;
+  }
+
+  if (_import_umath() < 0) {
+    return false;
+  }
+  PyObject* numpy = PyImport_ImportModule("numpy");
+  if (numpy == nullptr) {
+    return false;
+  }
+  bool ok = AddBinLoop(numpy, "add", BinLoop<BinOp::kAdd>) &&
+            AddBinLoop(numpy, "subtract", BinLoop<BinOp::kSub>) &&
+            AddNegLoop(numpy);
+  Py_DECREF(numpy);
+  return ok;
+}
+
+}  // namespace zk_dtypes

--- a/zk_dtypes/_src/ec_point_dtype.cc
+++ b/zk_dtypes/_src/ec_point_dtype.cc
@@ -14,16 +14,19 @@ limitations under the License.
 ==============================================================================*/
 
 // Parametric elliptic-curve point numpy DType (NEP-42). An EC point group is a
-// Module, not a Field: the ops are point add / subtract / negate (and, later,
-// scalar multiplication) — there is no point*point. This first cut covers
-// short-Weierstrass G1 (a=0) Jacobian points over a prime coordinate field.
+// Module, not a Field: the ops are point add / subtract / negate and scalar
+// multiplication — there is no point*point. Covers short-Weierstrass (a=0)
+// Jacobian points over a prime (G1) or Fp2 (G2) coordinate field.
 //
 // A point is `num_coords` coordinate-field elements (X, Y, Z for Jacobian),
 // stored exactly as the coordinate field stores them (canonical or per-coord
-// Montgomery, little-endian). The add/double formulas (EFD add-2007-bl /
-// dbl-2009-l) are R-linear, so we decode coordinates to canonical, run the
-// group law with prime-field arithmetic, and re-encode — byte-identical to the
-// legacy Montgomery formulas because the resulting representative is the same.
+// Montgomery, little-endian). The group-law formulas live once, in
+// ec_group_law.h, and are instantiated here for three execution tiers that
+// differ only in their coordinate ops (see `Tier`): CPython ints (any config;
+// decode to canonical, compute, re-encode — the EFD formulas are R-linear, so
+// this is byte-identical to computing in Montgomery space), native Montgomery
+// kernels on the stored bytes, and 256-bit typed limbs. The tier is chosen
+// once per descriptor at creation.
 
 // numpy.h must precede every other numpy header (it sets the API symbol) and
 // NPY_TARGET_VERSION must precede numpyconfig.h; the associated header pulls in
@@ -36,6 +39,7 @@ limitations under the License.
 #include <cstdint>
 #include <cstring>
 
+#include "zk_dtypes/_src/ec_group_law.h"
 #include "zk_dtypes/_src/field_dtype.h"
 #include "zk_dtypes/_src/field_modarith.h"
 #include "zk_dtypes/_src/numpy.h"
@@ -48,6 +52,17 @@ namespace {
 
 constexpr int kMaxCoords = 4;
 
+struct CoordField;
+
+// Which group-law arithmetic serves a descriptor. Decided once at descriptor
+// creation from the coordinate field's width and storage; the ufunc loops
+// only switch on it.
+enum class Tier : uint8_t {
+  kPy,        // CPython-int arithmetic; any width, storage, and degree
+  kByte,      // native Montgomery kernels on the stored bytes
+  kTyped256,  // typed-limb BigInt<4> / Fp2<4> locals (256-bit base field)
+};
+
 struct EcPointDescr {
   PyArray_Descr base;
   PyObject* modulus;  // owned: base prime field modulus
@@ -55,10 +70,12 @@ struct EcPointDescr {
   PyObject* rinv_mod_p;  // owned (Montgomery): R^-1 mod p; else NULL
   // Coordinate field: prime (G1, degree 1) or Fp2 (G2, degree 2, u^2 = nr).
   PyObject* non_residue;  // owned (degree 2): the Fp2 non-residue; else NULL
+  CoordField* native;     // owned: native-kernel constants; may have ok=false
   uint8_t coord_degree;   // 1 = G1 (Fq), 2 = G2 (Fp2)
   uint8_t base_width_bytes;
   uint8_t num_coords;  // 2 affine, 3 Jacobian, 4 xyzz
   uint8_t is_montgomery;
+  Tier tier;
 };
 
 PyArray_DTypeMeta EcPointDType = {};
@@ -327,47 +344,121 @@ PyObject* CInv(EcPointDescr* d, PyObject* a) {
   return MakeFp2(c0, c1);
 }
 
-// Jacobian doubling, a == 0 (EFD dbl-2009-l). in/out: 3 canonical coords.
-int JacDouble(EcPointDescr* ec, PyObject* const* in, PyObject** out) {
-  PyObject* X = in[0];
-  PyObject* Y = in[1];
-  PyObject* Z = in[2];
-  PyObject* xx = CMul(ec, X, X);
-  PyObject* yy = CMul(ec, Y, Y);
-  PyObject* yyyy = yy ? CMul(ec, yy, yy) : nullptr;
-  PyObject* xyy = (xx && yy) ? CMul(ec, X, yy) : nullptr;
-  PyObject* d = xyy ? CMulInt(ec, xyy, 4) : nullptr;  // d = 4*X*yy
-  PyObject* e = xx ? CMulInt(ec, xx, 3) : nullptr;    // e = 3*xx
-  PyObject* ee = e ? CMul(ec, e, e) : nullptr;
-  PyObject* twod = d ? CMulInt(ec, d, 2) : nullptr;
-  PyObject* X2 = (ee && twod) ? CSub(ec, ee, twod) : nullptr;  // e^2 - 2d
-  PyObject* dmx = (d && X2) ? CSub(ec, d, X2) : nullptr;
-  PyObject* edmx = (e && dmx) ? CMul(ec, e, dmx) : nullptr;
-  PyObject* eightyyyy = yyyy ? CMulInt(ec, yyyy, 8) : nullptr;
-  PyObject* Y2 = (edmx && eightyyyy) ? CSub(ec, edmx, eightyyyy) : nullptr;
-  PyObject* yz = CMul(ec, Y, Z);
-  PyObject* Z2 = yz ? CMulInt(ec, yz, 2) : nullptr;
-  Py_XDECREF(xx);
-  Py_XDECREF(yy);
-  Py_XDECREF(yyyy);
-  Py_XDECREF(xyy);
-  Py_XDECREF(d);
-  Py_XDECREF(e);
-  Py_XDECREF(ee);
-  Py_XDECREF(twod);
-  Py_XDECREF(dmx);
-  Py_XDECREF(edmx);
-  Py_XDECREF(eightyyyy);
-  Py_XDECREF(yz);
-  if (!X2 || !Y2 || !Z2) {
-    Py_XDECREF(X2);
-    Py_XDECREF(Y2);
-    Py_XDECREF(Z2);
-    return -1;
+// --- CPython-int instantiation of the shared group law -------------------
+// `PyRef` is the value-semantic coordinate (copy = INCREF) and `PyCoordOps`
+// adapts the C* helpers to the ec_law Ops concept. A failing CPython call
+// (allocation, comparison) poisons the ops: the failing helper has already set
+// the exception, every later operation no-ops on the null value, and the Jac*
+// wrappers translate the poisoned flag into their usual -1.
+
+class PyRef {
+ public:
+  PyRef() = default;
+  explicit PyRef(PyObject* p) : p_(p) {}  // steals
+  PyRef(const PyRef& o) : p_(o.p_) { Py_XINCREF(p_); }
+  PyRef(PyRef&& o) noexcept : p_(o.p_) { o.p_ = nullptr; }
+  PyRef& operator=(const PyRef& o) {
+    if (this != &o) {
+      Py_XINCREF(o.p_);
+      Py_XDECREF(p_);
+      p_ = o.p_;
+    }
+    return *this;
   }
-  out[0] = X2;
-  out[1] = Y2;
-  out[2] = Z2;
+  PyRef& operator=(PyRef&& o) noexcept {
+    if (this != &o) {
+      Py_XDECREF(p_);
+      p_ = o.p_;
+      o.p_ = nullptr;
+    }
+    return *this;
+  }
+  ~PyRef() { Py_XDECREF(p_); }
+  PyObject* get() const { return p_; }
+  PyObject* release() {
+    PyObject* r = p_;
+    p_ = nullptr;
+    return r;
+  }
+  static PyRef Borrow(PyObject* p) {
+    Py_XINCREF(p);
+    return PyRef(p);
+  }
+
+ private:
+  PyObject* p_ = nullptr;
+};
+
+struct PyCoordOps {
+  EcPointDescr* d;
+  mutable bool failed = false;
+  PyRef Wrap(PyObject* r) const {
+    if (r == nullptr) failed = true;
+    return PyRef(r);
+  }
+  bool Bad(const PyRef& a) const { return failed || a.get() == nullptr; }
+  PyRef One() const { return Wrap(COne(d)); }
+  PyRef Zero() const { return Wrap(CZero(d)); }
+  PyRef Add(const PyRef& a, const PyRef& b) const {
+    if (Bad(a) || Bad(b)) {
+      failed = true;
+      return PyRef();
+    }
+    return Wrap(CAdd(d, a.get(), b.get()));
+  }
+  PyRef Sub(const PyRef& a, const PyRef& b) const {
+    if (Bad(a) || Bad(b)) {
+      failed = true;
+      return PyRef();
+    }
+    return Wrap(CSub(d, a.get(), b.get()));
+  }
+  PyRef Mul(const PyRef& a, const PyRef& b) const {
+    if (Bad(a) || Bad(b)) {
+      failed = true;
+      return PyRef();
+    }
+    return Wrap(CMul(d, a.get(), b.get()));
+  }
+  PyRef Neg(const PyRef& a) const {
+    if (Bad(a)) {
+      failed = true;
+      return PyRef();
+    }
+    return Wrap(CNeg(d, a.get()));
+  }
+  PyRef MulInt(const PyRef& a, int k) const {
+    if (Bad(a)) {
+      failed = true;
+      return PyRef();
+    }
+    return Wrap(CMulInt(d, a.get(), k));
+  }
+  bool IsZero(const PyRef& a) const {
+    if (Bad(a)) return false;
+    return CIsZero(d, a.get());
+  }
+  bool Equal(const PyRef& a, const PyRef& b) const {
+    if (Bad(a) || Bad(b)) return false;
+    int r = PyObject_RichCompareBool(a.get(), b.get(), Py_EQ);
+    if (r < 0) {
+      failed = true;
+      return false;
+    }
+    return r == 1;
+  }
+};
+
+// Jacobian addition; in1/in2/out: 3 canonical coords. -1 on CPython failure.
+int JacAdd(EcPointDescr* ec, PyObject* const* P, PyObject* const* Q,
+           PyObject** out) {
+  PyCoordOps f{ec};
+  PyRef Pr[3] = {PyRef::Borrow(P[0]), PyRef::Borrow(P[1]), PyRef::Borrow(P[2])};
+  PyRef Qr[3] = {PyRef::Borrow(Q[0]), PyRef::Borrow(Q[1]), PyRef::Borrow(Q[2])};
+  PyRef R[3];
+  ec_law::EcAddT<PyRef, PyCoordOps>(f, Pr, Qr, R);
+  if (f.failed) return -1;
+  for (int i = 0; i < 3; ++i) out[i] = R[i].release();
   return 0;
 }
 
@@ -378,99 +469,6 @@ void CopyPoint(PyObject* const* in, PyObject** out, int n) {
   }
 }
 
-// Jacobian addition (EFD add-2007-bl), a == 0. in1/in2/out: 3 canonical coords.
-int JacAdd(EcPointDescr* ec, PyObject* const* P, PyObject* const* Q,
-           PyObject** out) {
-  if (CIsZero(ec, P[2])) {  // P is infinity
-    CopyPoint(Q, out, 3);
-    return 0;
-  }
-  if (CIsZero(ec, Q[2])) {  // Q is infinity
-    CopyPoint(P, out, 3);
-    return 0;
-  }
-  PyObject *X1 = P[0], *Y1 = P[1], *Z1 = P[2];
-  PyObject *X2 = Q[0], *Y2 = Q[1], *Z2 = Q[2];
-  PyObject* z1z1 = CMul(ec, Z1, Z1);
-  PyObject* z2z2 = CMul(ec, Z2, Z2);
-  PyObject* u1 = z2z2 ? CMul(ec, X1, z2z2) : nullptr;
-  PyObject* u2 = z1z1 ? CMul(ec, X2, z1z1) : nullptr;
-  PyObject* yz2 = z2z2 ? CMul(ec, Y1, Z2) : nullptr;
-  PyObject* s1 = yz2 ? CMul(ec, yz2, z2z2) : nullptr;
-  PyObject* yz1 = z1z1 ? CMul(ec, Y2, Z1) : nullptr;
-  PyObject* s2 = yz1 ? CMul(ec, yz1, z1z1) : nullptr;
-  int rc = -1;
-  if (!u1 || !u2 || !s1 || !s2) goto cleanup;
-  if (PyObject_RichCompareBool(u1, u2, Py_EQ) == 1 &&
-      PyObject_RichCompareBool(s1, s2, Py_EQ) == 1) {
-    rc = JacDouble(ec, P, out);
-    goto cleanup;
-  }
-  {
-    PyObject* h = CSub(ec, u2, u1);
-    PyObject* twoh = h ? CMulInt(ec, h, 2) : nullptr;
-    PyObject* i = twoh ? CMul(ec, twoh, twoh) : nullptr;  // (2h)^2
-    PyObject* hi = (h && i) ? CMul(ec, h, i) : nullptr;
-    PyObject* j = hi ? CNeg(ec, hi) : nullptr;  // j = -(h*i)
-    PyObject* sdiff = CSub(ec, s2, s1);
-    PyObject* r = sdiff ? CMulInt(ec, sdiff, 2) : nullptr;  // 2(s2-s1)
-    PyObject* v = i ? CMul(ec, u1, i) : nullptr;
-    PyObject* rr = r ? CMul(ec, r, r) : nullptr;
-    PyObject* twov = v ? CMulInt(ec, v, 2) : nullptr;
-    PyObject* rrj = (rr && j) ? CAdd(ec, rr, j) : nullptr;
-    PyObject* X3 =
-        (rrj && twov) ? CSub(ec, rrj, twov) : nullptr;  // r^2 + j - 2v
-    PyObject* vmx = (v && X3) ? CSub(ec, v, X3) : nullptr;
-    PyObject* rvmx = (r && vmx) ? CMul(ec, r, vmx) : nullptr;
-    PyObject* s1j = (s1 && j) ? CMul(ec, s1, j) : nullptr;
-    PyObject* twos1j = s1j ? CMulInt(ec, s1j, 2) : nullptr;
-    PyObject* Y3 =
-        (rvmx && twos1j) ? CAdd(ec, rvmx, twos1j) : nullptr;  // r(v-X3)+2*s1*j
-    PyObject* z1z2 = CMul(ec, Z1, Z2);
-    PyObject* z1z2h = (z1z2 && h) ? CMul(ec, z1z2, h) : nullptr;
-    PyObject* Z3 = z1z2h ? CMulInt(ec, z1z2h, 2) : nullptr;  // 2*Z1*Z2*h
-    Py_XDECREF(h);
-    Py_XDECREF(twoh);
-    Py_XDECREF(i);
-    Py_XDECREF(hi);
-    Py_XDECREF(sdiff);
-    Py_XDECREF(r);
-    Py_XDECREF(v);
-    Py_XDECREF(rr);
-    Py_XDECREF(twov);
-    Py_XDECREF(rrj);
-    Py_XDECREF(vmx);
-    Py_XDECREF(rvmx);
-    Py_XDECREF(s1j);
-    Py_XDECREF(twos1j);
-    Py_XDECREF(z1z2);
-    Py_XDECREF(z1z2h);
-    if (!X3 || !Y3 || !Z3 || !j) {
-      Py_XDECREF(X3);
-      Py_XDECREF(Y3);
-      Py_XDECREF(Z3);
-      Py_XDECREF(j);
-      goto cleanup;
-    }
-    Py_DECREF(j);
-    out[0] = X3;
-    out[1] = Y3;
-    out[2] = Z3;
-    rc = 0;
-  }
-cleanup:
-  Py_XDECREF(z1z1);
-  Py_XDECREF(z2z2);
-  Py_XDECREF(u1);
-  Py_XDECREF(u2);
-  Py_XDECREF(yz2);
-  Py_XDECREF(s1);
-  Py_XDECREF(yz1);
-  Py_XDECREF(s2);
-  return rc;
-}
-
-// Negate: flip Y only.
 // Negate flips Y (coordinate 1) and copies the rest — rep-safe for affine /
 // Jacobian / xyzz alike (Y is coordinate 1 in every representation).
 int JacNegate(EcPointDescr* ec, PyObject* const* in, PyObject** out) {
@@ -489,48 +487,13 @@ int JacNegate(EcPointDescr* ec, PyObject* const* in, PyObject** out) {
   return 0;
 }
 
-// Group equality (cross-representative): a Jacobian point has many byte
-// encodings for one group element. Returns 1 if P == Q as group elements,
-// 0 if not, -1 on error. Both infinity -> equal; one infinity -> not equal;
-// else x1*z2^2 == x2*z1^2 and y1*z2^3 == y2*z1^3.
+// Group equality (cross-representative): 1 equal, 0 not, -1 on error.
 int JacEqual(EcPointDescr* ec, PyObject* const* P, PyObject* const* Q) {
-  bool pz = CIsZero(ec, P[2]);
-  bool qz = CIsZero(ec, Q[2]);
-  if (pz || qz) {
-    return (pz && qz) ? 1 : 0;
-  }
-  int result = -1;
-  PyObject* z1s = CMul(ec, P[2], P[2]);
-  PyObject* z2s = CMul(ec, Q[2], Q[2]);
-  PyObject* lx = z2s ? CMul(ec, P[0], z2s) : nullptr;
-  PyObject* rx = z1s ? CMul(ec, Q[0], z1s) : nullptr;
-  PyObject* z1c = z1s ? CMul(ec, z1s, P[2]) : nullptr;
-  PyObject* z2c = z2s ? CMul(ec, z2s, Q[2]) : nullptr;
-  PyObject* ly = z2c ? CMul(ec, P[1], z2c) : nullptr;
-  PyObject* ry = z1c ? CMul(ec, Q[1], z1c) : nullptr;
-  if (lx && rx && ly && ry) {
-    int xe = PyObject_RichCompareBool(lx, rx, Py_EQ);
-    int ye = PyObject_RichCompareBool(ly, ry, Py_EQ);
-    if (xe >= 0 && ye >= 0) {
-      result = (xe == 1 && ye == 1) ? 1 : 0;
-    }
-  }
-  Py_XDECREF(z1s);
-  Py_XDECREF(z2s);
-  Py_XDECREF(lx);
-  Py_XDECREF(rx);
-  Py_XDECREF(z1c);
-  Py_XDECREF(z2c);
-  Py_XDECREF(ly);
-  Py_XDECREF(ry);
-  return result;
-}
-
-void MovePoint(PyObject** dst, PyObject* const* src, int n) {
-  for (int i = 0; i < n; ++i) {
-    Py_DECREF(dst[i]);
-    dst[i] = src[i];
-  }
+  PyCoordOps f{ec};
+  PyRef Pr[3] = {PyRef::Borrow(P[0]), PyRef::Borrow(P[1]), PyRef::Borrow(P[2])};
+  PyRef Qr[3] = {PyRef::Borrow(Q[0]), PyRef::Borrow(Q[1]), PyRef::Borrow(Q[2])};
+  int r = ec_law::EcEqualT<PyRef, PyCoordOps>(f, Pr, Qr);
+  return f.failed ? -1 : r;
 }
 
 // Decodes a canonical scalar int into `buf` (little-endian, zero-padded) and
@@ -552,57 +515,33 @@ Py_ssize_t ScalarToBytesLE(PyObject* scalar, unsigned char* buf,
   return static_cast<Py_ssize_t>(nbits);
 }
 
-// MSB-first double-and-add: ret = scalar * point (canonical Jacobian coords).
-// The scalar is a canonical integer (Montgomery already decoded by the caller),
-// matching the legacy curve operator* which de-Montgomery's the scalar first.
+// ret = scalar * point (canonical Jacobian coords). The scalar is a canonical
+// integer (Montgomery already decoded by the caller), matching the legacy
+// curve operator* which de-Montgomery's the scalar first.
 int JacScalarMul(EcPointDescr* ec, PyObject* scalar, PyObject* const* point,
                  PyObject** out) {
-  PyObject* ret[3] = {COne(ec), COne(ec), CZero(ec)};  // Zero = (1, 1, 0)
-  if (!ret[0] || !ret[1] || !ret[2]) {
-    for (int j = 0; j < 3; ++j) Py_XDECREF(ret[j]);
-    return -1;
-  }
   unsigned char buf[64];
   Py_ssize_t nbits = ScalarToBytesLE(scalar, buf, sizeof(buf));
-  if (nbits < 0) {
-    for (int j = 0; j < 3; ++j) Py_DECREF(ret[j]);
-    return -1;
-  }
-  for (Py_ssize_t i = nbits - 1; i >= 0; --i) {
-    PyObject* tmp[3];
-    if (JacDouble(ec, ret, tmp) < 0) {
-      for (int j = 0; j < 3; ++j) Py_DECREF(ret[j]);
-      return -1;
-    }
-    MovePoint(ret, tmp, 3);
-    if ((buf[i >> 3] >> (i & 7)) & 1) {
-      if (JacAdd(ec, ret, point, tmp) < 0) {
-        for (int j = 0; j < 3; ++j) Py_DECREF(ret[j]);
-        return -1;
-      }
-      MovePoint(ret, tmp, 3);
-    }
-  }
-  out[0] = ret[0];
-  out[1] = ret[1];
-  out[2] = ret[2];
+  if (nbits < 0) return -1;
+  PyCoordOps f{ec};
+  PyRef P[3] = {PyRef::Borrow(point[0]), PyRef::Borrow(point[1]),
+                PyRef::Borrow(point[2])};
+  PyRef R[3];
+  ec_law::EcScalarMulT<PyRef, PyCoordOps>(f, P, buf, static_cast<int>(nbits),
+                                          R);
+  if (f.failed) return -1;
+  for (int i = 0; i < 3; ++i) out[i] = R[i].release();
   return 0;
 }
 
-// --- native fixed-width group law ----------------------------------------
-// The Python-int group law above is correct but allocates a CPython int per
-// coordinate operation. For Montgomery-stored points over a coordinate field
-// whose base width the native kernels handle, run the identical EFD formulas in
-// Montgomery space directly on the stored bytes (mont(x)*mont(y)*R^-1 =
-// mont(x*y); add/sub are linear; X^... = non_residue folds with mont(nr)), so
-// no decode/encode and no Python ints — byte-identical to the path above.
-//
-// These are byte-space twins of the PyObject Jac* functions: EcDouble<->
-// JacDouble, EcAdd<->JacAdd, EcNegate<->JacNegate, EcEqual<->JacEqual,
-// EcScalarMul<->JacScalarMul, CoordField::Mul (Fp2) <-> CMul. The two MUST stay
-// in lockstep — the Jac* versions are the canonical spec; a formula change must
-// be made in both (the byte-identity tests only catch divergence on the cases
-// they exercise).
+// --- native fixed-width coordinate field ---------------------------------
+// The CPython-int ops above allocate an int per coordinate operation. For
+// Montgomery-stored points over a coordinate field whose base width the native
+// kernels handle, run the same shared formulas in Montgomery space directly on
+// the stored bytes (mont(x)*mont(y)*R^-1 = mont(x*y); add/sub are linear;
+// non_residue folds with mont(nr)), so no decode/encode and no Python ints —
+// byte-identical to the CPython tier because both instantiate the one
+// ec_law formula body.
 
 constexpr int kCoordBytes = 64;  // max coordinate: Fp2 over 256-bit base
 
@@ -719,166 +658,70 @@ struct CoordField {
   }
 };
 
-// Jacobian doubling (EFD dbl-2009-l, a == 0); 3 coords. out may alias in.
-void EcDouble(const CoordField& cf, const unsigned char* in,
-              unsigned char* out) {
-  const int cb = cf.cb;
-  const unsigned char* X = in;
-  const unsigned char* Y = in + cb;
-  const unsigned char* Z = in + 2 * cb;
-  unsigned char xx[kCoordBytes], yy[kCoordBytes], yyyy[kCoordBytes];
-  unsigned char xyy[kCoordBytes], dd[kCoordBytes], e[kCoordBytes];
-  unsigned char ee[kCoordBytes], twod[kCoordBytes], X2[kCoordBytes];
-  unsigned char dmx[kCoordBytes], edmx[kCoordBytes], eightyyyy[kCoordBytes];
-  unsigned char Y2[kCoordBytes], yz[kCoordBytes], Z2[kCoordBytes];
-  cf.Mul(X, X, xx);
-  cf.Mul(Y, Y, yy);
-  cf.Mul(yy, yy, yyyy);
-  cf.Mul(X, yy, xyy);
-  cf.MulInt(xyy, 4, dd);
-  cf.MulInt(xx, 3, e);
-  cf.Mul(e, e, ee);
-  cf.MulInt(dd, 2, twod);
-  cf.Sub(ee, twod, X2);
-  cf.Sub(dd, X2, dmx);
-  cf.Mul(e, dmx, edmx);
-  cf.MulInt(yyyy, 8, eightyyyy);
-  cf.Sub(edmx, eightyyyy, Y2);
-  cf.Mul(Y, Z, yz);
-  cf.MulInt(yz, 2, Z2);
-  std::memcpy(out, X2, cb);
-  std::memcpy(out + cb, Y2, cb);
-  std::memcpy(out + 2 * cb, Z2, cb);
-}
+// ec_law instantiation over the stored bytes: `ByteCoord` is one coordinate
+// (fixed max-width buffer; only the descriptor's cb bytes are meaningful) and
+// `ByteOps` adapts CoordField's kernels to the Ops concept.
+struct ByteCoord {
+  unsigned char b[kCoordBytes] = {};
+};
 
-// Jacobian addition (EFD add-2007-bl, a == 0); 3 coords. `out` may alias an
-// input: every read of P/Q completes into stack temporaries before the result
-// is written, and the infinity copies below skip a no-op self-copy.
-void EcAdd(const CoordField& cf, const unsigned char* P, const unsigned char* Q,
-           unsigned char* out) {
-  const int cb = cf.cb;
-  const unsigned char* Z1 = P + 2 * cb;
-  const unsigned char* Z2 = Q + 2 * cb;
-  if (cf.IsZero(Z1)) {
-    if (out != Q) std::memcpy(out, Q, 3 * cb);
-    return;
+struct ByteOps {
+  const CoordField* cf;
+  int coord_bytes() const { return cf->cb; }
+  void Load(ByteCoord& c, const unsigned char* p) const {
+    std::memcpy(c.b, p, cf->cb);
   }
-  if (cf.IsZero(Z2)) {
-    if (out != P) std::memcpy(out, P, 3 * cb);
-    return;
+  void Store(unsigned char* p, const ByteCoord& c) const {
+    std::memcpy(p, c.b, cf->cb);
   }
-  const unsigned char* X1 = P;
-  const unsigned char* Y1 = P + cb;
-  const unsigned char* X2 = Q;
-  const unsigned char* Y2 = Q + cb;
-  unsigned char z1z1[kCoordBytes], z2z2[kCoordBytes], u1[kCoordBytes];
-  unsigned char u2[kCoordBytes], yz2[kCoordBytes], s1[kCoordBytes];
-  unsigned char yz1[kCoordBytes], s2[kCoordBytes];
-  cf.Mul(Z1, Z1, z1z1);
-  cf.Mul(Z2, Z2, z2z2);
-  cf.Mul(X1, z2z2, u1);
-  cf.Mul(X2, z1z1, u2);
-  cf.Mul(Y1, Z2, yz2);
-  cf.Mul(yz2, z2z2, s1);
-  cf.Mul(Y2, Z1, yz1);
-  cf.Mul(yz1, z1z1, s2);
-  if (cf.Equal(u1, u2) && cf.Equal(s1, s2)) {  // P == Q
-    EcDouble(cf, P, out);
-    return;
+  ByteCoord One() const {
+    ByteCoord o;
+    cf->SetOne(o.b);
+    return o;
   }
-  unsigned char h[kCoordBytes], twoh[kCoordBytes], ii[kCoordBytes];
-  unsigned char hi[kCoordBytes], j[kCoordBytes], sdiff[kCoordBytes];
-  unsigned char r[kCoordBytes], v[kCoordBytes], rr[kCoordBytes];
-  unsigned char twov[kCoordBytes], rrj[kCoordBytes], X3[kCoordBytes];
-  unsigned char vmx[kCoordBytes], rvmx[kCoordBytes], s1j[kCoordBytes];
-  unsigned char twos1j[kCoordBytes], Y3[kCoordBytes], z1z2[kCoordBytes];
-  unsigned char z1z2h[kCoordBytes], Z3[kCoordBytes];
-  cf.Sub(u2, u1, h);
-  cf.MulInt(h, 2, twoh);
-  cf.Mul(twoh, twoh, ii);
-  cf.Mul(h, ii, hi);
-  cf.Neg(hi, j);
-  cf.Sub(s2, s1, sdiff);
-  cf.MulInt(sdiff, 2, r);
-  cf.Mul(u1, ii, v);
-  cf.Mul(r, r, rr);
-  cf.MulInt(v, 2, twov);
-  cf.Add(rr, j, rrj);
-  cf.Sub(rrj, twov, X3);  // r^2 + j - 2v
-  cf.Sub(v, X3, vmx);
-  cf.Mul(r, vmx, rvmx);
-  cf.Mul(s1, j, s1j);
-  cf.MulInt(s1j, 2, twos1j);
-  cf.Add(rvmx, twos1j, Y3);  // r(v - X3) + 2 s1 j
-  cf.Mul(Z1, Z2, z1z2);
-  cf.Mul(z1z2, h, z1z2h);
-  cf.MulInt(z1z2h, 2, Z3);  // 2 Z1 Z2 h
-  std::memcpy(out, X3, cb);
-  std::memcpy(out + cb, Y3, cb);
-  std::memcpy(out + 2 * cb, Z3, cb);
-}
+  ByteCoord Zero() const {
+    ByteCoord o;
+    cf->SetZero(o.b);
+    return o;
+  }
+  ByteCoord Add(const ByteCoord& a, const ByteCoord& b) const {
+    ByteCoord o;
+    cf->Add(a.b, b.b, o.b);
+    return o;
+  }
+  ByteCoord Sub(const ByteCoord& a, const ByteCoord& b) const {
+    ByteCoord o;
+    cf->Sub(a.b, b.b, o.b);
+    return o;
+  }
+  ByteCoord Neg(const ByteCoord& a) const {
+    ByteCoord o;
+    cf->Neg(a.b, o.b);
+    return o;
+  }
+  ByteCoord Mul(const ByteCoord& a, const ByteCoord& b) const {
+    ByteCoord o;
+    cf->Mul(a.b, b.b, o.b);
+    return o;
+  }
+  ByteCoord MulInt(const ByteCoord& a, int k) const {
+    ByteCoord o;
+    cf->MulInt(a.b, k, o.b);
+    return o;
+  }
+  bool IsZero(const ByteCoord& a) const { return cf->IsZero(a.b); }
+  bool Equal(const ByteCoord& a, const ByteCoord& b) const {
+    return cf->Equal(a.b, b.b);
+  }
+};
 
-void EcNegate(const CoordField& cf, const unsigned char* in, unsigned char* out,
-              int num_coords) {
-  const int cb = cf.cb;
-  for (int i = 0; i < num_coords; ++i) {
-    if (i == 1) {
-      cf.Neg(in + cb, out + cb);
-    } else {
-      std::memcpy(out + i * cb, in + i * cb, cb);
-    }
-  }
-}
-
-// Cross-representative group equality of two Jacobian points; 1 / 0.
-int EcEqual(const CoordField& cf, const unsigned char* P,
-            const unsigned char* Q) {
-  const int cb = cf.cb;
-  bool pz = cf.IsZero(P + 2 * cb);
-  bool qz = cf.IsZero(Q + 2 * cb);
-  if (pz || qz) return (pz && qz) ? 1 : 0;
-  unsigned char z1s[kCoordBytes], z2s[kCoordBytes], lx[kCoordBytes];
-  unsigned char rx[kCoordBytes], z1c[kCoordBytes], z2c[kCoordBytes];
-  unsigned char ly[kCoordBytes], ry[kCoordBytes];
-  cf.Mul(P + 2 * cb, P + 2 * cb, z1s);
-  cf.Mul(Q + 2 * cb, Q + 2 * cb, z2s);
-  cf.Mul(P, z2s, lx);
-  cf.Mul(Q, z1s, rx);
-  cf.Mul(z1s, P + 2 * cb, z1c);
-  cf.Mul(z2s, Q + 2 * cb, z2c);
-  cf.Mul(P + cb, z2c, ly);
-  cf.Mul(Q + cb, z1c, ry);
-  return (cf.Equal(lx, rx) && cf.Equal(ly, ry)) ? 1 : 0;
-}
-
-// ret = scalar * point, MSB-first double-and-add; scalar as little-endian
-// bytes.
-void EcScalarMul(const CoordField& cf, const unsigned char* point,
-                 const unsigned char* sbytes, int nbits, unsigned char* out) {
-  const int cb = cf.cb;
-  unsigned char ret[3 * kCoordBytes];
-  cf.SetOne(ret);  // Jacobian zero = (1, 1, 0)
-  cf.SetOne(ret + cb);
-  cf.SetZero(ret + 2 * cb);
-  // EcDouble/EcAdd read all of their inputs before writing the result, so they
-  // accept out == in1 in place; no scratch point is needed.
-  for (int i = nbits - 1; i >= 0; --i) {
-    EcDouble(cf, ret, ret);
-    if ((sbytes[i >> 3] >> (i & 7)) & 1) {
-      EcAdd(cf, ret, point, ret);
-    }
-  }
-  std::memcpy(out, ret, 3 * cb);
-}
-
-// --- typed-limb group law (256-bit coordinate field) ---------------------
-// The byte-space Ec* above re-memcpy every coordinate in and out of every field
-// operation. For the dominant case — a 256-bit Montgomery coordinate field
-// (bn254 / bls12-381 / secp256k1 Fq, G1 and G2) — run the *same* formulas on
+// --- typed-limb coordinate field (256-bit) --------------------------------
+// ByteOps round-trips every coordinate through memory per field operation. For
+// the dominant case — a 256-bit Montgomery coordinate field (bn254 /
+// bls12-381 / secp256k1 Fq, G1 and G2) — instantiate the same formulas on
 // BigInt<4> values held in locals: load each coordinate from the stored bytes
-// once, compute, store once. Same MontMul<4>/ModAdd/ModSub kernels as the byte
-// path, so the result is byte-identical. Twins of the Jac*/Ec* spec — keep in
-// lockstep.
+// once, compute, store once. Same MontMul<4>/ModAdd/ModSub kernels as
+// CoordField, so the result is byte-identical.
 
 template <size_t N>
 struct FqOpsBig {
@@ -912,6 +755,13 @@ struct FqOpsBig {
   }
   bool IsZero(const BigInt<N>& a) const { return a == BigInt<N>(0); }
   bool Equal(const BigInt<N>& a, const BigInt<N>& b) const { return a == b; }
+  int coord_bytes() const { return static_cast<int>(N * 8); }
+  void Load(BigInt<N>& c, const unsigned char* p) const {
+    std::memcpy(&c[0], p, N * 8);
+  }
+  void Store(unsigned char* p, const BigInt<N>& c) const {
+    std::memcpy(p, &c[0], N * 8);
+  }
 };
 
 template <size_t N>
@@ -949,125 +799,22 @@ struct Fp2OpsBig {
   bool Equal(const Fp2<N>& a, const Fp2<N>& b) const {
     return fq.Equal(a.c0, b.c0) && fq.Equal(a.c1, b.c1);
   }
+  int coord_bytes() const { return static_cast<int>(2 * N * 8); }
+  void Load(Fp2<N>& c, const unsigned char* p) const {
+    fq.Load(c.c0, p);
+    fq.Load(c.c1, p + N * 8);
+  }
+  void Store(unsigned char* p, const Fp2<N>& c) const {
+    fq.Store(p, c.c0);
+    fq.Store(p + N * 8, c.c1);
+  }
 };
-
-template <size_t N>
-void LoadCoord(BigInt<N>& c, const unsigned char* p) {
-  std::memcpy(&c[0], p, N * 8);
-}
-template <size_t N>
-void StoreCoord(unsigned char* p, const BigInt<N>& c) {
-  std::memcpy(p, &c[0], N * 8);
-}
-template <size_t N>
-void LoadCoord(Fp2<N>& c, const unsigned char* p) {
-  LoadCoord(c.c0, p);
-  LoadCoord(c.c1, p + N * 8);
-}
-template <size_t N>
-void StoreCoord(unsigned char* p, const Fp2<N>& c) {
-  StoreCoord(p, c.c0);
-  StoreCoord(p + N * 8, c.c1);
-}
-template <typename C>
-void LoadPt(C out[3], const unsigned char* p, int cb) {
-  for (int i = 0; i < 3; ++i) LoadCoord(out[i], p + i * cb);
-}
-template <typename C>
-void StorePt(unsigned char* p, const C in[3], int cb) {
-  for (int i = 0; i < 3; ++i) StoreCoord(p + i * cb, in[i]);
-}
-
-// Jacobian doubling (EFD dbl-2009-l, a == 0). out may alias in.
-template <typename C, typename Ops>
-void EcDoubleT(const Ops& f, const C in[3], C out[3]) {
-  const C& X = in[0];
-  const C& Y = in[1];
-  const C& Z = in[2];
-  C xx = f.Mul(X, X);
-  C yy = f.Mul(Y, Y);
-  C yyyy = f.Mul(yy, yy);
-  C dd = f.MulInt(f.Mul(X, yy), 4);
-  C e = f.MulInt(xx, 3);
-  C X2 = f.Sub(f.Mul(e, e), f.MulInt(dd, 2));
-  C Y2 = f.Sub(f.Mul(e, f.Sub(dd, X2)), f.MulInt(yyyy, 8));
-  C Z2 = f.MulInt(f.Mul(Y, Z), 2);
-  out[0] = X2;
-  out[1] = Y2;
-  out[2] = Z2;
-}
-
-// Jacobian addition (EFD add-2007-bl, a == 0). out may alias an input.
-template <typename C, typename Ops>
-void EcAddT(const Ops& f, const C P[3], const C Q[3], C out[3]) {
-  if (f.IsZero(P[2])) {
-    out[0] = Q[0];
-    out[1] = Q[1];
-    out[2] = Q[2];
-    return;
-  }
-  if (f.IsZero(Q[2])) {
-    out[0] = P[0];
-    out[1] = P[1];
-    out[2] = P[2];
-    return;
-  }
-  C z1z1 = f.Mul(P[2], P[2]);
-  C z2z2 = f.Mul(Q[2], Q[2]);
-  C u1 = f.Mul(P[0], z2z2);
-  C u2 = f.Mul(Q[0], z1z1);
-  C s1 = f.Mul(f.Mul(P[1], Q[2]), z2z2);
-  C s2 = f.Mul(f.Mul(Q[1], P[2]), z1z1);
-  if (f.Equal(u1, u2) && f.Equal(s1, s2)) {  // P == Q
-    EcDoubleT<C, Ops>(f, P, out);
-    return;
-  }
-  C h = f.Sub(u2, u1);
-  C ii = f.Mul(f.MulInt(h, 2), f.MulInt(h, 2));
-  C j = f.Neg(f.Mul(h, ii));
-  C r = f.MulInt(f.Sub(s2, s1), 2);
-  C v = f.Mul(u1, ii);
-  C X3 = f.Sub(f.Add(f.Mul(r, r), j), f.MulInt(v, 2));  // r^2 + j - 2v
-  C Y3 = f.Add(f.Mul(r, f.Sub(v, X3)),
-               f.MulInt(f.Mul(s1, j), 2));          // r(v - X3) + 2 s1 j
-  C Z3 = f.MulInt(f.Mul(f.Mul(P[2], Q[2]), h), 2);  // 2 Z1 Z2 h
-  out[0] = X3;
-  out[1] = Y3;
-  out[2] = Z3;
-}
-
-// Cross-representative group equality; 1 / 0.
-template <typename C, typename Ops>
-int EcEqualT(const Ops& f, const C P[3], const C Q[3]) {
-  bool pz = f.IsZero(P[2]);
-  bool qz = f.IsZero(Q[2]);
-  if (pz || qz) return (pz && qz) ? 1 : 0;
-  C z1s = f.Mul(P[2], P[2]);
-  C z2s = f.Mul(Q[2], Q[2]);
-  bool xe = f.Equal(f.Mul(P[0], z2s), f.Mul(Q[0], z1s));
-  bool ye =
-      f.Equal(f.Mul(P[1], f.Mul(z2s, Q[2])), f.Mul(Q[1], f.Mul(z1s, P[2])));
-  return (xe && ye) ? 1 : 0;
-}
-
-// ret = scalar * point, MSB-first double-and-add (point/ret as typed coords).
-template <typename C, typename Ops>
-void EcScalarMulT(const Ops& f, const C point[3], const unsigned char* sbytes,
-                  int nbits, C ret[3]) {
-  ret[0] = f.One();  // Jacobian zero = (1, 1, 0)
-  ret[1] = f.One();
-  ret[2] = f.Zero();
-  for (int i = nbits - 1; i >= 0; --i) {
-    EcDoubleT<C, Ops>(f, ret, ret);
-    if ((sbytes[i >> 3] >> (i & 7)) & 1) EcAddT<C, Ops>(f, ret, point, ret);
-  }
-}
 
 // Build the typed 256-bit ops from the already-extracted CoordField constants.
 FqOpsBig<4> MakeFqOps(const CoordField& cf) {
   FqOpsBig<4> f;
   f.p = cf.fq.p256;
-  LoadCoord(f.one_mont, cf.one_le);
+  std::memcpy(&f.one_mont[0], cf.one_le, 4 * 8);
   f.nprime = cf.fq.nprime_neg;
   f.spare = cf.fq.spare;
   f.no_carry = cf.fq.no_carry;
@@ -1076,25 +823,37 @@ FqOpsBig<4> MakeFqOps(const CoordField& cf) {
 Fp2OpsBig<4> MakeFp2Ops(const CoordField& cf) {
   Fp2OpsBig<4> f;
   f.fq = MakeFqOps(cf);
-  LoadCoord(f.mont_nr, cf.mont_nr);
+  std::memcpy(&f.mont_nr[0], cf.mont_nr, 4 * 8);
   return f;
 }
 
-// Typed loop bodies (256-bit Jacobian). C = BigInt<4> (G1) or Fp2<4> (G2).
+// Strided loop bodies over any ec_law Ops with Load/Store (ByteOps and the
+// typed 256-bit ops alike).
+template <typename C, typename Ops>
+void LoadPt(const Ops& f, C out[3], const char* p) {
+  const auto* u = reinterpret_cast<const unsigned char*>(p);
+  for (int i = 0; i < 3; ++i) f.Load(out[i], u + i * f.coord_bytes());
+}
+template <typename C, typename Ops>
+void StorePt(const Ops& f, char* p, const C in[3]) {
+  auto* u = reinterpret_cast<unsigned char*>(p);
+  for (int i = 0; i < 3; ++i) f.Store(u + i * f.coord_bytes(), in[i]);
+}
+
 template <typename C, typename Ops>
 void RunBinT(const Ops& f, bool sub, char* a, char* b, char* o, npy_intp n,
-             const npy_intp* st, int cb) {
+             const npy_intp* st) {
   for (npy_intp i = 0; i < n; ++i) {
     C P[3], Q[3], R[3];
-    LoadPt<C>(P, reinterpret_cast<const unsigned char*>(a), cb);
-    LoadPt<C>(Q, reinterpret_cast<const unsigned char*>(b), cb);
+    LoadPt<C>(f, P, a);
+    LoadPt<C>(f, Q, b);
     if (sub) {
       C nq[3] = {Q[0], f.Neg(Q[1]), Q[2]};
-      EcAddT<C, Ops>(f, P, nq, R);
+      ec_law::EcAddT<C, Ops>(f, P, nq, R);
     } else {
-      EcAddT<C, Ops>(f, P, Q, R);
+      ec_law::EcAddT<C, Ops>(f, P, Q, R);
     }
-    StorePt<C>(reinterpret_cast<unsigned char*>(o), R, cb);
+    StorePt<C>(f, o, R);
     a += st[0];
     b += st[1];
     o += st[2];
@@ -1102,13 +861,14 @@ void RunBinT(const Ops& f, bool sub, char* a, char* b, char* o, npy_intp n,
 }
 template <typename C, typename Ops>
 void RunNegT(const Ops& f, char* a, char* o, npy_intp n, const npy_intp* st,
-             int cb, int num_coords) {
+             int num_coords) {
   for (npy_intp i = 0; i < n; ++i) {
     for (int k = 0; k < num_coords; ++k) {
       C c;
-      LoadCoord(c, reinterpret_cast<const unsigned char*>(a) + k * cb);
+      f.Load(c,
+             reinterpret_cast<const unsigned char*>(a) + k * f.coord_bytes());
       if (k == 1) c = f.Neg(c);
-      StoreCoord(reinterpret_cast<unsigned char*>(o) + k * cb, c);
+      f.Store(reinterpret_cast<unsigned char*>(o) + k * f.coord_bytes(), c);
     }
     a += st[0];
     o += st[1];
@@ -1116,12 +876,12 @@ void RunNegT(const Ops& f, char* a, char* o, npy_intp n, const npy_intp* st,
 }
 template <typename C, typename Ops>
 void RunCmpT(const Ops& f, bool negate, char* a, char* b, char* o, npy_intp n,
-             const npy_intp* st, int cb) {
+             const npy_intp* st) {
   for (npy_intp i = 0; i < n; ++i) {
     C P[3], Q[3];
-    LoadPt<C>(P, reinterpret_cast<const unsigned char*>(a), cb);
-    LoadPt<C>(Q, reinterpret_cast<const unsigned char*>(b), cb);
-    int eq = EcEqualT<C, Ops>(f, P, Q);
+    LoadPt<C>(f, P, a);
+    LoadPt<C>(f, Q, b);
+    int eq = ec_law::EcEqualT<C, Ops>(f, P, Q);
     *reinterpret_cast<npy_bool*>(o) = (negate ? !eq : eq) ? 1 : 0;
     a += st[0];
     b += st[1];
@@ -1131,7 +891,7 @@ void RunCmpT(const Ops& f, bool negate, char* a, char* b, char* o, npy_intp n,
 template <typename C, typename Ops>
 int RunScalarT(const Ops& f, PyArray_Descr* scalar_descr, char* s, char* pt,
                char* o, npy_intp n, npy_intp s_stride, npy_intp pt_stride,
-               npy_intp o_stride, int cb) {
+               npy_intp o_stride) {
   for (npy_intp i = 0; i < n; ++i) {
     PyObject* scalar =
         PrimeFieldValue(reinterpret_cast<PyObject*>(scalar_descr), s);
@@ -1141,9 +901,9 @@ int RunScalarT(const Ops& f, PyArray_Descr* scalar_descr, char* s, char* pt,
     Py_DECREF(scalar);
     if (nbits < 0) return -1;
     C point[3], ret[3];
-    LoadPt<C>(point, reinterpret_cast<const unsigned char*>(pt), cb);
-    EcScalarMulT<C, Ops>(f, point, buf, static_cast<int>(nbits), ret);
-    StorePt<C>(reinterpret_cast<unsigned char*>(o), ret, cb);
+    LoadPt<C>(f, point, pt);
+    ec_law::EcScalarMulT<C, Ops>(f, point, buf, static_cast<int>(nbits), ret);
+    StorePt<C>(f, o, ret);
     s += s_stride;
     pt += pt_stride;
     o += o_stride;
@@ -1174,6 +934,11 @@ PyArray_Descr* MakeDescr(PyObject* modulus, int base_width_bytes,
   d->base_width_bytes = static_cast<uint8_t>(base_width_bytes);
   d->num_coords = static_cast<uint8_t>(num_coords);
   d->is_montgomery = static_cast<uint8_t>(is_montgomery ? 1 : 0);
+  // Group-law tier: decided once here; the ufunc loops only switch on it.
+  d->native = new CoordField(CoordField::Make(d));
+  d->tier = !d->native->ok        ? Tier::kPy
+            : d->native->wb == 32 ? Tier::kTyped256
+                                  : Tier::kByte;
   PyArray_Descr* base = &d->base;
   base->kind = 'V';
   base->type = 'j';
@@ -1190,6 +955,7 @@ void Descr_dealloc(PyObject* self) {
   Py_XDECREF(d->r_mod_p);
   Py_XDECREF(d->rinv_mod_p);
   Py_XDECREF(d->non_residue);
+  delete d->native;
   PyArrayDescr_Type.tp_dealloc(self);
 }
 
@@ -1666,34 +1432,17 @@ int BinLoop(PyArrayMethod_Context* context, char* const* data,
   char* a = data[0];
   char* b = data[1];
   char* o = data[2];
-  CoordField cf = CoordField::Make(d);
-  if (cf.ok &&
-      cf.wb == 32) {  // typed-limb fast path (256-bit coordinate field)
+  const CoordField& cf = *d->native;
+  if (d->tier == Tier::kTyped256) {
     if (cf.degree == 1) {
-      RunBinT<BigInt<4>>(MakeFqOps(cf), op == BinOp::kSub, a, b, o, n, strides,
-                         cf.cb);
+      RunBinT<BigInt<4>>(MakeFqOps(cf), op == BinOp::kSub, a, b, o, n, strides);
     } else {
-      RunBinT<Fp2<4>>(MakeFp2Ops(cf), op == BinOp::kSub, a, b, o, n, strides,
-                      cf.cb);
+      RunBinT<Fp2<4>>(MakeFp2Ops(cf), op == BinOp::kSub, a, b, o, n, strides);
     }
     return 0;
   }
-  if (cf.ok) {  // num_coords == 3 guaranteed by BinResolve
-    unsigned char neg_q[3 * kCoordBytes];
-    for (npy_intp i = 0; i < n; ++i) {
-      const auto* ua = reinterpret_cast<const unsigned char*>(a);
-      const auto* ub = reinterpret_cast<const unsigned char*>(b);
-      auto* uo = reinterpret_cast<unsigned char*>(o);
-      if (op == BinOp::kSub) {
-        EcNegate(cf, ub, neg_q, 3);
-        EcAdd(cf, ua, neg_q, uo);
-      } else {
-        EcAdd(cf, ua, ub, uo);
-      }
-      a += strides[0];
-      b += strides[1];
-      o += strides[2];
-    }
+  if (d->tier == Tier::kByte) {  // num_coords == 3 guaranteed by BinResolve
+    RunBinT<ByteCoord>(ByteOps{&cf}, op == BinOp::kSub, a, b, o, n, strides);
     return 0;
   }
   for (npy_intp i = 0; i < n; ++i) {
@@ -1738,23 +1487,17 @@ int NegLoop(PyArrayMethod_Context* context, char* const* data,
   npy_intp n = dimensions[0];
   char* a = data[0];
   char* o = data[1];
-  CoordField cf = CoordField::Make(d);
-  if (cf.ok &&
-      cf.wb == 32) {  // typed-limb fast path (negate flips Y per coord)
+  const CoordField& cf = *d->native;
+  if (d->tier == Tier::kTyped256) {  // negate flips Y per coord
     if (cf.degree == 1) {
-      RunNegT<BigInt<4>>(MakeFqOps(cf), a, o, n, strides, cf.cb, d->num_coords);
+      RunNegT<BigInt<4>>(MakeFqOps(cf), a, o, n, strides, d->num_coords);
     } else {
-      RunNegT<Fp2<4>>(MakeFp2Ops(cf), a, o, n, strides, cf.cb, d->num_coords);
+      RunNegT<Fp2<4>>(MakeFp2Ops(cf), a, o, n, strides, d->num_coords);
     }
     return 0;
   }
-  if (cf.ok) {
-    for (npy_intp i = 0; i < n; ++i) {
-      EcNegate(cf, reinterpret_cast<const unsigned char*>(a),
-               reinterpret_cast<unsigned char*>(o), d->num_coords);
-      a += strides[0];
-      o += strides[1];
-    }
+  if (d->tier == Tier::kByte) {
+    RunNegT<ByteCoord>(ByteOps{&cf}, a, o, n, strides, d->num_coords);
     return 0;
   }
   for (npy_intp i = 0; i < n; ++i) {
@@ -1858,24 +1601,17 @@ int CmpLoop(PyArrayMethod_Context* context, char* const* data,
   char* a = data[0];
   char* b = data[1];
   char* o = data[2];
-  CoordField cf = CoordField::Make(d);
-  if (cf.ok && cf.wb == 32) {  // typed-limb fast path (256-bit)
+  const CoordField& cf = *d->native;
+  if (d->tier == Tier::kTyped256) {
     if (cf.degree == 1) {
-      RunCmpT<BigInt<4>>(MakeFqOps(cf), negate, a, b, o, n, strides, cf.cb);
+      RunCmpT<BigInt<4>>(MakeFqOps(cf), negate, a, b, o, n, strides);
     } else {
-      RunCmpT<Fp2<4>>(MakeFp2Ops(cf), negate, a, b, o, n, strides, cf.cb);
+      RunCmpT<Fp2<4>>(MakeFp2Ops(cf), negate, a, b, o, n, strides);
     }
     return 0;
   }
-  if (cf.ok) {  // num_coords == 3 guaranteed by CmpResolve
-    for (npy_intp i = 0; i < n; ++i) {
-      int eq = EcEqual(cf, reinterpret_cast<const unsigned char*>(a),
-                       reinterpret_cast<const unsigned char*>(b));
-      *reinterpret_cast<npy_bool*>(o) = (negate ? !eq : eq) ? 1 : 0;
-      a += strides[0];
-      b += strides[1];
-      o += strides[2];
-    }
+  if (d->tier == Tier::kByte) {  // num_coords == 3 guaranteed by CmpResolve
+    RunCmpT<ByteCoord>(ByteOps{&cf}, negate, a, b, o, n, strides);
     return 0;
   }
   for (npy_intp i = 0; i < n; ++i) {
@@ -1984,31 +1720,18 @@ int ScalarMulLoop(PyArrayMethod_Context* context, char* const* data,
   char* o = data[2];
   npy_intp s_stride = strides[scalar_first ? 0 : 1];
   npy_intp pt_stride = strides[scalar_first ? 1 : 0];
-  CoordField cf = CoordField::Make(d);
-  if (cf.ok && d->num_coords == 3 && cf.wb == 32) {  // typed-limb fast path
+  const CoordField& cf = *d->native;
+  if (d->tier == Tier::kTyped256 && d->num_coords == 3) {
     if (cf.degree == 1) {
       return RunScalarT<BigInt<4>>(MakeFqOps(cf), scalar_descr, s, pt, o, n,
-                                   s_stride, pt_stride, strides[2], cf.cb);
+                                   s_stride, pt_stride, strides[2]);
     }
     return RunScalarT<Fp2<4>>(MakeFp2Ops(cf), scalar_descr, s, pt, o, n,
-                              s_stride, pt_stride, strides[2], cf.cb);
+                              s_stride, pt_stride, strides[2]);
   }
-  if (cf.ok && d->num_coords == 3) {
-    for (npy_intp i = 0; i < n; ++i) {
-      PyObject* scalar =
-          PrimeFieldValue(reinterpret_cast<PyObject*>(scalar_descr), s);
-      if (scalar == nullptr) return -1;
-      unsigned char buf[64];
-      Py_ssize_t nbits = ScalarToBytesLE(scalar, buf, sizeof(buf));
-      Py_DECREF(scalar);
-      if (nbits < 0) return -1;
-      EcScalarMul(cf, reinterpret_cast<const unsigned char*>(pt), buf,
-                  static_cast<int>(nbits), reinterpret_cast<unsigned char*>(o));
-      s += s_stride;
-      pt += pt_stride;
-      o += strides[2];
-    }
-    return 0;
+  if (d->tier == Tier::kByte && d->num_coords == 3) {
+    return RunScalarT<ByteCoord>(ByteOps{&cf}, scalar_descr, s, pt, o, n,
+                                 s_stride, pt_stride, strides[2]);
   }
   for (npy_intp i = 0; i < n; ++i) {
     PyObject* scalar =

--- a/zk_dtypes/_src/ec_point_dtype.cc
+++ b/zk_dtypes/_src/ec_point_dtype.cc
@@ -1268,7 +1268,45 @@ PyArray_Descr* DiscoverDescrFromPyobject(PyArray_DTypeMeta* /*cls*/,
   return nullptr;
 }
 
-// setitem accepts a length-num_coords sequence of coordinate integers.
+// Normalizes one setitem coordinate into the form EncodeCoord expects, the
+// mirror of what GetItem/DecodeCoord produce: a canonical int for a degree-1
+// (Fq) coordinate, or a `coord_degree`-tuple of ints for an Fp2 coordinate
+// (G2). Returns a new reference, or NULL with an exception set.
+PyObject* CoordFromPy(EcPointDescr* d, PyObject* item) {
+  if (d->coord_degree == 1) {
+    return PyNumber_Index(item);
+  }
+  PyObject* seq = PySequence_Fast(item, "Fp2 coordinate needs (c0, c1)");
+  if (seq == nullptr) {
+    return nullptr;
+  }
+  if (PySequence_Fast_GET_SIZE(seq) != d->coord_degree) {
+    PyErr_Format(PyExc_ValueError,
+                 "Fp2 coordinate needs %d components, got %zd", d->coord_degree,
+                 PySequence_Fast_GET_SIZE(seq));
+    Py_DECREF(seq);
+    return nullptr;
+  }
+  PyObject* tuple = PyTuple_New(d->coord_degree);
+  if (tuple == nullptr) {
+    Py_DECREF(seq);
+    return nullptr;
+  }
+  for (int k = 0; k < d->coord_degree; ++k) {
+    PyObject* c = PyNumber_Index(PySequence_Fast_GET_ITEM(seq, k));
+    if (c == nullptr) {
+      Py_DECREF(seq);
+      Py_DECREF(tuple);
+      return nullptr;
+    }
+    PyTuple_SET_ITEM(tuple, k, c);
+  }
+  Py_DECREF(seq);
+  return tuple;
+}
+
+// setitem accepts a length-num_coords sequence of coordinates; each coordinate
+// is an int (G1) or an (c0, c1) pair (G2 Fp2), matching getitem's output.
 int SetItem(PyArray_Descr* descr, PyObject* obj, char* dataptr) {
   EcPointDescr* d = AsEc(descr);
   PyObject* seq = PySequence_Fast(obj, "EC point needs a coordinate sequence");
@@ -1284,7 +1322,7 @@ int SetItem(PyArray_Descr* descr, PyObject* obj, char* dataptr) {
   PyObject* coords[kMaxCoords] = {nullptr};
   int rc = -1;
   for (int i = 0; i < d->num_coords; ++i) {
-    coords[i] = PyNumber_Index(PySequence_Fast_GET_ITEM(seq, i));
+    coords[i] = CoordFromPy(d, PySequence_Fast_GET_ITEM(seq, i));
     if (coords[i] == nullptr) {
       goto done;
     }

--- a/zk_dtypes/_src/ec_point_dtype.h
+++ b/zk_dtypes/_src/ec_point_dtype.h
@@ -1,0 +1,34 @@
+/* Copyright 2025 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES__SRC_EC_POINT_DTYPE_H_
+#define ZK_DTYPES__SRC_EC_POINT_DTYPE_H_
+
+#include <Python.h>
+
+namespace zk_dtypes {
+
+// Registers the parametric `EcPointDType` (NEP-42) and installs the
+// `ec_point_descr(modulus, base_width_bits, is_montgomery[, r, rinv])` factory
+// on `module`. This first cut covers short-Weierstrass G1 points (a=0) in the
+// Jacobian representation over a prime coordinate field, with the group law
+// (add / subtract / negate) registered on numpy. The curve, coordinate
+// representation, and field live on each descriptor instance. Returns false
+// (with a Python error set) on failure. Must run after numpy is imported.
+bool RegisterEcPointDType(PyObject* numpy, PyObject* module);
+
+}  // namespace zk_dtypes
+
+#endif  // ZK_DTYPES__SRC_EC_POINT_DTYPE_H_

--- a/zk_dtypes/_src/field_dtype.cc
+++ b/zk_dtypes/_src/field_dtype.cc
@@ -841,6 +841,20 @@ bool AddArithLoop(PyObject* numpy, const char* ufunc_name) {
 
 }  // namespace
 
+PyObject* FieldDTypeMetaObject() {
+  return reinterpret_cast<PyObject*>(&FieldDType);
+}
+
+PyObject* PrimeFieldValue(PyObject* descr, const char* data) {
+  FieldDescr* f = AsField(reinterpret_cast<PyArray_Descr*>(descr));
+  if (f->kind != kOddField || f->degree != 1) {
+    PyErr_SetString(PyExc_TypeError,
+                    "EC scalar must be a prime (degree-1) field element");
+    return nullptr;
+  }
+  return DecodeCoeff(f, data);
+}
+
 bool RegisterFieldDType(PyObject* /*numpy*/, PyObject* module) {
   FieldScalar_Type.tp_name = "zk_dtypes._zk_dtypes_ext.FieldScalar";
   FieldScalar_Type.tp_basicsize = 0;

--- a/zk_dtypes/_src/field_dtype.cc
+++ b/zk_dtypes/_src/field_dtype.cc
@@ -1,0 +1,948 @@
+/* Copyright 2025 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Parametric finite-field numpy DType (NEP-42). One DType class serves every
+// field — prime (degree 1) and binomial extension Fp[X]/(X^k - non_residue)
+// (degree k) — with modulus / degree / non_residue / storage form carried on
+// each descriptor *instance*, so a user-defined field needs no new C++ type.
+// This is the host counterpart to the parametric `algebraic*<...>` element type
+// in xla_fork; the compiler stack below is already modulus-generic.
+//
+// Storage matches the legacy named types byte-for-byte: an element is `degree`
+// base-field coefficients, constant term first, each coefficient stored at
+// base width little-endian and (for Montgomery storage) encoded as `c*R mod p`
+// with R = 2^base_width. Arithmetic is host Python-C-API bignum (correct and
+// width-generic; host eager arithmetic is not the perf path — the device is).
+
+// numpy.h must precede every other numpy header (it sets the API symbol) and
+// NPY_TARGET_VERSION must precede numpyconfig.h; the associated header pulls in
+// only <Python.h>, so it can lead. Keep this order — do not let clang-format
+// sort it.
+// clang-format off
+#define NPY_TARGET_VERSION NPY_2_0_API_VERSION
+#include "zk_dtypes/_src/field_dtype.h"
+
+#include <cstdint>
+#include <cstring>
+
+#include "zk_dtypes/_src/numpy.h"
+#include "numpy/dtype_api.h"
+#include "numpy/ndarraytypes.h"
+// clang-format on
+
+namespace zk_dtypes {
+namespace {
+
+// Extension degree is tiny in practice (<= 4 for the shipped families); cap the
+// stack coefficient buffers generously.
+constexpr int kMaxDegree = 16;
+
+// A field is one of two structurally-distinct families behind one DType. Both
+// are Fields (+ - * /); they share no arithmetic, so the loops dispatch on
+// kind.
+enum FieldKind : uint8_t {
+  kOddField = 0,     // prime or binomial extension over an odd prime p
+  kBinaryTower = 1,  // GF(2^(2^level)) tower, characteristic 2
+};
+
+struct FieldDescr {
+  PyArray_Descr base;
+  // Odd-field parameters (kBinaryTower leaves these NULL):
+  PyObject* modulus;  // owned: base prime p
+  PyObject*
+      non_residue;    // owned (degree > 1): X^degree = non_residue; else NULL
+  PyObject* r_mod_p;  // owned (Montgomery): R = 2^base_width mod p; else NULL
+  PyObject* rinv_mod_p;  // owned (Montgomery): R^-1 mod p; else NULL
+  // Binary-tower parameters (kOddField leaves value_mask NULL):
+  PyObject* value_mask;  // owned (binary): 2^(2^level) - 1
+  uint8_t kind;
+  uint8_t
+      base_width_bytes;  // odd: per-coefficient width; binary: storage width
+  uint8_t degree;        // odd: extension degree (1 = prime); binary: 1
+  uint8_t tower_level;   // binary tower level
+  uint8_t is_montgomery;
+};
+
+PyArray_DTypeMeta FieldDType = {};
+PyTypeObject FieldScalar_Type = {};
+
+FieldDescr* AsField(PyArray_Descr* d) {
+  return reinterpret_cast<FieldDescr*>(d);
+}
+
+// --- binary tower helpers (characteristic 2) ----------------------------
+
+// 2^bits - 1 as a Python int.
+PyObject* Mask(int bits) {
+  PyObject* one = PyLong_FromLong(1);
+  PyObject* shift = PyLong_FromLong(bits);
+  PyObject* shifted = (one && shift) ? PyNumber_Lshift(one, shift) : nullptr;
+  Py_XDECREF(one);
+  Py_XDECREF(shift);
+  if (shifted == nullptr) {
+    return nullptr;
+  }
+  PyObject* minus_one = PyLong_FromLong(1);
+  PyObject* mask = minus_one ? PyNumber_Subtract(shifted, minus_one) : nullptr;
+  Py_DECREF(shifted);
+  Py_XDECREF(minus_one);
+  return mask;
+}
+
+// Recursive Karatsuba tower multiply in GF(2^(2^level)) =
+// GF(2^(2^(level-1)))[X]/(X^2 + X + alpha_level), alpha = 1 << (2^(level-1)-1).
+PyObject* TowerMul(int level, PyObject* a, PyObject* b) {
+  if (level == 0) {
+    PyObject* ab = PyNumber_And(a, b);
+    if (ab == nullptr) {
+      return nullptr;
+    }
+    PyObject* one = PyLong_FromLong(1);
+    PyObject* r = one ? PyNumber_And(ab, one) : nullptr;
+    Py_DECREF(ab);
+    Py_XDECREF(one);
+    return r;
+  }
+  const int sb = 1 << (level - 1);
+  PyObject* submask = Mask(sb);
+  PyObject* shift = PyLong_FromLong(sb);
+  PyObject* one = PyLong_FromLong(1);
+  PyObject* abits = PyLong_FromLong(sb - 1);
+  PyObject* alpha = (one && abits) ? PyNumber_Lshift(one, abits) : nullptr;
+  Py_XDECREF(one);
+  Py_XDECREF(abits);
+  PyObject *a0 = nullptr, *a1 = nullptr, *b0 = nullptr, *b1 = nullptr;
+  PyObject *a0b0 = nullptr, *a1b1 = nullptr, *a1b1a = nullptr;
+  PyObject *axor = nullptr, *bxor = nullptr, *mid = nullptr;
+  PyObject *c0 = nullptr, *c1 = nullptr, *c1sh = nullptr, *result = nullptr;
+  if (!submask || !shift || !alpha) {
+    goto done;
+  }
+  a0 = PyNumber_And(a, submask);
+  b0 = PyNumber_And(b, submask);
+  {
+    PyObject* ah = PyNumber_Rshift(a, shift);
+    a1 = ah ? PyNumber_And(ah, submask) : nullptr;
+    Py_XDECREF(ah);
+    PyObject* bh = PyNumber_Rshift(b, shift);
+    b1 = bh ? PyNumber_And(bh, submask) : nullptr;
+    Py_XDECREF(bh);
+  }
+  if (!a0 || !a1 || !b0 || !b1) {
+    goto done;
+  }
+  a0b0 = TowerMul(level - 1, a0, b0);
+  a1b1 = TowerMul(level - 1, a1, b1);
+  if (!a0b0 || !a1b1) {
+    goto done;
+  }
+  a1b1a = TowerMul(level - 1, a1b1, alpha);
+  if (!a1b1a) {
+    goto done;
+  }
+  c0 = PyNumber_Xor(a0b0, a1b1a);
+  axor = PyNumber_Xor(a0, a1);
+  bxor = PyNumber_Xor(b0, b1);
+  if (!c0 || !axor || !bxor) {
+    goto done;
+  }
+  mid = TowerMul(level - 1, axor, bxor);
+  if (!mid) {
+    goto done;
+  }
+  c1 = PyNumber_Xor(mid, a0b0);
+  if (!c1) {
+    goto done;
+  }
+  c1sh = PyNumber_Lshift(c1, shift);
+  if (!c1sh) {
+    goto done;
+  }
+  result = PyNumber_Or(c0, c1sh);
+done:
+  Py_XDECREF(submask);
+  Py_XDECREF(shift);
+  Py_XDECREF(alpha);
+  Py_XDECREF(a0);
+  Py_XDECREF(a1);
+  Py_XDECREF(b0);
+  Py_XDECREF(b1);
+  Py_XDECREF(a0b0);
+  Py_XDECREF(a1b1);
+  Py_XDECREF(a1b1a);
+  Py_XDECREF(axor);
+  Py_XDECREF(bxor);
+  Py_XDECREF(mid);
+  Py_XDECREF(c0);
+  Py_XDECREF(c1);
+  Py_XDECREF(c1sh);
+  return result;
+}
+
+// --- per-coefficient encode / decode (canonical or Montgomery) ----------
+
+// Reads one base-field coefficient at `slot` and returns its canonical value.
+PyObject* DecodeCoeff(FieldDescr* d, const char* slot) {
+  PyObject* stored = _PyLong_FromByteArray(
+      reinterpret_cast<const unsigned char*>(slot), d->base_width_bytes,
+      /*little_endian=*/1, /*is_signed=*/0);
+  if (stored == nullptr || !d->is_montgomery) {
+    return stored;
+  }
+  PyObject* scaled = PyNumber_Multiply(stored, d->rinv_mod_p);
+  Py_DECREF(stored);
+  if (scaled == nullptr) {
+    return nullptr;
+  }
+  PyObject* canonical = PyNumber_Remainder(scaled, d->modulus);
+  Py_DECREF(scaled);
+  return canonical;
+}
+
+// Writes canonical value `value` into the base-field coefficient at `slot`.
+int EncodeCoeff(FieldDescr* d, char* slot, PyObject* value) {
+  PyObject* rem = PyNumber_Remainder(value, d->modulus);
+  if (rem == nullptr) {
+    return -1;
+  }
+  if (d->is_montgomery) {
+    PyObject* scaled = PyNumber_Multiply(rem, d->r_mod_p);
+    Py_DECREF(rem);
+    if (scaled == nullptr) {
+      return -1;
+    }
+    rem = PyNumber_Remainder(scaled, d->modulus);
+    Py_DECREF(scaled);
+    if (rem == nullptr) {
+      return -1;
+    }
+  }
+  int rc = _PyLong_AsByteArray(reinterpret_cast<PyLongObject*>(rem),
+                               reinterpret_cast<unsigned char*>(slot),
+                               d->base_width_bytes, /*little_endian=*/1,
+                               /*is_signed=*/0);
+  Py_DECREF(rem);
+  return rc < 0 ? -1 : 0;
+}
+
+// Fills `out[0..degree-1]` with new canonical-value references. On failure sets
+// a Python error, clears any it set, and returns -1.
+int DecodeElement(FieldDescr* d, const char* ptr, PyObject** out) {
+  for (int i = 0; i < d->degree; ++i) {
+    out[i] = DecodeCoeff(d, ptr + i * d->base_width_bytes);
+    if (out[i] == nullptr) {
+      for (int j = 0; j < i; ++j) {
+        Py_DECREF(out[j]);
+      }
+      return -1;
+    }
+  }
+  return 0;
+}
+
+int EncodeElement(FieldDescr* d, char* ptr, PyObject* const* coeffs) {
+  for (int i = 0; i < d->degree; ++i) {
+    if (EncodeCoeff(d, ptr + i * d->base_width_bytes, coeffs[i]) < 0) {
+      return -1;
+    }
+  }
+  return 0;
+}
+
+// --- descriptor lifecycle ------------------------------------------------
+
+PyArray_Descr* MakeDescr(PyObject* modulus, PyObject* non_residue, int degree,
+                         int base_width_bytes, int is_montgomery, PyObject* r,
+                         PyObject* rinv) {
+  auto* d = reinterpret_cast<FieldDescr*>(PyArrayDescr_Type.tp_new(
+      reinterpret_cast<PyTypeObject*>(&FieldDType), nullptr, nullptr));
+  if (d == nullptr) {
+    return nullptr;
+  }
+  Py_INCREF(modulus);
+  d->modulus = modulus;
+  Py_XINCREF(non_residue);
+  d->non_residue = non_residue;
+  Py_XINCREF(r);
+  d->r_mod_p = r;
+  Py_XINCREF(rinv);
+  d->rinv_mod_p = rinv;
+  d->value_mask = nullptr;
+  d->kind = kOddField;
+  d->base_width_bytes = static_cast<uint8_t>(base_width_bytes);
+  d->degree = static_cast<uint8_t>(degree);
+  d->tower_level = 0;
+  d->is_montgomery = static_cast<uint8_t>(is_montgomery ? 1 : 0);
+  PyArray_Descr* base = &d->base;
+  base->kind = 'V';
+  base->type = 'F';
+  base->byteorder = '=';
+  // Route scalar access (arr[i]) through the ArrFuncs getitem/setitem rather
+  // than the copyswap path, which is NULL for this minimal scalar type.
+  base->flags = NPY_USE_GETITEM | NPY_USE_SETITEM;
+  base->elsize = base_width_bytes * degree;
+  base->alignment = base_width_bytes <= 8 ? base_width_bytes : 8;
+  return base;
+}
+
+// Binary tower GF(2^(2^level)). All odd-field params stay NULL.
+PyArray_Descr* MakeBinaryDescr(int tower_level, int width_bytes) {
+  auto* d = reinterpret_cast<FieldDescr*>(PyArrayDescr_Type.tp_new(
+      reinterpret_cast<PyTypeObject*>(&FieldDType), nullptr, nullptr));
+  if (d == nullptr) {
+    return nullptr;
+  }
+  d->value_mask = Mask(1 << tower_level);  // 2^(2^level) - 1
+  if (d->value_mask == nullptr) {
+    Py_DECREF(d);
+    return nullptr;
+  }
+  d->modulus = nullptr;
+  d->non_residue = nullptr;
+  d->r_mod_p = nullptr;
+  d->rinv_mod_p = nullptr;
+  d->kind = kBinaryTower;
+  d->base_width_bytes = static_cast<uint8_t>(width_bytes);
+  d->degree = 1;
+  d->tower_level = static_cast<uint8_t>(tower_level);
+  d->is_montgomery = 0;
+  PyArray_Descr* base = &d->base;
+  base->kind = 'V';
+  base->type = 'B';
+  base->byteorder = '=';
+  // Route scalar access (arr[i]) through the ArrFuncs getitem/setitem rather
+  // than the copyswap path, which is NULL for this minimal scalar type.
+  base->flags = NPY_USE_GETITEM | NPY_USE_SETITEM;
+  base->elsize = width_bytes;
+  base->alignment = width_bytes <= 8 ? width_bytes : 8;
+  return base;
+}
+
+void Descr_dealloc(PyObject* self) {
+  FieldDescr* d = AsField(reinterpret_cast<PyArray_Descr*>(self));
+  Py_XDECREF(d->modulus);
+  Py_XDECREF(d->non_residue);
+  Py_XDECREF(d->r_mod_p);
+  Py_XDECREF(d->rinv_mod_p);
+  Py_XDECREF(d->value_mask);
+  PyArrayDescr_Type.tp_dealloc(self);
+}
+
+PyObject* DType_new(PyTypeObject* /*cls*/, PyObject* /*args*/,
+                    PyObject* /*kwds*/) {
+  PyErr_SetString(
+      PyExc_TypeError,
+      "construct a field via zk_dtypes.prime_field(p) / "
+      "zk_dtypes.extension_field(...), not FieldDType(...) directly");
+  return nullptr;
+}
+
+PyObject* Descr_repr(PyObject* self) {
+  FieldDescr* d = AsField(reinterpret_cast<PyArray_Descr*>(self));
+  if (d->kind == kBinaryTower) {
+    return PyUnicode_FromFormat("FieldDType(binary_tower_level=%d, bits=%d)",
+                                static_cast<int>(d->tower_level),
+                                1 << d->tower_level);
+  }
+  if (d->degree == 1) {
+    return PyUnicode_FromFormat("FieldDType(modulus=%R, width=%d, mont=%d)",
+                                d->modulus, d->base_width_bytes * 8,
+                                static_cast<int>(d->is_montgomery));
+  }
+  return PyUnicode_FromFormat(
+      "FieldDType(modulus=%R, degree=%d, non_residue=%R, base_width=%d, "
+      "mont=%d)",
+      d->modulus, static_cast<int>(d->degree), d->non_residue,
+      d->base_width_bytes * 8, static_cast<int>(d->is_montgomery));
+}
+
+// --- NEP-42 DType slots --------------------------------------------------
+
+PyArray_Descr* DefaultDescr(PyArray_DTypeMeta* /*cls*/) {
+  PyObject* two = PyLong_FromLong(2);
+  if (two == nullptr) {
+    return nullptr;
+  }
+  PyArray_Descr* d =
+      MakeDescr(two, nullptr, 1, 4, /*is_montgomery=*/0, nullptr, nullptr);
+  Py_DECREF(two);
+  return d;
+}
+
+PyArray_DTypeMeta* CommonDType(PyArray_DTypeMeta* a, PyArray_DTypeMeta* b) {
+  if (a == b) {
+    Py_INCREF(a);
+    return a;
+  }
+  Py_INCREF(Py_NotImplemented);
+  return reinterpret_cast<PyArray_DTypeMeta*>(Py_NotImplemented);
+}
+
+// Two field descriptors are the same field iff every parameter matches.
+bool SameField(FieldDescr* a, FieldDescr* b) {
+  if (a->kind != b->kind) {
+    return false;
+  }
+  if (a->kind == kBinaryTower) {
+    return a->tower_level == b->tower_level;
+  }
+  if (a->base_width_bytes != b->base_width_bytes || a->degree != b->degree ||
+      a->is_montgomery != b->is_montgomery) {
+    return false;
+  }
+  if (PyObject_RichCompareBool(a->modulus, b->modulus, Py_EQ) != 1) {
+    return false;
+  }
+  if (a->degree == 1) {
+    return true;
+  }
+  return PyObject_RichCompareBool(a->non_residue, b->non_residue, Py_EQ) == 1;
+}
+
+PyArray_Descr* CommonInstance(PyArray_Descr* a, PyArray_Descr* b) {
+  if (SameField(AsField(a), AsField(b))) {
+    Py_INCREF(a);
+    return a;
+  }
+  PyErr_SetString(PyExc_TypeError,
+                  "cannot combine field arrays of different fields");
+  return nullptr;
+}
+
+PyArray_Descr* EnsureCanonical(PyArray_Descr* self) {
+  Py_INCREF(self);
+  return self;
+}
+
+PyArray_Descr* DiscoverDescrFromPyobject(PyArray_DTypeMeta* /*cls*/,
+                                         PyObject* /*obj*/) {
+  PyErr_SetString(PyExc_TypeError,
+                  "cannot infer a field from a scalar; pass an explicit "
+                  "dtype=zk_dtypes.prime_field(p) / extension_field(...)");
+  return nullptr;
+}
+
+// setitem accepts a Python int (constant-term embedding) or a length-`degree`
+// sequence of coefficients (constant term first).
+int SetItem(PyArray_Descr* descr, PyObject* obj, char* dataptr) {
+  FieldDescr* d = AsField(descr);
+  if (d->kind == kBinaryTower) {
+    PyObject* idx = PyNumber_Index(obj);
+    if (idx == nullptr) {
+      return -1;
+    }
+    PyObject* masked = PyNumber_And(idx, d->value_mask);
+    Py_DECREF(idx);
+    if (masked == nullptr) {
+      return -1;
+    }
+    int brc = _PyLong_AsByteArray(reinterpret_cast<PyLongObject*>(masked),
+                                  reinterpret_cast<unsigned char*>(dataptr),
+                                  d->base_width_bytes, 1, 0);
+    Py_DECREF(masked);
+    return brc < 0 ? -1 : 0;
+  }
+  PyObject* coeffs[kMaxDegree] = {nullptr};
+  int rc = -1;
+  if (PyIndex_Check(obj)) {
+    coeffs[0] = PyNumber_Index(obj);
+    if (coeffs[0] == nullptr) {
+      goto done;
+    }
+    for (int i = 1; i < d->degree; ++i) {
+      coeffs[i] = PyLong_FromLong(0);
+      if (coeffs[i] == nullptr) {
+        goto done;
+      }
+    }
+  } else {
+    PyObject* seq = PySequence_Fast(
+        obj, "field element must be an int or a sequence of coefficients");
+    if (seq == nullptr) {
+      goto done;
+    }
+    if (PySequence_Fast_GET_SIZE(seq) != d->degree) {
+      Py_DECREF(seq);
+      PyErr_Format(PyExc_ValueError,
+                   "field element needs %d coefficients, got %zd", d->degree,
+                   PySequence_Fast_GET_SIZE(seq));
+      goto done;
+    }
+    for (int i = 0; i < d->degree; ++i) {
+      coeffs[i] = PyNumber_Index(PySequence_Fast_GET_ITEM(seq, i));
+      if (coeffs[i] == nullptr) {
+        Py_DECREF(seq);
+        goto done;
+      }
+    }
+    Py_DECREF(seq);
+  }
+  rc = EncodeElement(d, dataptr, coeffs);
+done:
+  for (int i = 0; i < d->degree; ++i) {
+    Py_XDECREF(coeffs[i]);
+  }
+  return rc;
+}
+
+// getitem returns a Python int for a prime field, or a tuple of canonical
+// coefficients (constant term first) for an extension field.
+PyObject* GetItem(PyArray_Descr* descr, char* dataptr) {
+  FieldDescr* d = AsField(descr);
+  if (d->kind == kBinaryTower) {
+    return _PyLong_FromByteArray(reinterpret_cast<unsigned char*>(dataptr),
+                                 d->base_width_bytes, 1, 0);
+  }
+  PyObject* coeffs[kMaxDegree] = {nullptr};
+  if (DecodeElement(d, dataptr, coeffs) < 0) {
+    return nullptr;
+  }
+  if (d->degree == 1) {
+    return coeffs[0];
+  }
+  PyObject* tuple = PyTuple_New(d->degree);
+  if (tuple == nullptr) {
+    for (int i = 0; i < d->degree; ++i) {
+      Py_DECREF(coeffs[i]);
+    }
+    return nullptr;
+  }
+  for (int i = 0; i < d->degree; ++i) {
+    PyTuple_SET_ITEM(tuple, i, coeffs[i]);  // steals the reference
+  }
+  return tuple;
+}
+
+// --- within-DType copy cast (numpy requires at least a self-copy) --------
+
+NPY_CASTING CastResolve(struct PyArrayMethodObject_tag* /*method*/,
+                        PyArray_DTypeMeta* const* /*dtypes*/,
+                        PyArray_Descr* const* given, PyArray_Descr** loop,
+                        npy_intp* view_offset) {
+  PyArray_Descr* from = given[0];
+  Py_INCREF(from);
+  loop[0] = from;
+  PyArray_Descr* to = given[1];
+  if (to == nullptr) {
+    Py_INCREF(from);
+    loop[1] = from;
+    *view_offset = 0;
+    return NPY_NO_CASTING;
+  }
+  Py_INCREF(to);
+  loop[1] = to;
+  if (SameField(AsField(from), AsField(to))) {
+    *view_offset = 0;
+    return NPY_NO_CASTING;
+  }
+  return NPY_UNSAFE_CASTING;
+}
+
+int CastLoop(PyArrayMethod_Context* context, char* const* data,
+             const npy_intp* dimensions, const npy_intp* strides,
+             NpyAuxData* /*aux*/) {
+  npy_intp n = dimensions[0];
+  char* in = data[0];
+  char* out = data[1];
+  npy_intp elsize = context->descriptors[0]->elsize;
+  for (npy_intp i = 0; i < n; ++i) {
+    std::memcpy(out, in, elsize);
+    in += strides[0];
+    out += strides[1];
+  }
+  return 0;
+}
+
+// --- factory -------------------------------------------------------------
+
+// field_descr(modulus, degree, non_residue, base_width_bits, is_montgomery
+//             [, r_mod_p, rinv_mod_p]) -> dtype
+// non_residue is ignored for degree 1. Montgomery storage passes R and R^-1
+// (mod p, R = 2^base_width) computed in Python.
+PyObject* MakeFieldDescrPy(PyObject* /*self*/, PyObject* args) {
+  PyObject* modulus_obj;
+  int degree;
+  PyObject* non_residue_obj;
+  int base_width_bits;
+  int is_montgomery;
+  PyObject* r_obj = nullptr;
+  PyObject* rinv_obj = nullptr;
+  if (!PyArg_ParseTuple(args, "OiOii|OO", &modulus_obj, &degree,
+                        &non_residue_obj, &base_width_bits, &is_montgomery,
+                        &r_obj, &rinv_obj)) {
+    return nullptr;
+  }
+  if (base_width_bits != 32 && base_width_bits != 64 &&
+      base_width_bits != 128 && base_width_bits != 256) {
+    PyErr_SetString(PyExc_ValueError,
+                    "base_width_bits must be one of 32, 64, 128, 256");
+    return nullptr;
+  }
+  if (degree < 1 || degree > kMaxDegree) {
+    PyErr_Format(PyExc_ValueError, "degree must be in [1, %d]", kMaxDegree);
+    return nullptr;
+  }
+  if (is_montgomery && (r_obj == nullptr || rinv_obj == nullptr)) {
+    PyErr_SetString(PyExc_ValueError,
+                    "Montgomery storage requires r_mod_p and rinv_mod_p");
+    return nullptr;
+  }
+  PyObject* modulus = PyNumber_Index(modulus_obj);
+  if (modulus == nullptr) {
+    return nullptr;
+  }
+  PyObject* non_residue = nullptr;
+  if (degree > 1) {
+    non_residue = PyNumber_Index(non_residue_obj);
+    if (non_residue == nullptr) {
+      Py_DECREF(modulus);
+      return nullptr;
+    }
+  }
+  PyObject* r = nullptr;
+  PyObject* rinv = nullptr;
+  if (is_montgomery) {
+    r = PyNumber_Index(r_obj);
+    rinv = (r == nullptr) ? nullptr : PyNumber_Index(rinv_obj);
+    if (r == nullptr || rinv == nullptr) {
+      Py_DECREF(modulus);
+      Py_XDECREF(non_residue);
+      Py_XDECREF(r);
+      return nullptr;
+    }
+  }
+  PyArray_Descr* d = MakeDescr(modulus, non_residue, degree,
+                               base_width_bits / 8, is_montgomery, r, rinv);
+  Py_DECREF(modulus);
+  Py_XDECREF(non_residue);
+  Py_XDECREF(r);
+  Py_XDECREF(rinv);
+  return reinterpret_cast<PyObject*>(d);
+}
+
+PyObject* MakeBinaryFieldDescrPy(PyObject* /*self*/, PyObject* args) {
+  int tower_level;
+  if (!PyArg_ParseTuple(args, "i", &tower_level)) {
+    return nullptr;
+  }
+  if (tower_level < 0 || tower_level > 12) {
+    PyErr_SetString(PyExc_ValueError, "tower_level must be in [0, 12]");
+    return nullptr;
+  }
+  int m = 1 << tower_level;             // field bit width 2^level
+  int width_bytes = m < 8 ? 1 : m / 8;  // small levels occupy one byte
+  return reinterpret_cast<PyObject*>(MakeBinaryDescr(tower_level, width_bytes));
+}
+
+PyMethodDef kModuleMethods[] = {
+    {"field_descr", MakeFieldDescrPy, METH_VARARGS,
+     "field_descr(modulus, degree, non_residue, base_width_bits, is_montgomery"
+     "[, r_mod_p, rinv_mod_p]) -> dtype\n\n"
+     "Build a parametric field descriptor (prime or binomial extension)."},
+    {"binary_field_descr", MakeBinaryFieldDescrPy, METH_VARARGS,
+     "binary_field_descr(tower_level) -> dtype\n\n"
+     "Build a parametric binary tower field GF(2^(2^level)) descriptor."},
+    {nullptr, nullptr, 0, nullptr},
+};
+
+// --- arithmetic ufunc loops (host eager add / sub / mul) -----------------
+
+enum class Op { kAdd, kSub, kMul };
+
+NPY_CASTING ArithResolve(struct PyArrayMethodObject_tag* /*method*/,
+                         PyArray_DTypeMeta* const* /*dtypes*/,
+                         PyArray_Descr* const* given, PyArray_Descr** loop,
+                         npy_intp* view_offset) {
+  if (!SameField(AsField(given[0]), AsField(given[1]))) {
+    PyErr_SetString(PyExc_TypeError,
+                    "field operation requires identical fields");
+    return static_cast<NPY_CASTING>(-1);
+  }
+  Py_INCREF(given[0]);
+  loop[0] = given[0];
+  Py_INCREF(given[1]);
+  loop[1] = given[1];
+  PyArray_Descr* out = given[2] == nullptr ? given[0] : given[2];
+  Py_INCREF(out);
+  loop[2] = out;
+  *view_offset = NPY_MIN_INTP;
+  return NPY_NO_CASTING;
+}
+
+// Computes out[] = a[] op b[] in the field (canonical coefficients in/out).
+// For mul, multiplies the degree-(k-1) polynomials and reduces X^k = nr.
+int ComputeFieldOp(FieldDescr* d, Op op, PyObject* const* a, PyObject* const* b,
+                   PyObject** out) {
+  const int k = d->degree;
+  if (op != Op::kMul) {
+    for (int i = 0; i < k; ++i) {
+      PyObject* r = op == Op::kAdd ? PyNumber_Add(a[i], b[i])
+                                   : PyNumber_Subtract(a[i], b[i]);
+      if (r == nullptr) {
+        for (int j = 0; j < i; ++j) Py_DECREF(out[j]);
+        return -1;
+      }
+      out[i] = PyNumber_Remainder(r, d->modulus);
+      Py_DECREF(r);
+      if (out[i] == nullptr) {
+        for (int j = 0; j < i; ++j) Py_DECREF(out[j]);
+        return -1;
+      }
+    }
+    return 0;
+  }
+  // Polynomial product, then fold X^k = non_residue.
+  PyObject* prod[2 * kMaxDegree] = {nullptr};
+  int rc = -1;
+  for (int i = 0; i < 2 * k - 1; ++i) {
+    prod[i] = PyLong_FromLong(0);
+    if (prod[i] == nullptr) goto cleanup;
+  }
+  for (int i = 0; i < k; ++i) {
+    for (int j = 0; j < k; ++j) {
+      PyObject* term = PyNumber_Multiply(a[i], b[j]);
+      if (term == nullptr) goto cleanup;
+      PyObject* sum = PyNumber_Add(prod[i + j], term);
+      Py_DECREF(term);
+      if (sum == nullptr) goto cleanup;
+      Py_SETREF(prod[i + j], sum);
+    }
+  }
+  for (int i = 2 * k - 2; i >= k; --i) {
+    PyObject* scaled = PyNumber_Multiply(d->non_residue, prod[i]);
+    if (scaled == nullptr) goto cleanup;
+    PyObject* sum = PyNumber_Add(prod[i - k], scaled);
+    Py_DECREF(scaled);
+    if (sum == nullptr) goto cleanup;
+    Py_SETREF(prod[i - k], sum);
+  }
+  for (int i = 0; i < k; ++i) {
+    out[i] = PyNumber_Remainder(prod[i], d->modulus);
+    if (out[i] == nullptr) {
+      for (int j = 0; j < i; ++j) Py_DECREF(out[j]);
+      goto cleanup;
+    }
+  }
+  rc = 0;
+cleanup:
+  for (int i = 0; i < 2 * k - 1; ++i) {
+    Py_XDECREF(prod[i]);
+  }
+  return rc;
+}
+
+template <Op op>
+int ArithLoop(PyArrayMethod_Context* context, char* const* data,
+              const npy_intp* dimensions, const npy_intp* strides,
+              NpyAuxData* /*aux*/) {
+  FieldDescr* d = AsField(context->descriptors[0]);
+  npy_intp n = dimensions[0];
+  char* a = data[0];
+  char* b = data[1];
+  char* o = data[2];
+  if (d->kind == kBinaryTower) {
+    const int wb = d->base_width_bytes;
+    for (npy_intp i = 0; i < n; ++i) {
+      if (op != Op::kMul) {  // characteristic 2: add == sub == XOR
+        for (int k = 0; k < wb; ++k) o[k] = static_cast<char>(a[k] ^ b[k]);
+      } else {
+        PyObject* av = _PyLong_FromByteArray(
+            reinterpret_cast<unsigned char*>(a), wb, 1, 0);
+        PyObject* bv = _PyLong_FromByteArray(
+            reinterpret_cast<unsigned char*>(b), wb, 1, 0);
+        if (!av || !bv) {
+          Py_XDECREF(av);
+          Py_XDECREF(bv);
+          return -1;
+        }
+        PyObject* rv = TowerMul(d->tower_level, av, bv);
+        Py_DECREF(av);
+        Py_DECREF(bv);
+        if (!rv) return -1;
+        int rc =
+            _PyLong_AsByteArray(reinterpret_cast<PyLongObject*>(rv),
+                                reinterpret_cast<unsigned char*>(o), wb, 1, 0);
+        Py_DECREF(rv);
+        if (rc < 0) return -1;
+      }
+      a += strides[0];
+      b += strides[1];
+      o += strides[2];
+    }
+    return 0;
+  }
+  for (npy_intp i = 0; i < n; ++i) {
+    PyObject* av[kMaxDegree];
+    PyObject* bv[kMaxDegree];
+    PyObject* ov[kMaxDegree];
+    if (DecodeElement(d, a, av) < 0) {
+      return -1;
+    }
+    if (DecodeElement(d, b, bv) < 0) {
+      for (int j = 0; j < d->degree; ++j) Py_DECREF(av[j]);
+      return -1;
+    }
+    int rc = ComputeFieldOp(d, op, av, bv, ov);
+    for (int j = 0; j < d->degree; ++j) {
+      Py_DECREF(av[j]);
+      Py_DECREF(bv[j]);
+    }
+    if (rc < 0) {
+      return -1;
+    }
+    int erc = EncodeElement(d, o, ov);
+    for (int j = 0; j < d->degree; ++j) Py_DECREF(ov[j]);
+    if (erc < 0) {
+      return -1;
+    }
+    a += strides[0];
+    b += strides[1];
+    o += strides[2];
+  }
+  return 0;
+}
+
+template <Op op>
+bool AddArithLoop(PyObject* numpy, const char* ufunc_name) {
+  PyObject* ufunc = PyObject_GetAttrString(numpy, ufunc_name);
+  if (ufunc == nullptr) {
+    return false;
+  }
+  PyArray_DTypeMeta* dtypes[3] = {&FieldDType, &FieldDType, &FieldDType};
+  PyType_Slot slots[] = {
+      {NPY_METH_resolve_descriptors, reinterpret_cast<void*>(ArithResolve)},
+      {NPY_METH_strided_loop, reinterpret_cast<void*>(ArithLoop<op>)},
+      {0, nullptr},
+  };
+  PyArrayMethod_Spec spec = {};
+  spec.name = "field_arith";
+  spec.nin = 2;
+  spec.nout = 1;
+  spec.casting = NPY_NO_CASTING;
+  spec.flags = NPY_METH_REQUIRES_PYAPI;
+  spec.dtypes = dtypes;
+  spec.slots = slots;
+  int rc = PyUFunc_AddLoopFromSpec(ufunc, &spec);
+  Py_DECREF(ufunc);
+  return rc >= 0;
+}
+
+}  // namespace
+
+bool RegisterFieldDType(PyObject* /*numpy*/, PyObject* module) {
+  FieldScalar_Type.tp_name = "zk_dtypes._zk_dtypes_ext.FieldScalar";
+  FieldScalar_Type.tp_basicsize = 0;
+  FieldScalar_Type.tp_flags = Py_TPFLAGS_DEFAULT;
+  FieldScalar_Type.tp_base = &PyGenericArrType_Type;
+  if (PyType_Ready(&FieldScalar_Type) < 0) {
+    return false;
+  }
+
+  PyTypeObject* type = reinterpret_cast<PyTypeObject*>(&FieldDType);
+  Py_SET_TYPE(reinterpret_cast<PyObject*>(&FieldDType), &PyArrayDTypeMeta_Type);
+  Py_SET_REFCNT(reinterpret_cast<PyObject*>(&FieldDType), 1);
+  type->tp_name = "zk_dtypes._zk_dtypes_ext.FieldDType";
+  type->tp_basicsize = sizeof(FieldDescr);
+  type->tp_flags = Py_TPFLAGS_DEFAULT;
+  type->tp_base = &PyArrayDescr_Type;
+  type->tp_dealloc = Descr_dealloc;
+  type->tp_repr = Descr_repr;
+  type->tp_str = Descr_repr;
+  type->tp_new = DType_new;
+  if (PyType_Ready(type) < 0) {
+    return false;
+  }
+
+  PyArray_DTypeMeta* cast_dtypes[2] = {nullptr, nullptr};
+  PyType_Slot cast_slots[] = {
+      {NPY_METH_resolve_descriptors, reinterpret_cast<void*>(CastResolve)},
+      {NPY_METH_strided_loop, reinterpret_cast<void*>(CastLoop)},
+      {NPY_METH_unaligned_strided_loop, reinterpret_cast<void*>(CastLoop)},
+      {0, nullptr},
+  };
+  PyArrayMethod_Spec copy_cast = {};
+  copy_cast.name = "field_copy";
+  copy_cast.nin = 1;
+  copy_cast.nout = 1;
+  copy_cast.casting = NPY_UNSAFE_CASTING;
+  copy_cast.flags = NPY_METH_SUPPORTS_UNALIGNED;
+  copy_cast.dtypes = cast_dtypes;
+  copy_cast.slots = cast_slots;
+  PyArrayMethod_Spec* casts[] = {&copy_cast, nullptr};
+
+  PyType_Slot dtype_slots[] = {
+      {NPY_DT_default_descr, reinterpret_cast<void*>(DefaultDescr)},
+      {NPY_DT_common_dtype, reinterpret_cast<void*>(CommonDType)},
+      {NPY_DT_common_instance, reinterpret_cast<void*>(CommonInstance)},
+      {NPY_DT_ensure_canonical, reinterpret_cast<void*>(EnsureCanonical)},
+      {NPY_DT_discover_descr_from_pyobject,
+       reinterpret_cast<void*>(DiscoverDescrFromPyobject)},
+      {NPY_DT_setitem, reinterpret_cast<void*>(SetItem)},
+      {NPY_DT_getitem, reinterpret_cast<void*>(GetItem)},
+      {0, nullptr},
+  };
+
+  PyArrayDTypeMeta_Spec spec = {};
+  spec.typeobj = &FieldScalar_Type;
+  spec.flags = NPY_DT_PARAMETRIC;
+  spec.casts = casts;
+  spec.slots = dtype_slots;
+  spec.baseclass = nullptr;
+  if (PyArrayInitDTypeMeta_FromSpec(&FieldDType, &spec) < 0) {
+    return false;
+  }
+  FieldDType.singleton = PyArray_GetDefaultDescr(&FieldDType);
+  if (FieldDType.singleton == nullptr) {
+    return false;
+  }
+
+  if (PyModule_AddObject(module, "FieldDType",
+                         reinterpret_cast<PyObject*>(&FieldDType)) < 0) {
+    return false;
+  }
+  Py_INCREF(reinterpret_cast<PyObject*>(&FieldDType));
+
+  PyObject* fn = PyCFunction_New(&kModuleMethods[0], nullptr);
+  if (fn == nullptr) {
+    return false;
+  }
+  if (PyModule_AddObject(module, "field_descr", fn) < 0) {
+    Py_DECREF(fn);
+    return false;
+  }
+  PyObject* bfn = PyCFunction_New(&kModuleMethods[1], nullptr);
+  if (bfn == nullptr) {
+    return false;
+  }
+  if (PyModule_AddObject(module, "binary_field_descr", bfn) < 0) {
+    Py_DECREF(bfn);
+    return false;
+  }
+
+  if (_import_umath() < 0) {
+    return false;
+  }
+  PyObject* numpy = PyImport_ImportModule("numpy");
+  if (numpy == nullptr) {
+    return false;
+  }
+  bool ok = AddArithLoop<Op::kAdd>(numpy, "add") &&
+            AddArithLoop<Op::kSub>(numpy, "subtract") &&
+            AddArithLoop<Op::kMul>(numpy, "multiply");
+  Py_DECREF(numpy);
+  return ok;
+}
+
+}  // namespace zk_dtypes

--- a/zk_dtypes/_src/field_dtype.cc
+++ b/zk_dtypes/_src/field_dtype.cc
@@ -816,7 +816,24 @@ void TypedAddSub(char* a, char* b, char* o, npy_intp n, const npy_intp* strides,
     const T* ap = reinterpret_cast<const T*>(a);
     const T* bp = reinterpret_cast<const T*>(b);
     T* op = reinterpret_cast<T*>(o);
-    for (npy_intp i = 0; i < m; ++i) {
+    if (spare) {
+      // a, b < p < 2^(w-1), so a+b does not overflow: the conditional reduce is
+      // a branchless min(x, x-+p), which auto-vectorizes (legacy gets the same
+      // from its compile-time modulus). Byte-identical to ModAdd/ModSub.
+      for (npy_intp i = 0; i < m; ++i) {
+        if (kSub) {
+          T d = ap[i] - bp[i];
+          T dp = d + modulus;
+          op[i] = dp < d ? dp : d;
+        } else {
+          T s = ap[i] + bp[i];
+          T sm = s - modulus;
+          op[i] = sm < s ? sm : s;
+        }
+      }
+      return;
+    }
+    for (npy_intp i = 0; i < m; ++i) {  // no spare bit: carry-aware reduce
       if (kSub) {
         ModSub<T>(ap[i], bp[i], op[i], modulus, spare);
       } else {

--- a/zk_dtypes/_src/field_dtype.cc
+++ b/zk_dtypes/_src/field_dtype.cc
@@ -69,10 +69,11 @@ struct FieldDescr {
   // Binary-tower parameters (kOddField leaves value_mask NULL):
   PyObject* value_mask;  // owned (binary): 2^(2^level) - 1
   uint8_t kind;
-  uint8_t
-      base_width_bytes;  // odd: per-coefficient width; binary: storage width
-  uint8_t degree;        // odd: extension degree (1 = prime); binary: 1
-  uint8_t tower_level;   // binary tower level
+  // odd: per-coefficient width; binary: storage width. uint16 so a high binary
+  // tower (level 11/12 -> 256/512 bytes) does not truncate to 0.
+  uint16_t base_width_bytes;
+  uint8_t degree;       // odd: extension degree (1 = prime); binary: 1
+  uint8_t tower_level;  // binary tower level
   uint8_t is_montgomery;
 };
 
@@ -282,7 +283,7 @@ PyArray_Descr* MakeDescr(PyObject* modulus, PyObject* non_residue, int degree,
   d->rinv_mod_p = rinv;
   d->value_mask = nullptr;
   d->kind = kOddField;
-  d->base_width_bytes = static_cast<uint8_t>(base_width_bytes);
+  d->base_width_bytes = static_cast<uint16_t>(base_width_bytes);
   d->degree = static_cast<uint8_t>(degree);
   d->tower_level = 0;
   d->is_montgomery = static_cast<uint8_t>(is_montgomery ? 1 : 0);
@@ -315,7 +316,7 @@ PyArray_Descr* MakeBinaryDescr(int tower_level, int width_bytes) {
   d->r_mod_p = nullptr;
   d->rinv_mod_p = nullptr;
   d->kind = kBinaryTower;
-  d->base_width_bytes = static_cast<uint8_t>(width_bytes);
+  d->base_width_bytes = static_cast<uint16_t>(width_bytes);
   d->degree = 1;
   d->tower_level = static_cast<uint8_t>(tower_level);
   d->is_montgomery = 0;
@@ -528,14 +529,38 @@ PyObject* GetItem(PyArray_Descr* descr, char* dataptr) {
 
 // --- within-DType copy cast (numpy requires at least a self-copy) --------
 
+// Same odd field except for the storage form (Montgomery vs canonical) — the
+// only non-identity cast we re-encode. Anything else (different modulus/degree/
+// width, binary level, or kind) is a meaningless cast and is rejected rather
+// than raw-copied (which would corrupt values and, across widths, write out of
+// bounds).
+bool CastCompatible(FieldDescr* a, FieldDescr* b) {
+  if (a->kind != kOddField || b->kind != kOddField) return false;
+  if (a->base_width_bytes != b->base_width_bytes || a->degree != b->degree) {
+    return false;
+  }
+  if (PyObject_RichCompareBool(a->modulus, b->modulus, Py_EQ) != 1)
+    return false;
+  if (a->degree > 1) {
+    return PyObject_RichCompareBool(a->non_residue, b->non_residue, Py_EQ) == 1;
+  }
+  return true;
+}
+
 NPY_CASTING CastResolve(struct PyArrayMethodObject_tag* /*method*/,
                         PyArray_DTypeMeta* const* /*dtypes*/,
                         PyArray_Descr* const* given, PyArray_Descr** loop,
                         npy_intp* view_offset) {
   PyArray_Descr* from = given[0];
+  PyArray_Descr* to = given[1];
+  if (to != nullptr && !SameField(AsField(from), AsField(to)) &&
+      !CastCompatible(AsField(from), AsField(to))) {
+    PyErr_SetString(PyExc_TypeError,
+                    "cannot cast between different parametric fields");
+    return static_cast<NPY_CASTING>(-1);
+  }
   Py_INCREF(from);
   loop[0] = from;
-  PyArray_Descr* to = given[1];
   if (to == nullptr) {
     Py_INCREF(from);
     loop[1] = from;
@@ -548,18 +573,33 @@ NPY_CASTING CastResolve(struct PyArrayMethodObject_tag* /*method*/,
     *view_offset = 0;
     return NPY_NO_CASTING;
   }
-  return NPY_UNSAFE_CASTING;
+  return NPY_UNSAFE_CASTING;  // same field, Montgomery <-> canonical re-encode
 }
 
 int CastLoop(PyArrayMethod_Context* context, char* const* data,
              const npy_intp* dimensions, const npy_intp* strides,
              NpyAuxData* /*aux*/) {
+  FieldDescr* from = AsField(context->descriptors[0]);
+  FieldDescr* to = AsField(context->descriptors[1]);
   npy_intp n = dimensions[0];
   char* in = data[0];
   char* out = data[1];
-  npy_intp elsize = context->descriptors[0]->elsize;
+  if (SameField(from, to)) {  // byte-identical: raw copy
+    npy_intp elsize = context->descriptors[0]->elsize;
+    for (npy_intp i = 0; i < n; ++i) {
+      std::memcpy(out, in, elsize);
+      in += strides[0];
+      out += strides[1];
+    }
+    return 0;
+  }
+  // Montgomery <-> canonical of the same field: decode then re-encode.
   for (npy_intp i = 0; i < n; ++i) {
-    std::memcpy(out, in, elsize);
+    PyObject* coeffs[kMaxDegree];
+    if (DecodeElement(from, in, coeffs) < 0) return -1;
+    int rc = EncodeElement(to, out, coeffs);
+    for (int j = 0; j < from->degree; ++j) Py_DECREF(coeffs[j]);
+    if (rc < 0) return -1;
     in += strides[0];
     out += strides[1];
   }

--- a/zk_dtypes/_src/field_dtype.cc
+++ b/zk_dtypes/_src/field_dtype.cc
@@ -751,6 +751,30 @@ inline void Advance(char*& a, char*& b, char*& o, const npy_intp* strides) {
   o += strides[2];
 }
 
+// Monomorphic strided modular add/sub over `degree` coefficients of a
+// single-word field (T = uint32_t / uint64_t). Type-specialized and free of the
+// per-element width switch, so the contiguous case auto-vectorizes — this is
+// the small-field add/sub hot path (degree 1 for a prime, k for an extension).
+template <typename T, bool kSub>
+void IntAddSubLoop(char* a, char* b, char* o, npy_intp n,
+                   const npy_intp* strides, int degree, int wb, T modulus,
+                   bool spare) {
+  for (npy_intp i = 0; i < n; ++i) {
+    for (int c = 0; c < degree; ++c) {
+      T x, y, r;
+      std::memcpy(&x, a + c * wb, sizeof(T));
+      std::memcpy(&y, b + c * wb, sizeof(T));
+      if (kSub) {
+        ModSub<T>(x, y, r, modulus, spare);
+      } else {
+        ModAdd<T>(x, y, r, modulus, spare);
+      }
+      std::memcpy(o + c * wb, &r, sizeof(T));
+    }
+    Advance(a, b, o, strides);
+  }
+}
+
 template <Op op>
 int ArithLoop(PyArrayMethod_Context* context, char* const* data,
               const npy_intp* dimensions, const npy_intp* strides,
@@ -810,35 +834,41 @@ int ArithLoop(PyArrayMethod_Context* context, char* const* data,
                           wb, 1, 0) >= 0) {
     modarith::PrimeField pf =
         modarith::PrimeField::Make(mod_le, wb, d->is_montgomery);
-    if (d->degree == 1 && pf.native) {
-      for (npy_intp i = 0; i < n; ++i) {
-        const auto* ua = reinterpret_cast<const unsigned char*>(a);
-        const auto* ub = reinterpret_cast<const unsigned char*>(b);
-        auto* uo = reinterpret_cast<unsigned char*>(o);
-        if (op == Op::kAdd) {
-          pf.Add(ua, ub, uo);
-        } else if (op == Op::kSub) {
-          pf.Sub(ua, ub, uo);
-        } else {
-          pf.Mul(ua, ub, uo);
-        }
-        Advance(a, b, o, strides);
-      }
-      return 0;
-    }
     const int k = d->degree;
-    if (k > 1 && op != Op::kMul && pf.native) {  // extension add/sub: linear
+    // Add/sub: a monomorphic typed loop at single-word widths
+    // (auto-vectorizes), BigInt per-element at 128/256-bit. Prime (k == 1) and
+    // extension share it.
+    if (op != Op::kMul && pf.native) {
+      if (wb == 4) {
+        IntAddSubLoop<uint32_t, op == Op::kSub>(a, b, o, n, strides, k, wb,
+                                                pf.p32, pf.spare);
+        return 0;
+      }
+      if (wb == 8) {
+        IntAddSubLoop<uint64_t, op == Op::kSub>(a, b, o, n, strides, k, wb,
+                                                pf.p64, pf.spare);
+        return 0;
+      }
       for (npy_intp i = 0; i < n; ++i) {
         for (int c = 0; c < k; ++c) {
           const auto* ua = reinterpret_cast<const unsigned char*>(a) + c * wb;
           const auto* ub = reinterpret_cast<const unsigned char*>(b) + c * wb;
           auto* uo = reinterpret_cast<unsigned char*>(o) + c * wb;
-          if (op == Op::kAdd) {
-            pf.Add(ua, ub, uo);
-          } else {
+          if (op == Op::kSub) {
             pf.Sub(ua, ub, uo);
+          } else {
+            pf.Add(ua, ub, uo);
           }
         }
+        Advance(a, b, o, strides);
+      }
+      return 0;
+    }
+    if (k == 1 && pf.native) {  // prime multiply
+      for (npy_intp i = 0; i < n; ++i) {
+        pf.Mul(reinterpret_cast<const unsigned char*>(a),
+               reinterpret_cast<const unsigned char*>(b),
+               reinterpret_cast<unsigned char*>(o));
         Advance(a, b, o, strides);
       }
       return 0;

--- a/zk_dtypes/_src/field_dtype.cc
+++ b/zk_dtypes/_src/field_dtype.cc
@@ -879,6 +879,41 @@ void TypedMul(char* a, char* b, char* o, npy_intp n, const npy_intp* strides,
   }
 }
 
+// Native binomial-extension (degree k) multiply over a single-word base field
+// (T = uint32_t / uint64_t), in Montgomery space: coefficient products via
+// MontMul<T>, the X^k = non_residue fold via a canonical scalar multiply, all
+// typed (no per-coefficient width switch). nr is the canonical non-residue;
+// mont_nprime is the single-word +p^-1. Byte-identical to the byte EF-mul path.
+template <typename T>
+void EfMulTyped(char* a, char* b, char* o, npy_intp n, const npy_intp* strides,
+                int k, int wb, T modulus, T mont_nprime, bool spare, T nr) {
+  for (npy_intp i = 0; i < n; ++i) {
+    T av[kMaxDegree], bv[kMaxDegree], prod[2 * kMaxDegree];
+    for (int c = 0; c < 2 * k - 1; ++c) prod[c] = 0;
+    for (int c = 0; c < k; ++c) {
+      std::memcpy(&av[c], a + c * wb, sizeof(T));
+      std::memcpy(&bv[c], b + c * wb, sizeof(T));
+    }
+    for (int ii = 0; ii < k; ++ii) {
+      for (int jj = 0; jj < k; ++jj) {
+        T t, s;
+        MontMul<T>(av[ii], bv[jj], t, modulus, mont_nprime);
+        ModAdd<T>(prod[ii + jj], t, s, modulus, spare);
+        prod[ii + jj] = s;
+      }
+    }
+    for (int ii = 2 * k - 2; ii >= k; --ii) {  // fold X^k = non_residue
+      T sc = static_cast<T>(
+          (static_cast<internal::make_promoted_t<T>>(nr) * prod[ii]) % modulus);
+      T s;
+      ModAdd<T>(prod[ii - k], sc, s, modulus, spare);
+      prod[ii - k] = s;
+    }
+    for (int c = 0; c < k; ++c) std::memcpy(o + c * wb, &prod[c], sizeof(T));
+    Advance(a, b, o, strides);
+  }
+}
+
 template <Op op>
 int ArithLoop(PyArrayMethod_Context* context, char* const* data,
               const npy_intp* dimensions, const npy_intp* strides,
@@ -1002,39 +1037,27 @@ int ArithLoop(PyArrayMethod_Context* context, char* const* data,
       return 0;
     }
     if (k > 1 && op == Op::kMul && pf.ext_native) {  // binomial polynomial mul
-      // ext_native is set only for a base width of 4 or 8 (PrimeField::Make),
-      // so the 8-byte coefficient buffers (nr_le/prod/term/scaled) below always
-      // hold a full coefficient.
-      unsigned char nr_le[8] = {0};
-      if (_PyLong_AsByteArray(reinterpret_cast<PyLongObject*>(d->non_residue),
-                              nr_le, wb, 1, 0) >= 0) {
-        for (npy_intp i = 0; i < n; ++i) {
-          // Coefficients stay in their storage form; the product/accumulate
-          // (montmul/modadd) and the X^k = non_residue fold preserve it, so the
-          // output is byte-identical to the decode/compute/encode path. Only
-          // the 2k-1 product rows that get touched need zeroing.
-          unsigned char prod[2 * kMaxDegree][8];
-          std::memset(prod, 0, sizeof(prod[0]) * (2 * k - 1));
-          for (int ii = 0; ii < k; ++ii) {
-            for (int jj = 0; jj < k; ++jj) {
-              unsigned char term[8];
-              pf.Mul(reinterpret_cast<const unsigned char*>(a) + ii * wb,
-                     reinterpret_cast<const unsigned char*>(b) + jj * wb, term);
-              pf.Add(prod[ii + jj], term, prod[ii + jj]);
-            }
-          }
-          for (int ii = 2 * k - 2; ii >= k; --ii) {
-            unsigned char scaled[8];
-            pf.CanonMulBytes(nr_le, prod[ii], scaled);
-            pf.Add(prod[ii - k], scaled, prod[ii - k]);
-          }
-          for (int c = 0; c < k; ++c) {
-            std::memcpy(reinterpret_cast<unsigned char*>(o) + c * wb, prod[c],
-                        wb);
-          }
-          Advance(a, b, o, strides);
+      // ext_native ⟹ base width 4 or 8 (PrimeField::Make); dispatch the typed
+      // Montgomery-space schoolbook (coefficients stay in storage form, so the
+      // result is byte-identical to the decode/compute/encode path).
+      if (wb == 4) {
+        uint32_t nr = 0;
+        if (_PyLong_AsByteArray(reinterpret_cast<PyLongObject*>(d->non_residue),
+                                reinterpret_cast<unsigned char*>(&nr), 4, 1,
+                                0) >= 0) {
+          EfMulTyped<uint32_t>(a, b, o, n, strides, k, wb, pf.p32,
+                               static_cast<uint32_t>(pf.inv), pf.spare, nr);
+          return 0;
         }
-        return 0;
+      } else {  // wb == 8
+        uint64_t nr = 0;
+        if (_PyLong_AsByteArray(reinterpret_cast<PyLongObject*>(d->non_residue),
+                                reinterpret_cast<unsigned char*>(&nr), 8, 1,
+                                0) >= 0) {
+          EfMulTyped<uint64_t>(a, b, o, n, strides, k, wb, pf.p64, pf.inv,
+                               pf.spare, nr);
+          return 0;
+        }
       }
       PyErr_Clear();
     }

--- a/zk_dtypes/_src/field_dtype.cc
+++ b/zk_dtypes/_src/field_dtype.cc
@@ -907,7 +907,7 @@ int ArithLoop(PyArrayMethod_Context* context, char* const* data,
     }
     if (d->tower_level <= 7) {  // native recursive Karatsuba tower multiply
       for (npy_intp i = 0; i < n; ++i) {
-        modarith::BinaryTowerMul(d->tower_level, wb,
+        modarith::BinaryTowerMul(d->tower_level,
                                  reinterpret_cast<const unsigned char*>(a),
                                  reinterpret_cast<const unsigned char*>(b),
                                  reinterpret_cast<unsigned char*>(o));
@@ -1002,14 +1002,19 @@ int ArithLoop(PyArrayMethod_Context* context, char* const* data,
       return 0;
     }
     if (k > 1 && op == Op::kMul && pf.ext_native) {  // binomial polynomial mul
+      // ext_native is set only for a base width of 4 or 8 (PrimeField::Make),
+      // so the 8-byte coefficient buffers (nr_le/prod/term/scaled) below always
+      // hold a full coefficient.
       unsigned char nr_le[8] = {0};
       if (_PyLong_AsByteArray(reinterpret_cast<PyLongObject*>(d->non_residue),
                               nr_le, wb, 1, 0) >= 0) {
         for (npy_intp i = 0; i < n; ++i) {
           // Coefficients stay in their storage form; the product/accumulate
           // (montmul/modadd) and the X^k = non_residue fold preserve it, so the
-          // output is byte-identical to the decode/compute/encode path.
-          unsigned char prod[2 * kMaxDegree][8] = {{0}};
+          // output is byte-identical to the decode/compute/encode path. Only
+          // the 2k-1 product rows that get touched need zeroing.
+          unsigned char prod[2 * kMaxDegree][8];
+          std::memset(prod, 0, sizeof(prod[0]) * (2 * k - 1));
           for (int ii = 0; ii < k; ++ii) {
             for (int jj = 0; jj < k; ++jj) {
               unsigned char term[8];

--- a/zk_dtypes/_src/field_dtype.cc
+++ b/zk_dtypes/_src/field_dtype.cc
@@ -37,6 +37,7 @@ limitations under the License.
 #include <cstdint>
 #include <cstring>
 
+#include "zk_dtypes/_src/field_modarith.h"
 #include "zk_dtypes/_src/numpy.h"
 #include "numpy/dtype_api.h"
 #include "numpy/ndarraytypes.h"
@@ -743,6 +744,13 @@ cleanup:
   return rc;
 }
 
+// Advances the three element cursors by their strides.
+inline void Advance(char*& a, char*& b, char*& o, const npy_intp* strides) {
+  a += strides[0];
+  b += strides[1];
+  o += strides[2];
+}
+
 template <Op op>
 int ArithLoop(PyArrayMethod_Context* context, char* const* data,
               const npy_intp* dimensions, const npy_intp* strides,
@@ -752,38 +760,126 @@ int ArithLoop(PyArrayMethod_Context* context, char* const* data,
   char* a = data[0];
   char* b = data[1];
   char* o = data[2];
+  const int wb = d->base_width_bytes;
+
   if (d->kind == kBinaryTower) {
-    const int wb = d->base_width_bytes;
-    for (npy_intp i = 0; i < n; ++i) {
-      if (op != Op::kMul) {  // characteristic 2: add == sub == XOR
+    if (op != Op::kMul) {  // characteristic 2: add == sub == XOR
+      for (npy_intp i = 0; i < n; ++i) {
         for (int k = 0; k < wb; ++k) o[k] = static_cast<char>(a[k] ^ b[k]);
-      } else {
-        PyObject* av = _PyLong_FromByteArray(
-            reinterpret_cast<unsigned char*>(a), wb, 1, 0);
-        PyObject* bv = _PyLong_FromByteArray(
-            reinterpret_cast<unsigned char*>(b), wb, 1, 0);
-        if (!av || !bv) {
-          Py_XDECREF(av);
-          Py_XDECREF(bv);
-          return -1;
-        }
-        PyObject* rv = TowerMul(d->tower_level, av, bv);
-        Py_DECREF(av);
-        Py_DECREF(bv);
-        if (!rv) return -1;
-        int rc =
-            _PyLong_AsByteArray(reinterpret_cast<PyLongObject*>(rv),
-                                reinterpret_cast<unsigned char*>(o), wb, 1, 0);
-        Py_DECREF(rv);
-        if (rc < 0) return -1;
+        Advance(a, b, o, strides);
       }
-      a += strides[0];
-      b += strides[1];
-      o += strides[2];
+      return 0;
+    }
+    if (d->tower_level <= 7) {  // native recursive Karatsuba tower multiply
+      for (npy_intp i = 0; i < n; ++i) {
+        modarith::BinaryTowerMul(d->tower_level, wb,
+                                 reinterpret_cast<const unsigned char*>(a),
+                                 reinterpret_cast<const unsigned char*>(b),
+                                 reinterpret_cast<unsigned char*>(o));
+        Advance(a, b, o, strides);
+      }
+      return 0;
+    }
+    for (npy_intp i = 0; i < n; ++i) {  // wide tower: Python-int Karatsuba
+      PyObject* av =
+          _PyLong_FromByteArray(reinterpret_cast<unsigned char*>(a), wb, 1, 0);
+      PyObject* bv =
+          _PyLong_FromByteArray(reinterpret_cast<unsigned char*>(b), wb, 1, 0);
+      if (!av || !bv) {
+        Py_XDECREF(av);
+        Py_XDECREF(bv);
+        return -1;
+      }
+      PyObject* rv = TowerMul(d->tower_level, av, bv);
+      Py_DECREF(av);
+      Py_DECREF(bv);
+      if (!rv) return -1;
+      int rc =
+          _PyLong_AsByteArray(reinterpret_cast<PyLongObject*>(rv),
+                              reinterpret_cast<unsigned char*>(o), wb, 1, 0);
+      Py_DECREF(rv);
+      if (rc < 0) return -1;
+      Advance(a, b, o, strides);
     }
     return 0;
   }
-  for (npy_intp i = 0; i < n; ++i) {
+
+  // Odd field: native fixed-width path where supported, Python-int otherwise.
+  unsigned char mod_le[32];
+  if (_PyLong_AsByteArray(reinterpret_cast<PyLongObject*>(d->modulus), mod_le,
+                          wb, 1, 0) >= 0) {
+    modarith::PrimeField pf =
+        modarith::PrimeField::Make(mod_le, wb, d->is_montgomery);
+    if (d->degree == 1 && pf.native) {
+      for (npy_intp i = 0; i < n; ++i) {
+        const auto* ua = reinterpret_cast<const unsigned char*>(a);
+        const auto* ub = reinterpret_cast<const unsigned char*>(b);
+        auto* uo = reinterpret_cast<unsigned char*>(o);
+        if (op == Op::kAdd) {
+          pf.Add(ua, ub, uo);
+        } else if (op == Op::kSub) {
+          pf.Sub(ua, ub, uo);
+        } else {
+          pf.Mul(ua, ub, uo);
+        }
+        Advance(a, b, o, strides);
+      }
+      return 0;
+    }
+    const int k = d->degree;
+    if (k > 1 && op != Op::kMul && pf.native) {  // extension add/sub: linear
+      for (npy_intp i = 0; i < n; ++i) {
+        for (int c = 0; c < k; ++c) {
+          const auto* ua = reinterpret_cast<const unsigned char*>(a) + c * wb;
+          const auto* ub = reinterpret_cast<const unsigned char*>(b) + c * wb;
+          auto* uo = reinterpret_cast<unsigned char*>(o) + c * wb;
+          if (op == Op::kAdd) {
+            pf.Add(ua, ub, uo);
+          } else {
+            pf.Sub(ua, ub, uo);
+          }
+        }
+        Advance(a, b, o, strides);
+      }
+      return 0;
+    }
+    if (k > 1 && op == Op::kMul && pf.ext_native) {  // binomial polynomial mul
+      unsigned char nr_le[8] = {0};
+      if (_PyLong_AsByteArray(reinterpret_cast<PyLongObject*>(d->non_residue),
+                              nr_le, wb, 1, 0) >= 0) {
+        for (npy_intp i = 0; i < n; ++i) {
+          // Coefficients stay in their storage form; the product/accumulate
+          // (montmul/modadd) and the X^k = non_residue fold preserve it, so the
+          // output is byte-identical to the decode/compute/encode path.
+          unsigned char prod[2 * kMaxDegree][8] = {{0}};
+          for (int ii = 0; ii < k; ++ii) {
+            for (int jj = 0; jj < k; ++jj) {
+              unsigned char term[8];
+              pf.Mul(reinterpret_cast<const unsigned char*>(a) + ii * wb,
+                     reinterpret_cast<const unsigned char*>(b) + jj * wb, term);
+              pf.Add(prod[ii + jj], term, prod[ii + jj]);
+            }
+          }
+          for (int ii = 2 * k - 2; ii >= k; --ii) {
+            unsigned char scaled[8];
+            pf.CanonMulBytes(nr_le, prod[ii], scaled);
+            pf.Add(prod[ii - k], scaled, prod[ii - k]);
+          }
+          for (int c = 0; c < k; ++c) {
+            std::memcpy(reinterpret_cast<unsigned char*>(o) + c * wb, prod[c],
+                        wb);
+          }
+          Advance(a, b, o, strides);
+        }
+        return 0;
+      }
+      PyErr_Clear();
+    }
+  } else {
+    PyErr_Clear();
+  }
+
+  for (npy_intp i = 0; i < n; ++i) {  // generic Python-int fallback
     PyObject* av[kMaxDegree];
     PyObject* bv[kMaxDegree];
     PyObject* ov[kMaxDegree];
@@ -807,9 +903,7 @@ int ArithLoop(PyArrayMethod_Context* context, char* const* data,
     if (erc < 0) {
       return -1;
     }
-    a += strides[0];
-    b += strides[1];
-    o += strides[2];
+    Advance(a, b, o, strides);
   }
   return 0;
 }

--- a/zk_dtypes/_src/field_dtype.cc
+++ b/zk_dtypes/_src/field_dtype.cc
@@ -751,14 +751,40 @@ inline void Advance(char*& a, char*& b, char*& o, const npy_intp* strides) {
   o += strides[2];
 }
 
-// Monomorphic strided modular add/sub over `degree` coefficients of a
-// single-word field (T = uint32_t / uint64_t). Type-specialized and free of the
-// per-element width switch, so the contiguous case auto-vectorizes — this is
-// the small-field add/sub hot path (degree 1 for a prime, k for an extension).
+// True when all three operands are contiguous (stride == element size) and
+// pointer-aligned to T, so the element bytes can be read as a flat T[] and the
+// inner loop auto-vectorizes the same way the legacy compile-time loops do.
+template <typename T>
+inline bool FlatAligned(char* a, char* b, char* o, const npy_intp* strides,
+                        npy_intp elsize) {
+  return strides[0] == elsize && strides[1] == elsize && strides[2] == elsize &&
+         reinterpret_cast<uintptr_t>(a) % sizeof(T) == 0 &&
+         reinterpret_cast<uintptr_t>(b) % sizeof(T) == 0 &&
+         reinterpret_cast<uintptr_t>(o) % sizeof(T) == 0;
+}
+
+// Monomorphic modular add/sub over `degree` coefficients of a single-word field
+// (T = uint32_t / uint64_t). Free of the per-element width switch; the
+// contiguous case runs as one flat T[] loop (degree folds into the count) so
+// the compiler vectorizes it. Prime (degree 1) and extension share it.
 template <typename T, bool kSub>
-void IntAddSubLoop(char* a, char* b, char* o, npy_intp n,
-                   const npy_intp* strides, int degree, int wb, T modulus,
-                   bool spare) {
+void TypedAddSub(char* a, char* b, char* o, npy_intp n, const npy_intp* strides,
+                 int degree, int wb, T modulus, bool spare) {
+  npy_intp elsize = static_cast<npy_intp>(degree) * wb;
+  if (FlatAligned<T>(a, b, o, strides, elsize)) {
+    npy_intp m = n * degree;  // every coefficient is contiguous
+    const T* ap = reinterpret_cast<const T*>(a);
+    const T* bp = reinterpret_cast<const T*>(b);
+    T* op = reinterpret_cast<T*>(o);
+    for (npy_intp i = 0; i < m; ++i) {
+      if (kSub) {
+        ModSub<T>(ap[i], bp[i], op[i], modulus, spare);
+      } else {
+        ModAdd<T>(ap[i], bp[i], op[i], modulus, spare);
+      }
+    }
+    return;
+  }
   for (npy_intp i = 0; i < n; ++i) {
     for (int c = 0; c < degree; ++c) {
       T x, y, r;
@@ -775,6 +801,44 @@ void IntAddSubLoop(char* a, char* b, char* o, npy_intp n,
   }
 }
 
+// Monomorphic multiply for a degree-1 single-word prime field: Montgomery
+// (kMont) on the stored representatives, or canonical a*b mod p. Contiguous
+// case is a flat vectorizable loop.
+template <typename T, bool kMont>
+void TypedMul(char* a, char* b, char* o, npy_intp n, const npy_intp* strides,
+              T modulus, T mont_nprime) {
+  if (FlatAligned<T>(a, b, o, strides, sizeof(T))) {
+    const T* ap = reinterpret_cast<const T*>(a);
+    const T* bp = reinterpret_cast<const T*>(b);
+    T* op = reinterpret_cast<T*>(o);
+    for (npy_intp i = 0; i < n; ++i) {
+      if (kMont) {
+        MontMul<T>(ap[i], bp[i], op[i], modulus, mont_nprime);
+      } else {
+        op[i] = static_cast<T>(
+            (static_cast<internal::make_promoted_t<T>>(ap[i]) * bp[i]) %
+            modulus);
+      }
+    }
+    return;
+  }
+  for (npy_intp i = 0; i < n; ++i) {
+    T x, y, r;
+    std::memcpy(&x, a, sizeof(T));
+    std::memcpy(&y, b, sizeof(T));
+    if (kMont) {
+      MontMul<T>(x, y, r, modulus, mont_nprime);
+    } else {
+      r = static_cast<T>((static_cast<internal::make_promoted_t<T>>(x) * y) %
+                         modulus);
+    }
+    std::memcpy(o, &r, sizeof(T));
+    a += strides[0];
+    b += strides[1];
+    o += strides[2];
+  }
+}
+
 template <Op op>
 int ArithLoop(PyArrayMethod_Context* context, char* const* data,
               const npy_intp* dimensions, const npy_intp* strides,
@@ -788,9 +852,16 @@ int ArithLoop(PyArrayMethod_Context* context, char* const* data,
 
   if (d->kind == kBinaryTower) {
     if (op != Op::kMul) {  // characteristic 2: add == sub == XOR
-      for (npy_intp i = 0; i < n; ++i) {
-        for (int k = 0; k < wb; ++k) o[k] = static_cast<char>(a[k] ^ b[k]);
-        Advance(a, b, o, strides);
+      if (strides[0] == wb && strides[1] == wb && strides[2] == wb) {
+        npy_intp total = n * wb;  // contiguous: one flat XOR sweep, vectorizes
+        for (npy_intp i = 0; i < total; ++i) {
+          o[i] = static_cast<char>(a[i] ^ b[i]);
+        }
+      } else {
+        for (npy_intp i = 0; i < n; ++i) {
+          for (int k = 0; k < wb; ++k) o[k] = static_cast<char>(a[k] ^ b[k]);
+          Advance(a, b, o, strides);
+        }
       }
       return 0;
     }
@@ -840,13 +911,13 @@ int ArithLoop(PyArrayMethod_Context* context, char* const* data,
     // extension share it.
     if (op != Op::kMul && pf.native) {
       if (wb == 4) {
-        IntAddSubLoop<uint32_t, op == Op::kSub>(a, b, o, n, strides, k, wb,
-                                                pf.p32, pf.spare);
+        TypedAddSub<uint32_t, op == Op::kSub>(a, b, o, n, strides, k, wb,
+                                              pf.p32, pf.spare);
         return 0;
       }
       if (wb == 8) {
-        IntAddSubLoop<uint64_t, op == Op::kSub>(a, b, o, n, strides, k, wb,
-                                                pf.p64, pf.spare);
+        TypedAddSub<uint64_t, op == Op::kSub>(a, b, o, n, strides, k, wb,
+                                              pf.p64, pf.spare);
         return 0;
       }
       for (npy_intp i = 0; i < n; ++i) {
@@ -865,7 +936,24 @@ int ArithLoop(PyArrayMethod_Context* context, char* const* data,
       return 0;
     }
     if (k == 1 && pf.native) {  // prime multiply
-      for (npy_intp i = 0; i < n; ++i) {
+      if (wb == 4) {
+        if (pf.is_mont) {
+          TypedMul<uint32_t, true>(a, b, o, n, strides, pf.p32,
+                                   static_cast<uint32_t>(pf.inv));
+        } else {
+          TypedMul<uint32_t, false>(a, b, o, n, strides, pf.p32, 0);
+        }
+        return 0;
+      }
+      if (wb == 8) {
+        if (pf.is_mont) {
+          TypedMul<uint64_t, true>(a, b, o, n, strides, pf.p64, pf.inv);
+        } else {
+          TypedMul<uint64_t, false>(a, b, o, n, strides, pf.p64, 0);
+        }
+        return 0;
+      }
+      for (npy_intp i = 0; i < n; ++i) {  // 128/256-bit
         pf.Mul(reinterpret_cast<const unsigned char*>(a),
                reinterpret_cast<const unsigned char*>(b),
                reinterpret_cast<unsigned char*>(o));

--- a/zk_dtypes/_src/field_dtype.cc
+++ b/zk_dtypes/_src/field_dtype.cc
@@ -1053,10 +1053,13 @@ int ArithLoop(PyArrayMethod_Context* context, char* const* data,
       }
       return 0;
     }
-    if (k > 1 && op == Op::kMul && pf.ext_native) {  // binomial polynomial mul
-      // ext_native ⟹ base width 4 or 8 (PrimeField::Make); dispatch the typed
-      // Montgomery-space schoolbook (coefficients stay in storage form, so the
-      // result is byte-identical to the decode/compute/encode path).
+    if (k > 1 && op == Op::kMul && pf.ext_native && pf.is_mont) {
+      // Binomial polynomial mul. ext_native ⟹ base width 4 or 8
+      // (PrimeField::Make); dispatch the typed Montgomery-space schoolbook
+      // (coefficients stay in storage form, so the result is byte-identical to
+      // the decode/compute/encode path). EfMulTyped runs the Montgomery kernel,
+      // so it is Montgomery-only — a canonical extension falls through to the
+      // Python-int path below (which decodes to canonical and is storage-safe).
       if (wb == 4) {
         uint32_t nr = 0;
         if (_PyLong_AsByteArray(reinterpret_cast<PyLongObject*>(d->non_residue),

--- a/zk_dtypes/_src/field_dtype.h
+++ b/zk_dtypes/_src/field_dtype.h
@@ -29,6 +29,16 @@ namespace zk_dtypes {
 // a Python error set) on failure. Must run after numpy is imported.
 bool RegisterFieldDType(PyObject* numpy, PyObject* module);
 
+// Seam for EC scalar multiplication (the scalar is a prime FieldDType element).
+// `FieldDTypeMetaObject` returns the FieldDType metaclass (a
+// `PyArray_DTypeMeta*` as `PyObject*`) for registering a mixed ufunc loop
+// against. `PrimeFieldValue` returns the canonical integer value of a degree-1
+// (prime) FieldDType element at `data`, given its descriptor (a
+// `PyArray_Descr*` as `PyObject*`), or NULL with an error set if the descriptor
+// is not a prime FieldDType.
+PyObject* FieldDTypeMetaObject();
+PyObject* PrimeFieldValue(PyObject* descr, const char* data);
+
 }  // namespace zk_dtypes
 
 #endif  // ZK_DTYPES__SRC_FIELD_DTYPE_H_

--- a/zk_dtypes/_src/field_dtype.h
+++ b/zk_dtypes/_src/field_dtype.h
@@ -1,0 +1,34 @@
+/* Copyright 2025 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES__SRC_FIELD_DTYPE_H_
+#define ZK_DTYPES__SRC_FIELD_DTYPE_H_
+
+#include <Python.h>
+
+namespace zk_dtypes {
+
+// Registers the parametric `FieldDType` (NEP-42) and installs the
+// `field_descr(modulus, degree, non_residue, base_width_bits, is_montgomery
+// [, r_mod_p, rinv_mod_p])` factory on `module`. One DType class serves every
+// finite field — prime (degree 1) and binomial extension (degree k over the
+// prime, X^k = non_residue) alike; the parameters live on each descriptor
+// instance, so a user-defined field needs no new C++ type. Returns false (with
+// a Python error set) on failure. Must run after numpy is imported.
+bool RegisterFieldDType(PyObject* numpy, PyObject* module);
+
+}  // namespace zk_dtypes
+
+#endif  // ZK_DTYPES__SRC_FIELD_DTYPE_H_

--- a/zk_dtypes/_src/field_modarith.h
+++ b/zk_dtypes/_src/field_modarith.h
@@ -48,7 +48,7 @@ namespace modarith {
 // single-word MontMul<T> subtracts and needs n' = +p^-1 mod 2^w.
 inline uint64_t ComputeInverse(uint64_t p_low) {
   uint64_t inv = p_low;  // correct mod 2^3 for odd p_low
-  for (int i = 0; i < 6; ++i) inv *= 2 - p_low * inv;
+  for (int i = 0; i < 5; ++i) inv *= 2 - p_low * inv;  // 3->6->12->24->48->96
   return inv;
 }
 

--- a/zk_dtypes/_src/field_modarith.h
+++ b/zk_dtypes/_src/field_modarith.h
@@ -1,0 +1,351 @@
+/* Copyright 2025 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZK_DTYPES__SRC_FIELD_MODARITH_H_
+#define ZK_DTYPES__SRC_FIELD_MODARITH_H_
+
+// Native fixed-width modular arithmetic for the parametric numpy DTypes, with
+// the modulus supplied at runtime (the loops in field_dtype.cc / ec_point_dtype
+// .cc can't bake it at compile time). It reuses zk_dtypes' own Montgomery and
+// modular-add/sub kernels (field/mont_multiplication.h,
+// field/modular_operations .h) — the same code the legacy compile-time field
+// configs use — so a native result is byte-identical to the legacy dtype by
+// construction. The only piece not provided by those headers is n' = -p^-1 mod
+// 2^w, computed here by Newton-Hensel lifting.
+//
+// Storage matches the legacy types: a base-field element is `width_bytes`
+// little-endian, Montgomery-encoded (c*R mod p, R = 2^(width_bytes*8)) for the
+// Montgomery form. On a little-endian host the byte buffer is the limb buffer,
+// so load/store are plain memcpy.
+
+#include <cstdint>
+#include <cstring>
+
+#include "zk_dtypes/include/big_int.h"
+#include "zk_dtypes/include/field/binary_field_multiplication.h"
+#include "zk_dtypes/include/field/modular_operations.h"
+#include "zk_dtypes/include/field/mont_multiplication.h"
+
+namespace zk_dtypes {
+namespace modarith {
+
+// p^-1 mod 2^64 from the low limb of p (p odd). Newton-Hensel doubles the
+// number of correct low bits each step: 3 -> 6 -> 12 -> 24 -> 48 -> 96 (>= 64).
+// The two Montgomery kernels disagree on the sign of n': the multi-limb
+// FastMontMul/MontReduce add k*p and need n' = -p^-1 mod 2^64, while the
+// single-word MontMul<T> subtracts and needs n' = +p^-1 mod 2^w.
+inline uint64_t ComputeInverse(uint64_t p_low) {
+  uint64_t inv = p_low;  // correct mod 2^3 for odd p_low
+  for (int i = 0; i < 6; ++i) inv *= 2 - p_low * inv;
+  return inv;
+}
+
+// A prime base field of `width_bytes` (4/8/16/32) with a runtime modulus.
+// `native` is false when the (width, storage-form) combination is not handled
+// here and the caller must fall back to the generic Python-int path.
+struct PrimeField {
+  int width_bytes = 0;
+  bool is_mont = false;
+  bool native = false;      // prime add/sub/mul fully supported natively
+  bool ext_native = false;  // usable as an extension-field coefficient field
+  bool spare = false;       // modulus has a spare high bit in its storage width
+  bool no_carry = false;    // gnark no-carry Montgomery optimization applies
+  uint64_t nprime_neg = 0;  // -p^-1 mod 2^64 (multi-limb MontMul<N>)
+  uint32_t nprime_pos = 0;  // +p^-1 mod 2^32 (single-word MontMul<uint32>)
+  uint32_t p32 = 0;
+  uint64_t p64 = 0;
+  BigInt<2> p128{};
+  BigInt<4> p256{};
+
+  static PrimeField Make(const unsigned char* mod_le, int width_bytes,
+                         bool is_mont) {
+    PrimeField f;
+    f.width_bytes = width_bytes;
+    f.is_mont = is_mont;
+    uint64_t low = 0;
+    std::memcpy(&low, mod_le, width_bytes < 8 ? width_bytes : 8);
+    uint64_t inv = ComputeInverse(low);
+    f.nprime_neg = uint64_t{0} - inv;
+    f.nprime_pos = static_cast<uint32_t>(inv);
+    switch (width_bytes) {
+      case 4:
+        f.p32 = static_cast<uint32_t>(low);
+        f.spare = (f.p32 >> 31) == 0;
+        // The single-word uint32 Montgomery kernel needs the spare bit to avoid
+        // overflow; without it, defer to the generic path.
+        f.native = f.spare;
+        f.ext_native = f.spare;
+        break;
+      case 8:
+        f.p64 = low;
+        f.spare = (f.p64 >> 63) == 0;
+        f.no_carry = CanUseNoCarryMulOptimization(BigInt<1>(f.p64));
+        f.native = true;
+        f.ext_native = true;
+        break;
+      case 16:
+        std::memcpy(&f.p128[0], mod_le, 16);
+        f.spare = (f.p128[1] >> 63) == 0;
+        f.no_carry = CanUseNoCarryMulOptimization(f.p128);
+        f.native = true;
+        f.ext_native = false;  // extension coeff mul over 128-bit base: defer
+        break;
+      case 32:
+        std::memcpy(&f.p256[0], mod_le, 32);
+        f.spare = (f.p256[3] >> 63) == 0;
+        f.no_carry = CanUseNoCarryMulOptimization(f.p256);
+        f.native = true;
+        f.ext_native = false;
+        break;
+      default:
+        f.native = false;
+    }
+    // Canonical (non-Montgomery) multiply is only implemented natively for the
+    // single-word widths (a 128/256-bit reduce-by-division is deferred).
+    if (!is_mont && width_bytes > 8) {
+      f.native = false;
+      f.ext_native = false;
+    }
+    return f;
+  }
+
+  void Add(const unsigned char* a, const unsigned char* b,
+           unsigned char* o) const {
+    switch (width_bytes) {
+      case 4: {
+        uint32_t x, y, r;
+        std::memcpy(&x, a, 4);
+        std::memcpy(&y, b, 4);
+        ModAdd<uint32_t>(x, y, r, p32, spare);
+        std::memcpy(o, &r, 4);
+        break;
+      }
+      case 8: {
+        uint64_t x, y, r;
+        std::memcpy(&x, a, 8);
+        std::memcpy(&y, b, 8);
+        ModAdd<uint64_t>(x, y, r, p64, spare);
+        std::memcpy(o, &r, 8);
+        break;
+      }
+      case 16: {
+        BigInt<2> x, y, r;
+        std::memcpy(&x[0], a, 16);
+        std::memcpy(&y[0], b, 16);
+        ModAdd<BigInt<2>>(x, y, r, p128, spare);
+        std::memcpy(o, &r[0], 16);
+        break;
+      }
+      case 32: {
+        BigInt<4> x, y, r;
+        std::memcpy(&x[0], a, 32);
+        std::memcpy(&y[0], b, 32);
+        ModAdd<BigInt<4>>(x, y, r, p256, spare);
+        std::memcpy(o, &r[0], 32);
+        break;
+      }
+    }
+  }
+
+  void Sub(const unsigned char* a, const unsigned char* b,
+           unsigned char* o) const {
+    switch (width_bytes) {
+      case 4: {
+        uint32_t x, y, r;
+        std::memcpy(&x, a, 4);
+        std::memcpy(&y, b, 4);
+        ModSub<uint32_t>(x, y, r, p32, spare);
+        std::memcpy(o, &r, 4);
+        break;
+      }
+      case 8: {
+        uint64_t x, y, r;
+        std::memcpy(&x, a, 8);
+        std::memcpy(&y, b, 8);
+        ModSub<uint64_t>(x, y, r, p64, spare);
+        std::memcpy(o, &r, 8);
+        break;
+      }
+      case 16: {
+        BigInt<2> x, y, r;
+        std::memcpy(&x[0], a, 16);
+        std::memcpy(&y[0], b, 16);
+        ModSub<BigInt<2>>(x, y, r, p128, spare);
+        std::memcpy(o, &r[0], 16);
+        break;
+      }
+      case 32: {
+        BigInt<4> x, y, r;
+        std::memcpy(&x[0], a, 32);
+        std::memcpy(&y[0], b, 32);
+        ModSub<BigInt<4>>(x, y, r, p256, spare);
+        std::memcpy(o, &r[0], 32);
+        break;
+      }
+    }
+  }
+
+  // Montgomery multiply on stored (Montgomery) representatives:
+  // mont(x)*mont(y)*R^-1 = mont(x*y).
+  void MontMulBytes(const unsigned char* a, const unsigned char* b,
+                    unsigned char* o) const {
+    switch (width_bytes) {
+      case 4: {
+        uint32_t x, y, r;
+        std::memcpy(&x, a, 4);
+        std::memcpy(&y, b, 4);
+        MontMul<uint32_t>(x, y, r, p32, nprime_pos);
+        std::memcpy(o, &r, 4);
+        break;
+      }
+      case 8: {
+        BigInt<1> x(0), y(0), r;
+        std::memcpy(&x[0], a, 8);
+        std::memcpy(&y[0], b, 8);
+        MontMul<1>(x, y, r, BigInt<1>(p64), nprime_neg, spare, no_carry);
+        std::memcpy(o, &r[0], 8);
+        break;
+      }
+      case 16: {
+        BigInt<2> x, y, r;
+        std::memcpy(&x[0], a, 16);
+        std::memcpy(&y[0], b, 16);
+        MontMul<2>(x, y, r, p128, nprime_neg, spare, no_carry);
+        std::memcpy(o, &r[0], 16);
+        break;
+      }
+      case 32: {
+        BigInt<4> x, y, r;
+        std::memcpy(&x[0], a, 32);
+        std::memcpy(&y[0], b, 32);
+        MontMul<4>(x, y, r, p256, nprime_neg, spare, no_carry);
+        std::memcpy(o, &r[0], 32);
+        break;
+      }
+    }
+  }
+
+  // Canonical multiply r = a*b mod p on plain residues (width 4/8 only).
+  void CanonMulBytes(const unsigned char* a, const unsigned char* b,
+                     unsigned char* o) const {
+    if (width_bytes == 4) {
+      uint32_t x, y;
+      std::memcpy(&x, a, 4);
+      std::memcpy(&y, b, 4);
+      uint32_t r = static_cast<uint32_t>((static_cast<uint64_t>(x) * y) % p32);
+      std::memcpy(o, &r, 4);
+    } else {  // width_bytes == 8
+      uint64_t x, y;
+      std::memcpy(&x, a, 8);
+      std::memcpy(&y, b, 8);
+      uint64_t r =
+          static_cast<uint64_t>((static_cast<unsigned __int128>(x) * y) % p64);
+      std::memcpy(o, &r, 8);
+    }
+  }
+
+  // Storage-form-appropriate multiply for a degree-1 prime field.
+  void Mul(const unsigned char* a, const unsigned char* b,
+           unsigned char* o) const {
+    if (is_mont) {
+      MontMulBytes(a, b, o);
+    } else {
+      CanonMulBytes(a, b, o);
+    }
+  }
+};
+
+// Binary tower GF(2^(2^level)) multiply, levels 0..7 (1..128 bits). Returns
+// false for higher levels (caller falls back). Inputs/outputs are width_bytes
+// little-endian; the legacy binary_field_t* dtypes use the same BinaryMul.
+inline bool BinaryTowerMul(int level, int width_bytes, const unsigned char* a,
+                           const unsigned char* b, unsigned char* o) {
+  switch (level) {
+    case 0: {
+      uint8_t x = 0, y = 0;
+      std::memcpy(&x, a, 1);
+      std::memcpy(&y, b, 1);
+      uint8_t r = BinaryMul<0, uint8_t>(x, y);
+      std::memcpy(o, &r, 1);
+      return true;
+    }
+    case 1: {
+      uint8_t x = 0, y = 0;
+      std::memcpy(&x, a, 1);
+      std::memcpy(&y, b, 1);
+      uint8_t r = BinaryMul<1, uint8_t>(x, y);
+      std::memcpy(o, &r, 1);
+      return true;
+    }
+    case 2: {
+      uint8_t x = 0, y = 0;
+      std::memcpy(&x, a, 1);
+      std::memcpy(&y, b, 1);
+      uint8_t r = BinaryMul<2, uint8_t>(x, y);
+      std::memcpy(o, &r, 1);
+      return true;
+    }
+    case 3: {
+      uint8_t x = 0, y = 0;
+      std::memcpy(&x, a, 1);
+      std::memcpy(&y, b, 1);
+      uint8_t r = BinaryMul<3, uint8_t>(x, y);
+      std::memcpy(o, &r, 1);
+      return true;
+    }
+    case 4: {
+      uint16_t x = 0, y = 0;
+      std::memcpy(&x, a, 2);
+      std::memcpy(&y, b, 2);
+      uint16_t r = BinaryMul<4, uint16_t>(x, y);
+      std::memcpy(o, &r, 2);
+      return true;
+    }
+    case 5: {
+      uint32_t x = 0, y = 0;
+      std::memcpy(&x, a, 4);
+      std::memcpy(&y, b, 4);
+      uint32_t r = BinaryMul<5, uint32_t>(x, y);
+      std::memcpy(o, &r, 4);
+      return true;
+    }
+    case 6: {
+      uint64_t x = 0, y = 0;
+      std::memcpy(&x, a, 8);
+      std::memcpy(&y, b, 8);
+      uint64_t r = BinaryMul<6, uint64_t>(x, y);
+      std::memcpy(o, &r, 8);
+      return true;
+    }
+    case 7: {
+      // Level 7 (128-bit) stores as BigInt<2>, matching the legacy
+      // binary_field_t7 ValueType (TowerTraits<7>).
+      BigInt<2> x, y;
+      std::memcpy(&x[0], a, 16);
+      std::memcpy(&y[0], b, 16);
+      BigInt<2> r = BinaryMul<7, BigInt<2>>(x, y);
+      std::memcpy(o, &r[0], 16);
+      return true;
+    }
+    default:
+      (void)width_bytes;
+      return false;
+  }
+}
+
+}  // namespace modarith
+}  // namespace zk_dtypes
+
+#endif  // ZK_DTYPES__SRC_FIELD_MODARITH_H_

--- a/zk_dtypes/_src/field_modarith.h
+++ b/zk_dtypes/_src/field_modarith.h
@@ -63,7 +63,7 @@ struct PrimeField {
   bool spare = false;       // modulus has a spare high bit in its storage width
   bool no_carry = false;    // gnark no-carry Montgomery optimization applies
   uint64_t nprime_neg = 0;  // -p^-1 mod 2^64 (multi-limb MontMul<N>)
-  uint32_t nprime_pos = 0;  // +p^-1 mod 2^32 (single-word MontMul<uint32>)
+  uint64_t inv = 0;         // +p^-1 mod 2^64 (single-word MontMul<uint32/64>)
   uint32_t p32 = 0;
   uint64_t p64 = 0;
   BigInt<2> p128{};
@@ -76,9 +76,8 @@ struct PrimeField {
     f.is_mont = is_mont;
     uint64_t low = 0;
     std::memcpy(&low, mod_le, width_bytes < 8 ? width_bytes : 8);
-    uint64_t inv = ComputeInverse(low);
-    f.nprime_neg = uint64_t{0} - inv;
-    f.nprime_pos = static_cast<uint32_t>(inv);
+    f.inv = ComputeInverse(low);
+    f.nprime_neg = uint64_t{0} - f.inv;
     switch (width_bytes) {
       case 4:
         f.p32 = static_cast<uint32_t>(low);
@@ -206,16 +205,16 @@ struct PrimeField {
         uint32_t x, y, r;
         std::memcpy(&x, a, 4);
         std::memcpy(&y, b, 4);
-        MontMul<uint32_t>(x, y, r, p32, nprime_pos);
+        MontMul<uint32_t>(x, y, r, p32, static_cast<uint32_t>(inv));
         std::memcpy(o, &r, 4);
         break;
       }
       case 8: {
-        BigInt<1> x(0), y(0), r;
-        std::memcpy(&x[0], a, 8);
-        std::memcpy(&y[0], b, 8);
-        MontMul<1>(x, y, r, BigInt<1>(p64), nprime_neg, spare, no_carry);
-        std::memcpy(o, &r[0], 8);
+        uint64_t x, y, r;
+        std::memcpy(&x, a, 8);
+        std::memcpy(&y, b, 8);
+        MontMul<uint64_t>(x, y, r, p64, inv);
+        std::memcpy(o, &r, 8);
         break;
       }
       case 16: {

--- a/zk_dtypes/_src/field_modarith.h
+++ b/zk_dtypes/_src/field_modarith.h
@@ -120,14 +120,21 @@ struct PrimeField {
     return f;
   }
 
-  void Add(const unsigned char* a, const unsigned char* b,
-           unsigned char* o) const {
+  // ModAdd and ModSub share one width switch; kSub picks the operation (the
+  // dead branch folds away at compile time).
+  template <bool kSub>
+  void AddSub(const unsigned char* a, const unsigned char* b,
+              unsigned char* o) const {
     switch (width_bytes) {
       case 4: {
         uint32_t x, y, r;
         std::memcpy(&x, a, 4);
         std::memcpy(&y, b, 4);
-        ModAdd<uint32_t>(x, y, r, p32, spare);
+        if (kSub) {
+          ModSub<uint32_t>(x, y, r, p32, spare);
+        } else {
+          ModAdd<uint32_t>(x, y, r, p32, spare);
+        }
         std::memcpy(o, &r, 4);
         break;
       }
@@ -135,7 +142,11 @@ struct PrimeField {
         uint64_t x, y, r;
         std::memcpy(&x, a, 8);
         std::memcpy(&y, b, 8);
-        ModAdd<uint64_t>(x, y, r, p64, spare);
+        if (kSub) {
+          ModSub<uint64_t>(x, y, r, p64, spare);
+        } else {
+          ModAdd<uint64_t>(x, y, r, p64, spare);
+        }
         std::memcpy(o, &r, 8);
         break;
       }
@@ -143,7 +154,11 @@ struct PrimeField {
         BigInt<2> x, y, r;
         std::memcpy(&x[0], a, 16);
         std::memcpy(&y[0], b, 16);
-        ModAdd<BigInt<2>>(x, y, r, p128, spare);
+        if (kSub) {
+          ModSub<BigInt<2>>(x, y, r, p128, spare);
+        } else {
+          ModAdd<BigInt<2>>(x, y, r, p128, spare);
+        }
         std::memcpy(o, &r[0], 16);
         break;
       }
@@ -151,49 +166,24 @@ struct PrimeField {
         BigInt<4> x, y, r;
         std::memcpy(&x[0], a, 32);
         std::memcpy(&y[0], b, 32);
-        ModAdd<BigInt<4>>(x, y, r, p256, spare);
+        if (kSub) {
+          ModSub<BigInt<4>>(x, y, r, p256, spare);
+        } else {
+          ModAdd<BigInt<4>>(x, y, r, p256, spare);
+        }
         std::memcpy(o, &r[0], 32);
         break;
       }
     }
   }
 
+  void Add(const unsigned char* a, const unsigned char* b,
+           unsigned char* o) const {
+    AddSub<false>(a, b, o);
+  }
   void Sub(const unsigned char* a, const unsigned char* b,
            unsigned char* o) const {
-    switch (width_bytes) {
-      case 4: {
-        uint32_t x, y, r;
-        std::memcpy(&x, a, 4);
-        std::memcpy(&y, b, 4);
-        ModSub<uint32_t>(x, y, r, p32, spare);
-        std::memcpy(o, &r, 4);
-        break;
-      }
-      case 8: {
-        uint64_t x, y, r;
-        std::memcpy(&x, a, 8);
-        std::memcpy(&y, b, 8);
-        ModSub<uint64_t>(x, y, r, p64, spare);
-        std::memcpy(o, &r, 8);
-        break;
-      }
-      case 16: {
-        BigInt<2> x, y, r;
-        std::memcpy(&x[0], a, 16);
-        std::memcpy(&y[0], b, 16);
-        ModSub<BigInt<2>>(x, y, r, p128, spare);
-        std::memcpy(o, &r[0], 16);
-        break;
-      }
-      case 32: {
-        BigInt<4> x, y, r;
-        std::memcpy(&x[0], a, 32);
-        std::memcpy(&y[0], b, 32);
-        ModSub<BigInt<4>>(x, y, r, p256, spare);
-        std::memcpy(o, &r[0], 32);
-        break;
-      }
-    }
+    AddSub<true>(a, b, o);
   }
 
   // Montgomery multiply on stored (Montgomery) representatives:
@@ -267,9 +257,10 @@ struct PrimeField {
 };
 
 // Binary tower GF(2^(2^level)) multiply, levels 0..7 (1..128 bits). Returns
-// false for higher levels (caller falls back). Inputs/outputs are width_bytes
-// little-endian; the legacy binary_field_t* dtypes use the same BinaryMul.
-inline bool BinaryTowerMul(int level, int width_bytes, const unsigned char* a,
+// false for higher levels (caller falls back). The byte width is implied by the
+// level; inputs/outputs are little-endian; the legacy binary_field_t* dtypes
+// use the same BinaryMul.
+inline bool BinaryTowerMul(int level, const unsigned char* a,
                            const unsigned char* b, unsigned char* o) {
   switch (level) {
     case 0: {
@@ -339,7 +330,6 @@ inline bool BinaryTowerMul(int level, int width_bytes, const unsigned char* a,
       return true;
     }
     default:
-      (void)width_bytes;
       return false;
   }
 }

--- a/zk_dtypes/tests/prime_field_factory_test.py
+++ b/zk_dtypes/tests/prime_field_factory_test.py
@@ -403,6 +403,32 @@ class PrimeFieldFactoryTest(parameterized.TestCase):
         xy.astype(param[2]).view(np.uint8), j.astype(param[2]).view(np.uint8)
     )
 
+  def test_ec_non_jacobian_arithmetic_rejected(self):
+    # Group-law arithmetic is defined on the Jacobian representation; affine /
+    # xyzz must be cast to Jacobian first (rather than misreading coordinates).
+    aff = self._ec_param(2)
+    a = np.zeros(2, dtype=aff)
+    with self.assertRaisesRegex(TypeError, "Jacobian"):
+      a + a  # noqa: B015
+    with self.assertRaisesRegex(TypeError, "Jacobian"):
+      np.equal(a, a)
+    scalar = np.array(
+        [3],
+        dtype=np.dtype(
+            zk_dtypes._zk_dtypes_ext.field_descr(
+                self._BN254_FQ,
+                1,
+                0,
+                256,
+                1,
+                (1 << 256) % self._BN254_FQ,
+                pow((1 << 256) % self._BN254_FQ, -1, self._BN254_FQ),
+            )
+        ),
+    )
+    with self.assertRaisesRegex(TypeError, "Jacobian"):
+      scalar * a
+
   def test_scalar_subscript_returns_element(self):
     # arr[i] (integer subscript to a scalar) must not segfault and returns the
     # element via getitem.

--- a/zk_dtypes/tests/prime_field_factory_test.py
+++ b/zk_dtypes/tests/prime_field_factory_test.py
@@ -1,0 +1,304 @@
+# Copyright 2025 The zk_dtypes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for zk_dtypes.prime_field runtime field resolution."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import numpy as np
+import zk_dtypes
+from zk_dtypes._field_factory import _is_probable_prime
+from zk_dtypes._field_factory import _storage_width
+
+# Modulus / storage / expected curated scalar type.
+_CURATED_CASES = (
+    (2013265921, "mont", zk_dtypes.babybear),
+    (2130706433, "mont", zk_dtypes.koalabear),
+    (18446744069414584321, "mont", zk_dtypes.goldilocks),
+    (2147483647, "std", zk_dtypes.mersenne31),
+)
+
+
+class PrimeFieldFactoryTest(parameterized.TestCase):
+
+  @parameterized.parameters(*_CURATED_CASES)
+  def test_curated_resolves_to_existing_type(self, modulus, storage, expected):
+    # A curated prime keeps its legacy dtype so the non-parametric stack still
+    # recognizes it.
+    self.assertEqual(
+        zk_dtypes.prime_field(modulus, storage), np.dtype(expected)
+    )
+
+  def test_storage_aliases_agree(self):
+    self.assertEqual(
+        zk_dtypes.prime_field(2130706433, "mont"),
+        zk_dtypes.prime_field(2130706433, "montgomery"),
+    )
+    self.assertEqual(
+        zk_dtypes.prime_field(2147483647, "std"),
+        zk_dtypes.prime_field(2147483647, "canonical"),
+    )
+
+  def test_bn254_sf_curated(self):
+    info = zk_dtypes.pfinfo(zk_dtypes.bn254_sf)
+    self.assertEqual(
+        zk_dtypes.prime_field(info.modulus, "mont"),
+        np.dtype(zk_dtypes.bn254_sf),
+    )
+
+  def test_composite_modulus_rejected(self):
+    # 2^31 (even) and a Carmichael number — the latter passes Fermat but must
+    # fail Miller-Rabin.
+    with self.assertRaisesRegex(ValueError, "not prime"):
+      zk_dtypes.prime_field(2**31, "mont")
+    with self.assertRaisesRegex(ValueError, "not prime"):
+      zk_dtypes.prime_field(561, "mont")  # 3 * 11 * 17, Carmichael
+
+  def test_unknown_storage_rejected(self):
+    with self.assertRaisesRegex(ValueError, "storage must be"):
+      zk_dtypes.prime_field(2130706433, "redc")
+
+  def test_non_int_modulus_rejected(self):
+    with self.assertRaisesRegex(TypeError, "must be an int"):
+      zk_dtypes.prime_field(2130706433.0, "mont")
+    with self.assertRaisesRegex(TypeError, "must be an int"):
+      zk_dtypes.prime_field(True, "mont")
+
+  def test_novel_prime_canonical_round_trips(self):
+    # A genuine prime that is not a curated family: 10**9 + 7.
+    novel = 10**9 + 7
+    self.assertTrue(_is_probable_prime(novel))
+    dt = zk_dtypes.prime_field(novel, "canonical")
+    self.assertEqual(dt.itemsize, 4)
+    self.assertEqual(dt.kind, "V")
+    vals = [1, 2, novel - 1, novel, novel + 5, 999999999]
+    arr = np.array(vals, dtype=dt)
+    self.assertEqual([int(x) for x in arr.tolist()], [v % novel for v in vals])
+    # Negative inputs canonicalize to non-negative residues.
+    self.assertEqual(
+        [int(x) for x in np.array([-1, -5], dtype=dt).tolist()],
+        [(-1) % novel, (-5) % novel],
+    )
+
+  def test_novel_prime_wide_canonical_round_trips(self):
+    # A 127-bit Mersenne prime exercises the 128-bit (16-byte) storage path.
+    novel = 2**127 - 1
+    self.assertTrue(_is_probable_prime(novel))
+    dt = zk_dtypes.prime_field(novel, "canonical")
+    self.assertEqual(dt.itemsize, 16)
+    vals = [2**130 + 7, 5, novel - 1]
+    arr = np.array(vals, dtype=dt)
+    self.assertEqual([int(x) for x in arr.tolist()], [v % novel for v in vals])
+
+  def test_novel_prime_montgomery_round_trips(self):
+    novel = 10**9 + 7
+    dt = zk_dtypes.prime_field(novel, "mont")  # 'mont' is the default
+    vals = [0, 1, 2, novel - 1, 123456789]
+    arr = np.array(vals, dtype=dt)
+    # getitem decodes Montgomery back to the canonical value.
+    self.assertEqual([int(x) for x in arr.tolist()], [v % novel for v in vals])
+
+  def test_montgomery_raw_bytes_match_device_encoding(self):
+    # Stored bytes are `a*R mod p` with R = 2^width, matching prime_ir's device
+    # encoding (so host-built buffers are byte-compatible with the device).
+    novel = 10**9 + 7
+    r = (1 << 32) % novel
+    dt = zk_dtypes.prime_field(novel, "mont")
+    raw = int(np.array([7], dtype=dt).view(np.uint32)[0])
+    self.assertEqual(raw, (7 * r) % novel)
+    # Canonical storage keeps the residue verbatim.
+    dc = zk_dtypes.prime_field(novel, "canonical")
+    self.assertEqual(int(np.array([7], dtype=dc).view(np.uint32)[0]), 7)
+
+  def test_oversize_modulus_rejected(self):
+    # A prime wider than the widest (256-bit) storage class. 2^521 - 1 is a
+    # Mersenne prime.
+    with self.assertRaisesRegex(ValueError, "widest field storage"):
+      zk_dtypes.prime_field(2**521 - 1, "mont")
+
+  @parameterized.parameters(
+      (31, 32), (32, 32), (33, 64), (64, 64), (65, 128), (254, 256), (256, 256)
+  )
+  def test_storage_width_roundup(self, bits, expected):
+    self.assertEqual(_storage_width(bits), expected)
+
+  @parameterized.parameters("canonical", "mont")
+  def test_novel_prime_host_arithmetic(self, storage):
+    p = 10**9 + 7
+    dt = zk_dtypes.prime_field(p, storage)
+    av = [5, 999999999, p - 1, 123456, 0]
+    bv = [7, 999999999, 2, 654321, p - 1]
+    a = np.array(av, dtype=dt)
+    b = np.array(bv, dtype=dt)
+    self.assertEqual(
+        [int(x) for x in (a + b).tolist()],
+        [(x + y) % p for x, y in zip(av, bv)],
+    )
+    self.assertEqual(
+        [int(x) for x in (a - b).tolist()],
+        [(x - y) % p for x, y in zip(av, bv)],
+    )
+    self.assertEqual(
+        [int(x) for x in (a * b).tolist()],
+        [(x * y) % p for x, y in zip(av, bv)],
+    )
+
+  def test_arithmetic_across_distinct_fields_errors(self):
+    a = np.array([1], dtype=zk_dtypes.prime_field(10**9 + 7))
+    b = np.array([1], dtype=zk_dtypes.prime_field(2147483647))
+    with self.assertRaises(TypeError):
+      np.add(a, b)
+
+  def _encode_ef(self, base_mod, base_width_bytes, is_mont, coeffs):
+    r = (1 << (base_width_bytes * 8)) % base_mod
+    out = b""
+    for c in coeffs:
+      v = c % base_mod
+      if is_mont:
+        v = v * r % base_mod
+      out += v.to_bytes(base_width_bytes, "little")
+    return np.frombuffer(out, np.uint8)
+
+  # Legacy family / parametric equivalent / base modulus / base width / mont.
+  _EF_BYTE_MATCH = (
+      ("babybearx4", 2013265921, 4, 11, "mont", 4, True),
+      ("koalabearx4", 2130706433, 4, 3, "mont", 4, True),
+      ("mersenne31x2", 2147483647, 2, 2147483646, "canonical", 4, False),
+  )
+
+  @parameterized.parameters(*_EF_BYTE_MATCH)
+  def test_extension_field_byte_matches_legacy(
+      self, legacy_name, base_mod, degree, nr, storage, bw, is_mont
+  ):
+    legacy = getattr(zk_dtypes, legacy_name)
+    param = zk_dtypes.extension_field(base_mod, degree, nr, storage)
+    self.assertEqual(np.dtype(param).itemsize, np.dtype(legacy).itemsize)
+    ca = [(i * 7 + 5) % base_mod for i in range(degree)]
+    cb = [(i * 11 + 3) % base_mod for i in range(degree)]
+    pa, pb = np.zeros(1, dtype=param), np.zeros(1, dtype=param)
+    la, lb = np.zeros(1, dtype=legacy), np.zeros(1, dtype=legacy)
+    for arr in (pa, la):
+      arr.view(np.uint8)[:] = self._encode_ef(base_mod, bw, is_mont, ca)
+    for arr in (pb, lb):
+      arr.view(np.uint8)[:] = self._encode_ef(base_mod, bw, is_mont, cb)
+    for op in (lambda x, y: x + y, lambda x, y: x - y, lambda x, y: x * y):
+      np.testing.assert_array_equal(
+          op(pa, pb).view(np.uint8), op(la, lb).view(np.uint8)
+      )
+
+  def test_novel_extension_field_arithmetic(self):
+    # A novel cubic extension Fp[X]/(X^3 - 5) over a novel prime, checked against
+    # a pure-Python binomial reference.
+    p, deg, nr = 10**9 + 7, 3, 5
+    dt = zk_dtypes.extension_field(p, deg, nr, "mont")
+    self.assertEqual(np.dtype(dt).itemsize, 12)
+
+    def ref_mul(a, b):
+      prod = [0] * (2 * deg - 1)
+      for i in range(deg):
+        for j in range(deg):
+          prod[i + j] = (prod[i + j] + a[i] * b[j]) % p
+      for i in range(2 * deg - 2, deg - 1, -1):
+        prod[i - deg] = (prod[i - deg] + nr * prod[i]) % p
+      return [prod[i] % p for i in range(deg)]
+
+    ca, cb = [3, 5, 7], [11, 13, 17]
+    pa, pb = np.zeros(1, dtype=dt), np.zeros(1, dtype=dt)
+    pa.view(np.uint8)[:] = self._encode_ef(p, 4, True, ca)
+    pb.view(np.uint8)[:] = self._encode_ef(p, 4, True, cb)
+    got = (pa * pb).view(np.uint32)
+    want = self._encode_ef(p, 4, True, ref_mul(ca, cb)).view(np.uint32)
+    np.testing.assert_array_equal(got, want)
+
+  def test_curated_extension_resolves_to_legacy(self):
+    self.assertEqual(
+        zk_dtypes.extension_field(2013265921, 4, 11, "mont"),
+        np.dtype(zk_dtypes.babybearx4),
+    )
+
+  def test_extension_field_degree_one_rejected(self):
+    with self.assertRaisesRegex(ValueError, "degree must be >= 2"):
+      zk_dtypes.extension_field(10**9 + 7, 1, 0, "mont")
+
+  @parameterized.parameters(0, 1, 2, 3, 4, 5, 6, 7)
+  def test_binary_field_byte_matches_legacy(self, level):
+    legacy = getattr(zk_dtypes, f"binary_field_t{level}")
+    param = np.dtype(zk_dtypes._zk_dtypes_ext.binary_field_descr(level))
+    wb = np.dtype(legacy).itemsize
+    self.assertEqual(np.dtype(param).itemsize, wb)
+    m = 1 << level
+    rng = np.random.default_rng(level)
+    n = 64
+    raw_a = rng.integers(0, 256, size=(n, wb), dtype=np.uint8)
+    raw_b = rng.integers(0, 256, size=(n, wb), dtype=np.uint8)
+    pa, pb = np.zeros(n, dtype=param), np.zeros(n, dtype=param)
+    la, lb = np.zeros(n, dtype=legacy), np.zeros(n, dtype=legacy)
+    for arr in (pa, la):
+      arr.view(np.uint8).reshape(n, wb)[:] = raw_a
+    for arr in (pb, lb):
+      arr.view(np.uint8).reshape(n, wb)[:] = raw_b
+    if m < 8:  # small levels: high byte bits are masked off
+      for arr in (pa, la, pb, lb):
+        arr.view(np.uint8)[:] &= (1 << m) - 1
+    np.testing.assert_array_equal(
+        (pa + pb).view(np.uint8), (la + lb).view(np.uint8)
+    )
+    np.testing.assert_array_equal(
+        (pa * pb).view(np.uint8), (la * lb).view(np.uint8)
+    )
+
+  def test_binary_field_curated_resolves_to_legacy(self):
+    for level in range(8):
+      self.assertEqual(
+          zk_dtypes.binary_field(level),
+          np.dtype(getattr(zk_dtypes, f"binary_field_t{level}")),
+      )
+
+  def test_binary_field_negative_level_rejected(self):
+    with self.assertRaisesRegex(ValueError, "level must be >= 0"):
+      zk_dtypes.binary_field(-1)
+
+  def test_scalar_subscript_returns_element(self):
+    # arr[i] (integer subscript to a scalar) must not segfault and returns the
+    # element via getitem.
+    p = 10**9 + 7
+    a = np.array([6, 7, 8], dtype=zk_dtypes.prime_field(p, "canonical"))
+    self.assertEqual(int(a[0]), 6)
+    self.assertEqual(int(a[2]), 8)
+    ef = zk_dtypes.extension_field(p, 3, 5, "canonical")
+    e = np.zeros(1, dtype=ef)
+    e.view(np.uint32).reshape(1, 3)[0] = [10, 20, 30]
+    self.assertEqual(tuple(int(c) for c in e[0]), (10, 20, 30))
+    bf = np.dtype(zk_dtypes._zk_dtypes_ext.binary_field_descr(5))
+    b = np.array([0x12345], dtype=bf)
+    self.assertEqual(int(b[0]), 0x12345)
+
+  def test_miller_rabin_known_primes(self):
+    for p in (
+        2,
+        3,
+        5,
+        2147483647,
+        2013265921,
+        2130706433,
+        18446744069414584321,
+    ):
+      self.assertTrue(_is_probable_prime(p), p)
+    for n in (0, 1, 4, 9, 561, 1105, 2147483646):
+      self.assertFalse(_is_probable_prime(n), n)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/zk_dtypes/tests/prime_field_factory_test.py
+++ b/zk_dtypes/tests/prime_field_factory_test.py
@@ -24,9 +24,9 @@ from zk_dtypes._field_factory import _storage_width
 
 # Modulus / storage / expected curated scalar type.
 _CURATED_CASES = (
-    (2013265921, "mont", zk_dtypes.babybear),
-    (2130706433, "mont", zk_dtypes.koalabear),
-    (18446744069414584321, "mont", zk_dtypes.goldilocks),
+    (2013265921, "mont", zk_dtypes.babybear_mont),
+    (2130706433, "mont", zk_dtypes.koalabear_mont),
+    (18446744069414584321, "mont", zk_dtypes.goldilocks_mont),
     (2147483647, "std", zk_dtypes.mersenne31),
 )
 
@@ -55,7 +55,7 @@ class PrimeFieldFactoryTest(parameterized.TestCase):
     info = zk_dtypes.pfinfo(zk_dtypes.bn254_sf)
     self.assertEqual(
         zk_dtypes.prime_field(info.modulus, "mont"),
-        np.dtype(zk_dtypes.bn254_sf),
+        np.dtype(zk_dtypes.bn254_sf_mont),
     )
 
   def test_composite_modulus_rejected(self):
@@ -173,8 +173,8 @@ class PrimeFieldFactoryTest(parameterized.TestCase):
 
   # Legacy family / parametric equivalent / base modulus / base width / mont.
   _EF_BYTE_MATCH = (
-      ("babybearx4", 2013265921, 4, 11, "mont", 4, True),
-      ("koalabearx4", 2130706433, 4, 3, "mont", 4, True),
+      ("babybearx4_mont", 2013265921, 4, 11, "mont", 4, True),
+      ("koalabearx4_mont", 2130706433, 4, 3, "mont", 4, True),
       ("mersenne31x2", 2147483647, 2, 2147483646, "canonical", 4, False),
   )
 
@@ -225,7 +225,7 @@ class PrimeFieldFactoryTest(parameterized.TestCase):
   def test_curated_extension_resolves_to_legacy(self):
     self.assertEqual(
         zk_dtypes.extension_field(2013265921, 4, 11, "mont"),
-        np.dtype(zk_dtypes.babybearx4),
+        np.dtype(zk_dtypes.babybearx4_mont),
     )
 
   def test_extension_field_degree_one_rejected(self):
@@ -273,7 +273,7 @@ class PrimeFieldFactoryTest(parameterized.TestCase):
   _BN254_FQ = 21888242871839275222246405745257275088696311157297823662689037894645226208583
 
   def test_ec_g1_jacobian_group_law_byte_matches_legacy(self):
-    legacy = zk_dtypes.bn254_g1_jacobian
+    legacy = zk_dtypes.bn254_g1_jacobian_mont
     p = self._BN254_FQ
     info = zk_dtypes.ecinfo(np.dtype(legacy))
     if getattr(info, "is_montgomery", True):
@@ -307,7 +307,7 @@ class PrimeFieldFactoryTest(parameterized.TestCase):
 
   def _ec_g1_jacobian_param(self):
     p = self._BN254_FQ
-    info = zk_dtypes.ecinfo(np.dtype(zk_dtypes.bn254_g1_jacobian))
+    info = zk_dtypes.ecinfo(np.dtype(zk_dtypes.bn254_g1_jacobian_mont))
     if getattr(info, "is_montgomery", True):
       r = (1 << 256) % p
       return np.dtype(
@@ -318,7 +318,7 @@ class PrimeFieldFactoryTest(parameterized.TestCase):
     return np.dtype(zk_dtypes._zk_dtypes_ext.ec_point_descr(p, 256, 3, 0))
 
   def test_ec_group_equality_cross_representative(self):
-    legacy = zk_dtypes.bn254_g1_jacobian
+    legacy = zk_dtypes.bn254_g1_jacobian_mont
     param = self._ec_g1_jacobian_param()
 
     def pt(n):
@@ -340,7 +340,7 @@ class PrimeFieldFactoryTest(parameterized.TestCase):
   _BN254_FR = 21888242871839275222246405745257275088548364400416034343698204186575808495617
 
   def test_ec_scalar_multiplication_byte_matches_legacy(self):
-    legacy = zk_dtypes.bn254_g1_jacobian
+    legacy = zk_dtypes.bn254_g1_jacobian_mont
     param = self._ec_g1_jacobian_param()
     rfr = (1 << 256) % self._BN254_FR
     # Parametric Fr scalar dtype (built directly: the Fr modulus is a curated
@@ -375,9 +375,9 @@ class PrimeFieldFactoryTest(parameterized.TestCase):
 
   def test_ec_coordinate_rep_casts(self):
     legacy = {
-        2: zk_dtypes.bn254_g1_affine,
-        3: zk_dtypes.bn254_g1_jacobian,
-        4: zk_dtypes.bn254_g1_xyzz,
+        2: zk_dtypes.bn254_g1_affine_mont,
+        3: zk_dtypes.bn254_g1_jacobian_mont,
+        4: zk_dtypes.bn254_g1_xyzz_mont,
     }
     param = {nc: self._ec_param(nc) for nc in (2, 3, 4)}
 
@@ -413,7 +413,7 @@ class PrimeFieldFactoryTest(parameterized.TestCase):
             q, 256, 3, 1, r, pow(r, -1, q), 2, q - 1
         )
     )
-    legacy = zk_dtypes.bn254_g2_jacobian
+    legacy = zk_dtypes.bn254_g2_jacobian_mont
     self.assertEqual(np.dtype(g2).itemsize, np.dtype(legacy).itemsize)
 
     def pt(n):

--- a/zk_dtypes/tests/prime_field_factory_test.py
+++ b/zk_dtypes/tests/prime_field_factory_test.py
@@ -487,6 +487,56 @@ class PrimeFieldFactoryTest(parameterized.TestCase):
     b = np.array([0x12345], dtype=bf)
     self.assertEqual(int(b[0]), 0x12345)
 
+  def test_mont_canonical_astype_reencodes(self):
+    # astype between the Montgomery and canonical forms of one field must
+    # re-encode the value, not raw-copy the bytes.
+    p = 10**9 + 7
+    mont = zk_dtypes.prime_field(p, "mont")
+    canon = zk_dtypes.prime_field(p, "canonical")
+    vals = [7, 123456789, p - 1]
+    a = np.array(vals, dtype=canon)
+    b = a.astype(mont)
+    self.assertEqual([int(x) for x in b.tolist()], vals)
+    r = (1 << 32) % p
+    self.assertEqual(b.view(np.uint32).tolist(), [(v * r) % p for v in vals])
+    self.assertEqual([int(x) for x in b.astype(canon).tolist()], vals)
+
+  def test_cast_between_distinct_fields_rejected(self):
+    # A cast between genuinely different fields is meaningless (and across widths
+    # would write out of bounds) — it must raise, not silently copy bytes.
+    a = np.array([1], dtype=zk_dtypes.prime_field(10**9 + 7))
+    with self.assertRaises(TypeError):
+      a.astype(zk_dtypes.prime_field(2130706433))
+
+  def test_high_binary_tower_round_trips(self):
+    # Levels 11/12 (256/512-byte storage) must not truncate base_width_bytes to
+    # 0 (would silently zero every element).
+    for level, width in ((11, 256), (12, 512)):
+      bf = np.dtype(zk_dtypes._zk_dtypes_ext.binary_field_descr(level))
+      self.assertEqual(np.dtype(bf).itemsize, width)
+      v = 0x123456789ABCDEF
+      a = np.array([v], dtype=bf)
+      self.assertEqual(int(a[0]), v)
+      b = np.array([0xFF], dtype=bf)
+      self.assertEqual(int((a + b)[0]), v ^ 0xFF)
+
+  def test_scalar_mul_output_curve_mismatch_rejected(self):
+    # out= of a different representation than the Jacobian point must be rejected
+    # (the native scalar-mul sizes its write from the input point's width).
+    jac = self._ec_param(3)
+    affine = self._ec_param(2)
+    rfr = (1 << 256) % self._BN254_FR
+    scalar_dt = np.dtype(
+        zk_dtypes._zk_dtypes_ext.field_descr(
+            self._BN254_FR, 1, 0, 256, 1, rfr, pow(rfr, -1, self._BN254_FR)
+        )
+    )
+    s = np.array([3], dtype=scalar_dt)
+    g = np.zeros(1, dtype=jac)
+    out = np.zeros(1, dtype=affine)
+    with self.assertRaises((TypeError, ValueError)):
+      np.multiply(s, g, out=out)
+
   def test_miller_rabin_known_primes(self):
     for p in (
         2,

--- a/zk_dtypes/tests/prime_field_factory_test.py
+++ b/zk_dtypes/tests/prime_field_factory_test.py
@@ -403,6 +403,49 @@ class PrimeFieldFactoryTest(parameterized.TestCase):
         xy.astype(param[2]).view(np.uint8), j.astype(param[2]).view(np.uint8)
     )
 
+  def test_ec_g2_jacobian_byte_matches_legacy(self):
+    # G2 points are over Fp2 = Fq[u]/(u^2 + 1); the same Jacobian formulas run
+    # over the degree-2 coordinate field.
+    q = self._BN254_FQ
+    r = (1 << 256) % q
+    g2 = np.dtype(
+        zk_dtypes._zk_dtypes_ext.ec_point_descr(
+            q, 256, 3, 1, r, pow(r, -1, q), 2, q - 1
+        )
+    )
+    legacy = zk_dtypes.bn254_g2_jacobian
+    self.assertEqual(np.dtype(g2).itemsize, np.dtype(legacy).itemsize)
+
+    def pt(n):
+      out = np.zeros(1, dtype=g2)
+      out.view(np.uint8)[:] = np.array([n], dtype=legacy).view(np.uint8)
+      return out
+
+    for a, b in [(1, 2), (3, 5), (2, 2), (123, 456)]:
+      la, lb = np.array([a], dtype=legacy), np.array([b], dtype=legacy)
+      np.testing.assert_array_equal(
+          (pt(a) + pt(b)).view(np.uint8), (la + lb).view(np.uint8)
+      )
+      np.testing.assert_array_equal(
+          (pt(a) - pt(b)).view(np.uint8), (la - lb).view(np.uint8)
+      )
+      np.testing.assert_array_equal(
+          (-pt(a)).view(np.uint8), (-la).view(np.uint8)
+      )
+
+    rfr = (1 << 256) % self._BN254_FR
+    scalar = np.dtype(
+        zk_dtypes._zk_dtypes_ext.field_descr(
+            self._BN254_FR, 1, 0, 256, 1, rfr, pow(rfr, -1, self._BN254_FR)
+        )
+    )
+    g = pt(1)
+    for s in (2, 3, 7, 100):
+      np.testing.assert_array_equal(
+          (np.array([s], dtype=scalar) * g).view(np.uint8), pt(s).view(np.uint8)
+      )
+    self.assertTrue(bool((pt(5) == (pt(2) + pt(3)))[0]))
+
   def test_ec_non_jacobian_arithmetic_rejected(self):
     # Group-law arithmetic is defined on the Jacobian representation; affine /
     # xyzz must be cast to Jacobian first (rather than misreading coordinates).

--- a/zk_dtypes/tests/prime_field_factory_test.py
+++ b/zk_dtypes/tests/prime_field_factory_test.py
@@ -270,6 +270,41 @@ class PrimeFieldFactoryTest(parameterized.TestCase):
     with self.assertRaisesRegex(ValueError, "level must be >= 0"):
       zk_dtypes.binary_field(-1)
 
+  _BN254_FQ = 21888242871839275222246405745257275088696311157297823662689037894645226208583
+
+  def test_ec_g1_jacobian_group_law_byte_matches_legacy(self):
+    legacy = zk_dtypes.bn254_g1_jacobian
+    p = self._BN254_FQ
+    info = zk_dtypes.ecinfo(np.dtype(legacy))
+    if getattr(info, "is_montgomery", True):
+      r = (1 << 256) % p
+      param = np.dtype(
+          zk_dtypes._zk_dtypes_ext.ec_point_descr(
+              p, 256, 3, 1, r, pow(r, -1, p)
+          )
+      )
+    else:
+      param = np.dtype(zk_dtypes._zk_dtypes_ext.ec_point_descr(p, 256, 3, 0))
+    self.assertEqual(np.dtype(param).itemsize, np.dtype(legacy).itemsize)
+
+    def to_param(legacy_arr):
+      out = np.zeros(len(legacy_arr), dtype=param)
+      out.view(np.uint8)[:] = legacy_arr.view(np.uint8)
+      return out
+
+    # n*G are valid curve points; identical input representatives let byte
+    # equality test that the EFD formulas reproduce the exact legacy output.
+    for a, b in [(1, 2), (3, 5), (7, 11), (2, 2), (10, 10), (123, 456), (0, 5)]:
+      la, lb = np.array([a], dtype=legacy), np.array([b], dtype=legacy)
+      pa, pb = to_param(la), to_param(lb)
+      np.testing.assert_array_equal(
+          (pa + pb).view(np.uint8), (la + lb).view(np.uint8)
+      )
+      np.testing.assert_array_equal(
+          (pa - pb).view(np.uint8), (la - lb).view(np.uint8)
+      )
+      np.testing.assert_array_equal((-pa).view(np.uint8), (-la).view(np.uint8))
+
   def test_scalar_subscript_returns_element(self):
     # arr[i] (integer subscript to a scalar) must not segfault and returns the
     # element via getitem.

--- a/zk_dtypes/tests/prime_field_factory_test.py
+++ b/zk_dtypes/tests/prime_field_factory_test.py
@@ -305,6 +305,38 @@ class PrimeFieldFactoryTest(parameterized.TestCase):
       )
       np.testing.assert_array_equal((-pa).view(np.uint8), (-la).view(np.uint8))
 
+  def _ec_g1_jacobian_param(self):
+    p = self._BN254_FQ
+    info = zk_dtypes.ecinfo(np.dtype(zk_dtypes.bn254_g1_jacobian))
+    if getattr(info, "is_montgomery", True):
+      r = (1 << 256) % p
+      return np.dtype(
+          zk_dtypes._zk_dtypes_ext.ec_point_descr(
+              p, 256, 3, 1, r, pow(r, -1, p)
+          )
+      )
+    return np.dtype(zk_dtypes._zk_dtypes_ext.ec_point_descr(p, 256, 3, 0))
+
+  def test_ec_group_equality_cross_representative(self):
+    legacy = zk_dtypes.bn254_g1_jacobian
+    param = self._ec_g1_jacobian_param()
+
+    def pt(n):
+      out = np.zeros(1, dtype=param)
+      out.view(np.uint8)[:] = np.array([n], dtype=legacy).view(np.uint8)
+      return out
+
+    p1, p2, p3, p5 = pt(1), pt(2), pt(3), pt(5)
+    self.assertTrue(bool((p3 == p3)[0]))
+    self.assertFalse(bool((p3 == p5)[0]))
+    self.assertTrue(bool((p3 != p5)[0]))
+    # 5G and 2G+3G are the same group element with different Jacobian
+    # representatives (byte-different); == must compare by group element.
+    s = p2 + p3
+    self.assertFalse(np.array_equal(p5.view(np.uint8), s.view(np.uint8)))
+    self.assertTrue(bool((p5 == s)[0]))
+    self.assertTrue(bool((p3 == (p1 + p2))[0]))
+
   def test_scalar_subscript_returns_element(self):
     # arr[i] (integer subscript to a scalar) must not segfault and returns the
     # element via getitem.

--- a/zk_dtypes/tests/prime_field_factory_test.py
+++ b/zk_dtypes/tests/prime_field_factory_test.py
@@ -337,6 +337,33 @@ class PrimeFieldFactoryTest(parameterized.TestCase):
     self.assertTrue(bool((p5 == s)[0]))
     self.assertTrue(bool((p3 == (p1 + p2))[0]))
 
+  _BN254_FR = 21888242871839275222246405745257275088548364400416034343698204186575808495617
+
+  def test_ec_scalar_multiplication_byte_matches_legacy(self):
+    legacy = zk_dtypes.bn254_g1_jacobian
+    param = self._ec_g1_jacobian_param()
+    rfr = (1 << 256) % self._BN254_FR
+    # Parametric Fr scalar dtype (built directly: the Fr modulus is a curated
+    # family that prime_field would resolve to the legacy dtype).
+    scalar_dt = np.dtype(
+        zk_dtypes._zk_dtypes_ext.field_descr(
+            self._BN254_FR, 1, 0, 256, 1, rfr, pow(rfr, -1, self._BN254_FR)
+        )
+    )
+
+    def pt(n):
+      out = np.zeros(1, dtype=param)
+      out.view(np.uint8)[:] = np.array([n], dtype=legacy).view(np.uint8)
+      return out
+
+    g = pt(1)
+    for s in (2, 3, 7, 100, 12345):
+      res = np.array([s], dtype=scalar_dt) * g
+      np.testing.assert_array_equal(res.view(np.uint8), pt(s).view(np.uint8))
+      # point * scalar (reverse operand order)
+      res2 = g * np.array([s], dtype=scalar_dt)
+      np.testing.assert_array_equal(res2.view(np.uint8), pt(s).view(np.uint8))
+
   def test_scalar_subscript_returns_element(self):
     # arr[i] (integer subscript to a scalar) must not segfault and returns the
     # element via getitem.

--- a/zk_dtypes/tests/prime_field_factory_test.py
+++ b/zk_dtypes/tests/prime_field_factory_test.py
@@ -364,6 +364,45 @@ class PrimeFieldFactoryTest(parameterized.TestCase):
       res2 = g * np.array([s], dtype=scalar_dt)
       np.testing.assert_array_equal(res2.view(np.uint8), pt(s).view(np.uint8))
 
+  def _ec_param(self, num_coords):
+    p = self._BN254_FQ
+    r = (1 << 256) % p
+    return np.dtype(
+        zk_dtypes._zk_dtypes_ext.ec_point_descr(
+            p, 256, num_coords, 1, r, pow(r, -1, p)
+        )
+    )
+
+  def test_ec_coordinate_rep_casts(self):
+    legacy = {
+        2: zk_dtypes.bn254_g1_affine,
+        3: zk_dtypes.bn254_g1_jacobian,
+        4: zk_dtypes.bn254_g1_xyzz,
+    }
+    param = {nc: self._ec_param(nc) for nc in (2, 3, 4)}
+
+    def to_param(arr, nc):
+      out = np.zeros(len(arr), dtype=param[nc])
+      out.view(np.uint8)[:] = arr.view(np.uint8)
+      return out
+
+    # The four affine<->projective directions the legacy backend registers;
+    # byte-match its cast.
+    for frm, to in [(3, 2), (4, 2), (2, 3), (2, 4)]:
+      lsrc = np.array([5], dtype=legacy[frm])
+      ldst = lsrc.astype(legacy[to])
+      pdst = to_param(lsrc, frm).astype(param[to])
+      np.testing.assert_array_equal(pdst.view(np.uint8), ldst.view(np.uint8))
+
+    # Jacobian<->xyzz (legacy registers neither direction): verify correctness
+    # by round-trip group equality and a shared affine projection.
+    j = to_param(np.array([5], dtype=legacy[3]), 3)
+    xy = j.astype(param[4])
+    self.assertTrue(bool((xy.astype(param[3]) == j)[0]))
+    np.testing.assert_array_equal(
+        xy.astype(param[2]).view(np.uint8), j.astype(param[2]).view(np.uint8)
+    )
+
   def test_scalar_subscript_returns_element(self):
     # arr[i] (integer subscript to a scalar) must not segfault and returns the
     # element via getitem.

--- a/zk_dtypes/tests/prime_field_factory_test.py
+++ b/zk_dtypes/tests/prime_field_factory_test.py
@@ -21,6 +21,7 @@ import numpy as np
 import zk_dtypes
 from zk_dtypes._field_factory import _is_probable_prime
 from zk_dtypes._field_factory import _storage_width
+from zk_dtypes._pfinfo import pfinfo
 
 # Modulus / storage / expected curated scalar type.
 _CURATED_CASES = (
@@ -486,6 +487,18 @@ class PrimeFieldFactoryTest(parameterized.TestCase):
     bf = np.dtype(zk_dtypes._zk_dtypes_ext.binary_field_descr(5))
     b = np.array([0x12345], dtype=bf)
     self.assertEqual(int(b[0]), 0x12345)
+
+  @parameterized.parameters(
+      "pallas_sf", "pallas_sf_mont", "vesta_sf", "vesta_sf_mont"
+  )
+  def test_curated_family_added_after_factory_resolves_to_legacy(self, name):
+    # The curated maps are built by probing every registered dtype, so a family
+    # added to the legacy stack after this factory (pallas/vesta) resolves to
+    # its legacy dtype instead of minting a duplicate parametric one.
+    legacy = np.dtype(getattr(zk_dtypes, name))
+    info = pfinfo(legacy)
+    storage = "mont" if info.is_montgomery else "canonical"
+    self.assertEqual(zk_dtypes.prime_field(info.modulus, storage), legacy)
 
   def test_ec_setitem_getitem_roundtrip_g1_and_g2(self):
     # setitem must accept the coordinate shape getitem returns: a bare int per

--- a/zk_dtypes/tests/prime_field_factory_test.py
+++ b/zk_dtypes/tests/prime_field_factory_test.py
@@ -500,6 +500,30 @@ class PrimeFieldFactoryTest(parameterized.TestCase):
     storage = "mont" if info.is_montgomery else "canonical"
     self.assertEqual(zk_dtypes.prime_field(info.modulus, storage), legacy)
 
+  def test_novel_canonical_extension_multiply(self):
+    # A canonical (non-Montgomery) extension multiply must not run the
+    # Montgomery kernel; check the product against a plain-int reference.
+    # Montgomery extensions are covered by the byte-match-legacy tests.
+    p = 2**61 - 1  # single-word canonical base
+    nr = 5
+    ef = zk_dtypes.extension_field(p, 3, nr, "canonical")
+    a = np.zeros(2, dtype=ef)
+    v = a.view(np.uint64).reshape(2, 3)
+    v[0] = [1, 2, 3]
+    v[1] = [4, 5, 6]
+    got = tuple(int(c) for c in (a[0:1] * a[1:2])[0])
+
+    def ref(x, y):
+      c = [0] * 5
+      for i in range(3):
+        for j in range(3):
+          c[i + j] = (c[i + j] + x[i] * y[j]) % p
+      for i in (4, 3):
+        c[i - 3] = (c[i - 3] + nr * c[i]) % p
+      return tuple(c[:3])
+
+    self.assertEqual(got, ref([1, 2, 3], [4, 5, 6]))
+
   def test_ec_setitem_getitem_roundtrip_g1_and_g2(self):
     # setitem must accept the coordinate shape getitem returns: a bare int per
     # Fq coordinate (G1), or a (c0, c1) pair per Fp2 coordinate (G2). Regression:

--- a/zk_dtypes/tests/prime_field_factory_test.py
+++ b/zk_dtypes/tests/prime_field_factory_test.py
@@ -19,6 +19,9 @@ from absl.testing import absltest
 from absl.testing import parameterized
 import numpy as np
 import zk_dtypes
+import warnings
+
+from zk_dtypes._field_factory import _GOLDILOCKS_MODULUS
 from zk_dtypes._field_factory import _is_probable_prime
 from zk_dtypes._field_factory import _storage_width
 from zk_dtypes._pfinfo import pfinfo
@@ -499,6 +502,19 @@ class PrimeFieldFactoryTest(parameterized.TestCase):
     info = pfinfo(legacy)
     storage = "mont" if info.is_montgomery else "canonical"
     self.assertEqual(zk_dtypes.prime_field(info.modulus, storage), legacy)
+
+  def test_goldilocks_montgomery_deprecation_warning(self):
+    # Montgomery goldilocks is inefficient (Solinas reduction); the factory
+    # warns and steers to canonical. Other fields and canonical goldilocks
+    # stay quiet.
+    with self.assertWarnsRegex(DeprecationWarning, "Goldilocks"):
+      zk_dtypes.prime_field(_GOLDILOCKS_MODULUS, "mont")
+    with self.assertWarnsRegex(DeprecationWarning, "Goldilocks"):
+      zk_dtypes.extension_field(_GOLDILOCKS_MODULUS, 2, 7, "mont")
+    with warnings.catch_warnings():
+      warnings.simplefilter("error")
+      zk_dtypes.prime_field(_GOLDILOCKS_MODULUS, "canonical")
+      zk_dtypes.prime_field(2013265921, "mont")  # babybear stays fine in mont
 
   def test_novel_canonical_extension_multiply(self):
     # A canonical (non-Montgomery) extension multiply must not run the

--- a/zk_dtypes/tests/prime_field_factory_test.py
+++ b/zk_dtypes/tests/prime_field_factory_test.py
@@ -487,6 +487,32 @@ class PrimeFieldFactoryTest(parameterized.TestCase):
     b = np.array([0x12345], dtype=bf)
     self.assertEqual(int(b[0]), 0x12345)
 
+  def test_ec_setitem_getitem_roundtrip_g1_and_g2(self):
+    # setitem must accept the coordinate shape getitem returns: a bare int per
+    # Fq coordinate (G1), or a (c0, c1) pair per Fp2 coordinate (G2). Regression:
+    # G2 setitem forced PyNumber_Index on each coordinate, rejecting the tuple.
+    q = self._BN254_FQ
+    r = (1 << 256) % q
+    g1 = self._ec_param(3)  # Jacobian G1, Montgomery
+    a = np.zeros(1, dtype=g1)
+    a[0] = (11, 22, 33)
+    self.assertEqual(tuple(int(c) for c in a[0]), (11, 22, 33))
+
+    g2 = np.dtype(
+        zk_dtypes._zk_dtypes_ext.ec_point_descr(
+            q, 256, 3, 1, r, pow(r, -1, q), 2, q - 1
+        )
+    )
+    b = np.zeros(1, dtype=g2)
+    b[0] = ((11, 12), (22, 23), (1, 0))
+    self.assertEqual(
+        tuple(tuple(int(x) for x in coord) for coord in b[0]),
+        ((11, 12), (22, 23), (1, 0)),
+    )
+    # A wrong-width Fp2 coordinate is rejected.
+    with self.assertRaisesRegex(ValueError, "Fp2 coordinate needs"):
+      b[0] = ((1, 2, 3), (1, 0), (1, 0))
+
   def test_mont_canonical_astype_reencodes(self):
     # astype between the Montgomery and canonical forms of one field must
     # re-encode the value, not raw-copy the bytes.

--- a/zk_dtypes/tests/prime_field_factory_test.py
+++ b/zk_dtypes/tests/prime_field_factory_test.py
@@ -631,5 +631,224 @@ class PrimeFieldFactoryTest(parameterized.TestCase):
       self.assertFalse(_is_probable_prime(n), n)
 
 
+# --- systematic parametric-kernel coverage --------------------------------
+# These tests build the dtype directly through field_descr / binary_field_descr,
+# bypassing the factory's curated resolution, so the *parametric* kernels run
+# even for production moduli (goldilocks, bn254, ...) — the curated path resolves
+# those to legacy dtypes and never exercises this code. Every result is checked
+# against an independent pure-Python reference, not against the legacy dtype, so
+# a bug shared by both the kernel and the legacy path could not hide (and a
+# canonical-only or width-specific kernel bug is caught regardless of storage).
+
+_EXT_MOD = zk_dtypes._zk_dtypes_ext
+
+
+def _r_mod_p(width_bits, p):
+  return (1 << width_bits) % p
+
+
+def _param_prime(p, width_bits, is_mont):
+  if is_mont:
+    r = _r_mod_p(width_bits, p)
+    return np.dtype(
+        _EXT_MOD.field_descr(p, 1, 0, width_bits, 1, r, pow(r, -1, p))
+    )
+  return np.dtype(_EXT_MOD.field_descr(p, 1, 0, width_bits, 0))
+
+
+def _param_ext(p, degree, nr, width_bits, is_mont):
+  if is_mont:
+    r = _r_mod_p(width_bits, p)
+    return np.dtype(
+        _EXT_MOD.field_descr(p, degree, nr, width_bits, 1, r, pow(r, -1, p))
+    )
+  return np.dtype(_EXT_MOD.field_descr(p, degree, nr, width_bits, 0))
+
+
+def _encode_elems(elems, p, width_bits, is_mont):
+  """Packs coefficient-lists (one per array element) into stored little-endian
+  bytes, applying the Montgomery factor R = 2^width_bits — an encoder written
+  independently of the C++ setitem so a shared bug cannot mask a wrong kernel.
+  """
+  wb = width_bits // 8
+  r = _r_mod_p(width_bits, p) if is_mont else 1
+  out = bytearray()
+  for coeffs in elems:
+    for c in coeffs:
+      v = (c % p) * r % p if is_mont else c % p
+      out += (v).to_bytes(wb, "little")
+  return np.frombuffer(bytes(out), np.uint8).copy()
+
+
+def _decode_elem(raw_u8, p, width_bits, is_mont, degree):
+  wb = width_bits // 8
+  rinv = pow(_r_mod_p(width_bits, p), -1, p) if is_mont else None
+  out = []
+  for k in range(degree):
+    v = int.from_bytes(bytes(raw_u8[k * wb : (k + 1) * wb]), "little")
+    out.append(v * rinv % p if is_mont else v % p)
+  return out
+
+
+def _ref_prime(op, a, b, p):
+  return {"add": (a + b) % p, "sub": (a - b) % p, "mul": a * b % p}[op]
+
+
+def _ref_ext(op, ca, cb, p, degree, nr):
+  if op != "mul":
+    s = 1 if op == "add" else -1
+    return [(ca[i] + s * cb[i]) % p for i in range(degree)]
+  prod = [0] * (2 * degree - 1)
+  for i in range(degree):
+    for j in range(degree):
+      prod[i + j] = (prod[i + j] + ca[i] * cb[j]) % p
+  for i in range(2 * degree - 2, degree - 1, -1):
+    prod[i - degree] = (prod[i - degree] + nr * prod[i]) % p
+  return [prod[i] % p for i in range(degree)]
+
+
+_OPS = {"add": np.add, "sub": np.subtract, "mul": np.multiply}
+
+# (label, modulus, storage width bits) spanning every native width and both the
+# single-word and BigInt kernels; curated production moduli plus novel ones.
+_PRIME_MATRIX = (
+    ("babybear", 2013265921, 32),
+    ("mersenne31", 2147483647, 32),
+    ("novel30", 10**9 + 7, 32),
+    ("goldilocks", 2**64 - 2**32 + 1, 64),
+    ("mersenne61", 2**61 - 1, 64),
+    ("mersenne127", 2**127 - 1, 128),
+    (
+        "bn254_fr",
+        21888242871839275222246405745257275088548364400416034343698204186575808495617,
+        256,
+    ),
+    (
+        "pallas",
+        0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000001,
+        256,
+    ),
+)
+
+# (label, base modulus, degree, non_residue, base width bits). The non-residue
+# need not be irreducible — the ring Fp[X]/(X^d - nr) multiply is well-defined
+# either way, which is what the kernel computes.
+_EXT_MATRIX = (
+    ("babybear_d4", 2013265921, 4, 11, 32),
+    ("koalabear_d4", 2130706433, 4, 3, 32),
+    ("mersenne31_d2", 2147483647, 2, 5, 32),
+    ("goldilocks_d2", 2**64 - 2**32 + 1, 2, 7, 64),
+    ("goldilocks_d3", 2**64 - 2**32 + 1, 3, 7, 64),
+    ("mersenne61_d3", 2**61 - 1, 3, 5, 64),
+)
+
+
+class ParametricFieldMatrixTest(parameterized.TestCase):
+
+  @parameterized.parameters(
+      *(
+          (lbl, p, w, mont, op)
+          for (lbl, p, w) in _PRIME_MATRIX
+          for mont in (False, True)
+          for op in ("add", "sub", "mul")
+      )
+  )
+  def test_prime_kernel(self, label, p, width_bits, is_mont, op):
+    dt = _param_prime(p, width_bits, is_mont)
+    av = [0, 1, 2, p - 1, p // 2, 7, p - 3, p - 1]
+    bv = [0, p - 1, 3, p - 1, p // 3, 7, 5, 1]
+    a = np.zeros(len(av), dtype=dt)
+    b = np.zeros(len(bv), dtype=dt)
+    a.view(np.uint8)[:] = _encode_elems(
+        [[v] for v in av], p, width_bits, is_mont
+    )
+    b.view(np.uint8)[:] = _encode_elems(
+        [[v] for v in bv], p, width_bits, is_mont
+    )
+    got = _OPS[op](a, b).view(np.uint8).reshape(len(av), width_bits // 8)
+    for i in range(len(av)):
+      dec = _decode_elem(got[i], p, width_bits, is_mont, 1)[0]
+      self.assertEqual(
+          dec,
+          _ref_prime(op, av[i], bv[i], p),
+          f"{label} {op} mont={is_mont} i={i}",
+      )
+
+  @parameterized.parameters(
+      *(
+          (lbl, p, d, nr, w, mont, op)
+          for (lbl, p, d, nr, w) in _EXT_MATRIX
+          for mont in (False, True)
+          for op in ("add", "sub", "mul")
+      )
+  )
+  def test_extension_kernel(
+      self, label, p, degree, nr, width_bits, is_mont, op
+  ):
+    dt = _param_ext(p, degree, nr, width_bits, is_mont)
+    ea = [[(i * 7 + 5 + j * 3) % p for j in range(degree)] for i in range(4)]
+    eb = [[(i * 11 + 2 + j * 9) % p for j in range(degree)] for i in range(4)]
+    a = np.zeros(len(ea), dtype=dt)
+    b = np.zeros(len(eb), dtype=dt)
+    a.view(np.uint8)[:] = _encode_elems(ea, p, width_bits, is_mont)
+    b.view(np.uint8)[:] = _encode_elems(eb, p, width_bits, is_mont)
+    got = (
+        _OPS[op](a, b).view(np.uint8).reshape(len(ea), degree * width_bits // 8)
+    )
+    for i in range(len(ea)):
+      dec = _decode_elem(got[i], p, width_bits, is_mont, degree)
+      self.assertEqual(
+          dec,
+          _ref_ext(op, ea[i], eb[i], p, degree, nr),
+          f"{label} {op} mont={is_mont} i={i}",
+      )
+
+  @parameterized.parameters(*range(0, 13))
+  def test_binary_tower_kernel(self, level):
+    bf = np.dtype(_EXT_MOD.binary_field_descr(level))
+    wb = bf.itemsize
+    mask = (1 << (1 << level)) - 1
+
+    def arr(vals):
+      out = np.zeros(len(vals), dtype=bf)
+      out.view(np.uint8).reshape(len(vals), wb)[:] = [
+          list((v & mask).to_bytes(wb, "little")) for v in vals
+      ]
+      return out
+
+    xs = [0, 1, mask, (mask ^ (mask >> 1)) & mask, 0xA5, mask // 3, 0xDEADBEEF]
+    ys = [0, mask, 2, 1, 0x5A, mask // 7, 0x1234567]
+    a, b, c = arr(xs), arr(ys), arr(ys[::-1])
+    one = arr([1] * len(xs))
+
+    # Addition is XOR (characteristic 2).
+    for i, (x, y) in enumerate(zip(xs, ys)):
+      self.assertEqual(
+          int((a + b)[i]), (x & mask) ^ (y & mask), f"L{level} xor {i}"
+      )
+
+    if level <= 7:
+      # Authoritative cross-check: an independent C++ kernel (the legacy tower
+      # dtype) multiplies the same bytes to the same result.
+      legacy = np.dtype(getattr(zk_dtypes, f"binary_field_t{level}"))
+      la, lb = np.zeros(len(xs), dtype=legacy), np.zeros(len(ys), dtype=legacy)
+      la.view(np.uint8)[:] = a.view(np.uint8)
+      lb.view(np.uint8)[:] = b.view(np.uint8)
+      np.testing.assert_array_equal(
+          (a * b).view(np.uint8), (la * lb).view(np.uint8)
+      )
+
+    # Basis-independent field axioms — the only reference available for levels
+    # > 7 (no legacy dtype), and enough to catch a wrong Karatsuba recombination
+    # or reduction: identity, commutativity, distributivity over XOR.
+    np.testing.assert_array_equal((a * one).view(np.uint8), a.view(np.uint8))
+    np.testing.assert_array_equal(
+        (a * b).view(np.uint8), (b * a).view(np.uint8)
+    )
+    np.testing.assert_array_equal(
+        (a * (b + c)).view(np.uint8), ((a * b) + (a * c)).view(np.uint8)
+    )
+
+
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
Closes #143

Adds runtime field registration so a user-defined prime — or extension /
binary-tower field, or EC point group — gets a working numpy dtype with **zero
per-field C++**, on top of the already-modulus-generic compiler stack.

```python
f = zk_dtypes.prime_field(0x3b9aca07)      # 10**9+7, any prime
x = np.array([1, 2, 3], dtype=f)
```

## What's here

- **`prime_field` / `extension_field` / `binary_field` factories** — Miller-Rabin
  primality gate, storage-width round-up {32,64,128,256}, curated families
  (babybear/koalabear/goldilocks/mersenne31/bn254_sf + extensions, binary t0–t7)
  resolve to their existing legacy dtype; a novel field mints a parametric one.
- **NEP-42 parametric `FieldDType`** (one numpy DType for every field; each
  descriptor instance carries modulus/degree/non_residue/width/storage) and a
  separate **`EcPointDType`** (G1/G2 Jacobian group law, scalar-mul, group
  equality, coordinate-rep casts).
- **Storage and arithmetic byte-match the legacy per-family dtypes** —
  babybear/koalabear/goldilocks/mersenne31/bn254 scalar field, the binomial
  extensions, binary towers t0–t7, and bn254 G1/G2.

## Additive — the old way is untouched

Registered alongside the legacy named dtypes; every legacy symbol (incl. the 39
`*_mont` variants) is retained. Verified against the ZKX jax stack: jax binds the
identical legacy dtype set (the parametric DTypes are invisible to it), and the
jax/zorch suites are byte-identical between this branch and plain `main`.

## Performance

Host arithmetic runs natively (fixed-width Montgomery, modulus from the
descriptor) — **on-par with or faster than the legacy compile-time dtypes** for
every prime field, the binary tower mul, the EF mul, and the EC group law; bn254
EC group add/sub beat legacy (~0.94×), scalar-mul ~1.05×. Curated families take
the legacy path regardless; production compute stays on device.

## Sequencing

Lands on `main` **before** the XLA/JAX parametric consumption
(fractalyze/xla_fork#32) — zk_dtypes is the leaf dependency; the device path is
already modulus-generic.

---

**Draft notes (not ready to merge):**
- Needs a **rebase**: `main` advanced past the branch base (0.0.7 bump #142,
  Pallas/Vesta #141, EC-dtype-info refactor #138) — the #138 EC-info change may
  touch the EC dtype surface this branch extends; rebase + re-run the byte-match
  suite before merging.
- Full suite green (5440 passed) at the current base.

---

Supersedes #144 (same feature, rebased history — that PR's head could not be
fast-forwarded). On top of the #144 series this adds, from the continued work:

- **Native fixed-width host arithmetic** for parametric fields and EC points
  (typed contiguous loops, branchless modular add/sub, typed extension-field
  multiply, typed-limb 256-bit group law) — parametric dtypes now track the
  legacy per-family kernels' performance shape instead of a generic slow path.
- **Both storage forms** (`canonical` / `mont`) resolvable for curated
  families, with a Montgomery-storage-only guard on the Montgomery ext-mul
  kernel and an inefficiency warning for Goldilocks Montgomery storage.
- Review fixes (correctness pass, curated-map sync with the legacy stack,
  Fp2 tuple coordinates in EC setitem) and a parametric-kernel **coverage
  matrix test across widths and storage forms**.

Verified: rebased onto current `main` (clean, zero conflicts; strictly
additive `+5,059/−0` across 11 files) and `bazel test //...` passes 14/14.
