### PR TITLE
fix(field): keep curated dtype resolution test green under strict warnings

### DIFF
--- a/zk_dtypes/tests/prime_field_factory_test.py
+++ b/zk_dtypes/tests/prime_field_factory_test.py
@@ -45,10 +45,13 @@ class PrimeFieldFactoryTest(parameterized.TestCase):
   @parameterized.parameters(*_CURATED_CASES)
   def test_curated_resolves_to_existing_type(self, modulus, storage, expected):
     # A curated prime keeps its legacy dtype so the non-parametric stack still
-    # recognizes it.
-    self.assertEqual(
-        zk_dtypes.prime_field(modulus, storage), np.dtype(expected)
-    )
+    # recognizes it. Storage-efficiency advisories are orthogonal to which
+    # dtype comes back, so they do not bear on this assertion.
+    with warnings.catch_warnings():
+      warnings.simplefilter("ignore", DeprecationWarning)
+      self.assertEqual(
+          zk_dtypes.prime_field(modulus, storage), np.dtype(expected)
+      )
 
   def test_storage_aliases_agree(self):
     self.assertEqual(


### PR DESCRIPTION
## What broke

The `Release` run for 0.0.13 failed on both `Build / Linux x86_64` and
`Build / macOS arm64`, at cibuildwheel's test step:

```
FAILED zk_dtypes/tests/prime_field_factory_test.py::PrimeFieldFactoryTest::test_curated_resolves_to_existing_type2
FAILED zk_dtypes/tests/prime_field_factory_test.py::PrimeFieldFactoryTest::test_curated_resolves_to_existing_type2_multi_threaded
2 failed, 7682 passed, 52 skipped
```

Both wheels build fine; only the test phase fails, so no artifacts are
produced and `Publish` never runs.

## Why

`prime_field()` warns when asked for Goldilocks in Montgomery storage —
that field has a fast Solinas reduction and no spare bit in its 64-bit
storage, so Montgomery form is slower than canonical. `pytest.ini` sets
`filterwarnings = error`, so the intended `DeprecationWarning` became a
test failure on the `(Goldilocks, mont)` entry of `_CURATED_CASES`, even
though the dtype returned was correct.

## The change

`test_curated_resolves_to_existing_type` asserts *which dtype* a curated
prime resolves to. The storage advisory is a separate contract with its
own test, so this suppresses `DeprecationWarning` around the assertion
and keeps the two independent.

The alternative — dropping the `(Goldilocks, mont)` row from
`_CURATED_CASES` — would silently lose coverage that Montgomery
Goldilocks still resolves to its legacy `goldilocks_mont` dtype, so the
parameter is kept.

## Verification

Built the extension and ran the suite the way cibuildwheel does
(neutral cwd, absolute path, `configfile: pytest.ini` confirmed active):

- With the fix reverted, the two failures reproduce exactly.
- With the fix: **7684 passed, 52 skipped**, 0 failed.
- The affected file run 25× to check the `catch_warnings` /
  `@multi_threaded(num_workers=3)` interaction: 0 flakes.
- `pyink --check` reports nothing on the changed hunk.

## Two follow-ups this uncovered

Neither is addressed here; both need a decision.

1. **`__version__` regressed.** `zk_dtypes/__init__.py` on `main` reads
   `0.0.11`, but `v0.0.12` shipped. Commit f629175 carried the older
   value back over the `chore: release 0.0.12` bump. The failed run was
   a `workflow_dispatch`, which skips the tag check — a genuine
   tag-triggered `v0.0.13` release would fail `Check tag matches
   packaged version` before building anything.

2. **CI never runs this suite.** No workflow under `.github/workflows/`
   invokes `pytest`; the Python tests execute only inside
   cibuildwheel's `test-command` at release time. That is why the
   parametric dtype factory PR was green on CI and only detonated when
   the release was cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)