### PR TITLE
chore: release 0.0.13

### DIFF
--- a/zk_dtypes/__init__.py
+++ b/zk_dtypes/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==============================================================================
 
-__version__ = "0.0.11"
+__version__ = "0.0.13"
 __all__ = [
     "__version__",
     "binary_field",


### PR DESCRIPTION
Bumps the packaged version to 0.0.13 so the tag-triggered release can run.

`pyproject.toml` derives the distribution version via
`version = { attr = "zk_dtypes.__version__" }`, so the literal in
`zk_dtypes/__init__.py` is the single source, and release.yml's
`Check tag matches packaged version` gate reads exactly it.

## This also repairs a regression

The literal read `0.0.11` on `main` even though `v0.0.12` shipped to
PyPI. The parametric dtype factory branch predated the 0.0.12 bump and
carried the older value back over it on merge. Cutting `v0.0.13` against
that stale literal would fail the tag-versus-packaged-version gate before
anything was built.

That gate is skipped on `workflow_dispatch` (a dispatch has no tag to
compare), which is why the earlier dispatched Release run got as far as
building wheels instead of stopping here.

## Contents since 0.0.12

- User-defined prime fields and elliptic curve points resolved at runtime
  through a NEP-42 parametric numpy dtype.
- Curated dtype resolution test no longer fails under
  `filterwarnings = error` on the Montgomery Goldilocks parameter (#168),
  which is what broke the previous release attempt.

No library change in this PR; one file, one literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)