### PR TITLE
feat(field): expose the runtime-modulus prime field as a consumable C++ library

### DIFF
--- a/zk_dtypes/BUILD.bazel
+++ b/zk_dtypes/BUILD.bazel
@@ -470,6 +470,7 @@ cc_library(
     deps = [
         ":big_int",
         ":binary_field_multiplication",
+        ":bits",
         ":modular_operations",
         ":mont_multiplication",
     ],

--- a/zk_dtypes/BUILD.bazel
+++ b/zk_dtypes/BUILD.bazel
@@ -462,6 +462,19 @@ cc_library(
     ],
 )
 
+# Deliberately free of numpy and the Python C API: the parametric DTypes are one
+# consumer, a compiler materializing field constants is another.
+cc_library(
+    name = "runtime_field",
+    hdrs = ["include/field/runtime_field.h"],
+    deps = [
+        ":big_int",
+        ":binary_field_multiplication",
+        ":modular_operations",
+        ":mont_multiplication",
+    ],
+)
+
 cc_library(
     name = "karatsuba_operation",
     hdrs = ["include/field/karatsuba_operation.h"],
@@ -1185,7 +1198,6 @@ cc_library(
         "_src/ec_point_numpy.h",
         "_src/field_dtype.cc",
         "_src/field_dtype.h",
-        "_src/field_modarith.h",
         "_src/field_numpy.h",
         "_src/int_caster.cc",
         "_src/int_caster.h",
@@ -1199,6 +1211,7 @@ cc_library(
     deps = [
         ":all_types",
         ":intn",
+        ":runtime_field",
         ":signed_big_int",
         "//third_party/py/numpy:headers",
         "@com_google_absl//absl/log",

--- a/zk_dtypes/BUILD.bazel
+++ b/zk_dtypes/BUILD.bazel
@@ -593,6 +593,7 @@ cc_test(
         "tests/field/goldilocksx3_unittest.cc",
         "tests/field/prime_field_unittest.cc",
         "tests/field/root_of_unity_unittest.cc",
+        "tests/field/runtime_field_unittest.cc",
         "tests/field/square_root_algorithms_unittest.cc",
     ],
     deps = [
@@ -601,6 +602,7 @@ cc_test(
         ":mersenne31x2x2",
         ":random",
         ":root_of_unity",
+        ":runtime_field",
         ":sw_test_curve_config",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",

--- a/zk_dtypes/_src/ec_point_dtype.cc
+++ b/zk_dtypes/_src/ec_point_dtype.cc
@@ -483,7 +483,7 @@ constexpr int kCoordBytes = 64;  // max coordinate: Fp2 over 256-bit base
 
 // One coordinate field (Fq for G1, Fp2 for G2) over a Montgomery base field.
 struct CoordField {
-  modarith::PrimeField fq;
+  runtime_field::RuntimeField fq;
   int degree = 1;                   // 1 = Fq, 2 = Fp2
   int wb = 0;                       // base-field width in bytes
   int cb = 0;                       // coordinate width = degree * wb
@@ -503,7 +503,7 @@ struct CoordField {
       PyErr_Clear();
       return cf;
     }
-    cf.fq = modarith::PrimeField::Make(mod_le, cf.wb, /*is_mont=*/true);
+    cf.fq = runtime_field::RuntimeField::Make(mod_le, cf.wb, /*is_mont=*/true);
     if (!cf.fq.native) return cf;
     // The native EC temporaries are fixed kCoordBytes stack buffers (= 2*32,
     // the Fp2-over-256-bit max). degree<=2 and a native base width<=32 keep cb

--- a/zk_dtypes/_src/ec_point_dtype.cc
+++ b/zk_dtypes/_src/ec_point_dtype.cc
@@ -41,7 +41,7 @@ limitations under the License.
 
 #include "zk_dtypes/_src/ec_group_law.h"
 #include "zk_dtypes/_src/field_dtype.h"
-#include "zk_dtypes/_src/field_modarith.h"
+#include "zk_dtypes/include/field/runtime_field.h"
 #include "zk_dtypes/_src/nep42_common.h"
 #include "zk_dtypes/_src/pyfield_ops.h"
 #include "zk_dtypes/_src/numpy.h"

--- a/zk_dtypes/_src/field_dtype.cc
+++ b/zk_dtypes/_src/field_dtype.cc
@@ -40,7 +40,7 @@ limitations under the License.
 #include <vector>
 #include <cstring>
 
-#include "zk_dtypes/_src/field_modarith.h"
+#include "zk_dtypes/include/field/runtime_field.h"
 #include "zk_dtypes/_src/nep42_common.h"
 #include "zk_dtypes/_src/numpy.h"
 #include "zk_dtypes/_src/pyfield_ops.h"

--- a/zk_dtypes/_src/field_dtype.cc
+++ b/zk_dtypes/_src/field_dtype.cc
@@ -1364,10 +1364,10 @@ int ArithLoop(PyArrayMethod_Context* context, char* const* data,
     }
     if (d->tower_level <= 7) {  // native recursive Karatsuba tower multiply
       for (npy_intp i = 0; i < n; ++i) {
-        modarith::BinaryTowerMul(d->tower_level,
-                                 reinterpret_cast<const unsigned char*>(a),
-                                 reinterpret_cast<const unsigned char*>(b),
-                                 reinterpret_cast<unsigned char*>(o));
+        runtime_field::BinaryTowerMul(d->tower_level,
+                                      reinterpret_cast<const unsigned char*>(a),
+                                      reinterpret_cast<const unsigned char*>(b),
+                                      reinterpret_cast<unsigned char*>(o));
         Advance(a, b, o, strides);
       }
       return 0;
@@ -1398,8 +1398,8 @@ int ArithLoop(PyArrayMethod_Context* context, char* const* data,
   // Odd field: native fixed-width path where supported, Python-int otherwise.
   unsigned char mod_le[32];
   if (pyfield::LongAsBytesLE(d->modulus, mod_le, wb) >= 0) {
-    modarith::PrimeField pf =
-        modarith::PrimeField::Make(mod_le, wb, d->is_montgomery);
+    runtime_field::RuntimeField pf =
+        runtime_field::RuntimeField::Make(mod_le, wb, d->is_montgomery);
     const int k = d->degree;
     // Add/sub: a monomorphic typed loop at single-word widths
     // (auto-vectorizes), BigInt per-element at 128/256-bit. Prime (k == 1) and

--- a/zk_dtypes/include/field/runtime_field.h
+++ b/zk_dtypes/include/field/runtime_field.h
@@ -13,17 +13,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#ifndef ZK_DTYPES__SRC_FIELD_MODARITH_H_
-#define ZK_DTYPES__SRC_FIELD_MODARITH_H_
+#ifndef ZK_DTYPES_INCLUDE_FIELD_RUNTIME_FIELD_H_
+#define ZK_DTYPES_INCLUDE_FIELD_RUNTIME_FIELD_H_
 
-// Native fixed-width modular arithmetic for the parametric numpy DTypes, with
-// the modulus supplied at runtime (the loops in field_dtype.cc / ec_point_dtype
-// .cc can't bake it at compile time). It reuses zk_dtypes' own Montgomery and
-// modular-add/sub kernels (field/mont_multiplication.h,
-// field/modular_operations .h) — the same code the legacy compile-time field
-// configs use — so a native result is byte-identical to the legacy dtype by
-// construction. The only piece not provided by those headers is n' = -p^-1 mod
-// 2^w, computed here by Newton-Hensel lifting.
+// Native fixed-width modular arithmetic with the modulus supplied at runtime,
+// for callers that cannot bake it in at compile time: the parametric numpy
+// DTypes (the loops in field_dtype.cc / ec_point_dtype.cc), and compilers
+// materializing constants for a field chosen by a user rather than curated
+// here.
+//
+// It reuses zk_dtypes' own Montgomery and modular-add/sub kernels
+// (field/mont_multiplication.h, field/modular_operations.h) — the same code the
+// compile-time field configs use — so a runtime result is byte-identical to the
+// corresponding curated type by construction, not by testing. That equivalence
+// is the point: a consumer can serve an arbitrary modulus without its curated
+// results changing. The only piece not provided by those headers is
+// n' = -p^-1 mod 2^w, computed here by Newton-Hensel lifting.
 //
 // Storage matches the legacy types: a base-field element is `width_bytes`
 // little-endian, Montgomery-encoded (c*R mod p, R = 2^(width_bytes*8)) for the
@@ -355,4 +360,4 @@ inline bool BinaryTowerMul(int level, const unsigned char* a,
 }  // namespace modarith
 }  // namespace zk_dtypes
 
-#endif  // ZK_DTYPES__SRC_FIELD_MODARITH_H_
+#endif  // ZK_DTYPES_INCLUDE_FIELD_RUNTIME_FIELD_H_

--- a/zk_dtypes/include/field/runtime_field.h
+++ b/zk_dtypes/include/field/runtime_field.h
@@ -81,6 +81,7 @@ struct PrimeField {
     PrimeField f;
     f.width_bytes = width_bytes;
     f.is_mont = is_mont;
+    std::memcpy(f.p_le, mod_le, width_bytes);
     uint64_t low = 0;
     std::memcpy(&low, mod_le, width_bytes < 8 ? width_bytes : 8);
     f.inv = ComputeInverse(low);
@@ -277,6 +278,223 @@ struct PrimeField {
       CanonMulBytes(a, b, o);
     }
   }
+
+  // --- values a caller needs to compute with, not just combine -------------
+  //
+  // The four above take stored representatives and hand back stored
+  // representatives, which is all a numpy ufunc loop needs. Materializing a
+  // constant needs more: an identity to start from, a way in and out of the
+  // storage encoding, and exponentiation.
+
+  // Multiplicative identity in storage form: canonical 1, or R mod p when
+  // Montgomery-encoded.
+  void One(unsigned char* o) const {
+    std::memset(o, 0, width_bytes);
+    o[0] = 1;
+    if (!is_mont) return;
+    // R mod p = 2^(8*width_bytes) mod p, by that many modular doublings of 1.
+    // ModAdd is the same kernel the stored values use, so no separate reduction
+    // path can disagree with it.
+    for (int i = 0; i < width_bytes * 8; ++i) Add(o, o, o);
+  }
+
+  // Canonical residue -> stored. Identity for canonical storage; c*R mod p for
+  // Montgomery, via MontMul(c, R^2) = c*R^2*R^-1.
+  void Encode(const unsigned char* c, unsigned char* o) const {
+    if (!is_mont) {
+      std::memcpy(o, c, width_bytes);
+      return;
+    }
+    unsigned char r2[kMaxWidthBytes];
+    std::memset(r2, 0, width_bytes);
+    r2[0] = 1;
+    for (int i = 0; i < width_bytes * 16; ++i) Add(r2, r2, r2);  // 2^(2w) mod p
+    MontMulBytes(c, r2, o);
+  }
+
+  // Stored -> canonical residue. MontMul(x, 1) = x*1*R^-1 undoes the encoding
+  // without needing R^-1 as a separate value.
+  void Decode(const unsigned char* x, unsigned char* o) const {
+    if (!is_mont) {
+      std::memcpy(o, x, width_bytes);
+      return;
+    }
+    unsigned char one_le[kMaxWidthBytes];
+    std::memset(one_le, 0, width_bytes);
+    one_le[0] = 1;
+    MontMulBytes(x, one_le, o);
+  }
+
+  // o = base^exp on stored representatives, exp little-endian. Square and
+  // multiply, most-significant bit first.
+  void Pow(const unsigned char* base, const unsigned char* exp_le,
+           int exp_bytes, unsigned char* o) const {
+    unsigned char acc[kMaxWidthBytes];
+    unsigned char b[kMaxWidthBytes];
+    One(acc);
+    std::memcpy(b, base, width_bytes);
+    int top = exp_bytes - 1;
+    while (top >= 0 && exp_le[top] == 0) --top;
+    if (top < 0) {  // exp == 0
+      std::memcpy(o, acc, width_bytes);
+      return;
+    }
+    bool started = false;
+    for (int byte = top; byte >= 0; --byte) {
+      for (int bit = 7; bit >= 0; --bit) {
+        if (started) Mul(acc, acc, acc);
+        if ((exp_le[byte] >> bit) & 1) {
+          if (started) {
+            Mul(acc, b, acc);
+          } else {
+            std::memcpy(acc, b, width_bytes);
+            started = true;
+          }
+        }
+      }
+    }
+    std::memcpy(o, acc, width_bytes);
+  }
+
+  void Pow(const unsigned char* base, uint64_t exp, unsigned char* o) const {
+    unsigned char e[8];
+    for (int i = 0; i < 8; ++i)
+      e[i] = static_cast<unsigned char>(exp >> (8 * i));
+    Pow(base, e, 8, o);
+  }
+
+  // Number of factors of two in p-1, i.e. the largest k with a 2^k-th root of
+  // unity. p is odd, so p-1 only clears the low bit of the low limb.
+  int TwoAdicity() const {
+    int adicity = 0;
+    for (int byte = 0; byte < width_bytes; ++byte) {
+      unsigned char v = p_le[byte];
+      if (byte == 0) v = static_cast<unsigned char>(v - 1);  // p odd
+      if (v != 0) {
+        while ((v & 1) == 0) {
+          ++adicity;
+          v = static_cast<unsigned char>(v >> 1);
+        }
+        return adicity;
+      }
+      adicity += 8;
+    }
+    return adicity;
+  }
+
+  // A primitive n-th root of unity for n a power of two dividing
+  // 2^TwoAdicity(), written to `o` in storage form. False when no such root
+  // exists.
+  //
+  // `generator` pins the subgroup generator g and yields g^((p-1)/n) — the form
+  // a caller uses to reproduce a specific root. 0 selects the smallest
+  // quadratic non-residue instead, which is deterministic but is NOT in general
+  // the root a curated config stores: those hold a chosen constant, and any of
+  // the φ(n) primitive n-th roots is as valid. A caller that needs a particular
+  // one must pin the generator.
+  bool RootOfUnity(uint64_t n, uint64_t generator, unsigned char* o) const {
+    if (n == 0 || (n & (n - 1)) != 0) return false;  // not a power of two
+    int log_n = 0;
+    while ((uint64_t{1} << log_n) < n) ++log_n;
+    if (log_n > TwoAdicity()) return false;
+
+    unsigned char exp[kMaxWidthBytes];  // (p-1) >> log_n
+    std::memcpy(exp, p_le, width_bytes);
+    exp[0] = static_cast<unsigned char>(exp[0] - 1);  // p odd
+    ShiftRight(exp, log_n);
+
+    unsigned char g[kMaxWidthBytes];
+    if (generator != 0) {
+      SetSmall(g, generator);
+      Pow(g, exp, width_bytes, o);
+      // A pinned generator is the caller's assertion, not a fact: g = 1 raises
+      // to 1 for every n, and any g that is a square gives a root of smaller
+      // order. Both would return a plausible value that silently corrupts every
+      // butterfly downstream, so the order is checked rather than assumed.
+      return HasOrder(o, n);
+    }
+    // g is a quadratic non-residue iff g^((p-1)/2) == -1; that makes
+    // g^((p-1)/2^k) have order exactly 2^k. Small candidates suffice — the
+    // non-residues have density 1/2.
+    unsigned char half[kMaxWidthBytes];
+    std::memcpy(half, p_le, width_bytes);
+    half[0] = static_cast<unsigned char>(half[0] - 1);
+    ShiftRight(half, 1);
+    unsigned char minus_one[kMaxWidthBytes];
+    unsigned char one_s[kMaxWidthBytes];
+    One(one_s);
+    std::memset(minus_one, 0, width_bytes);
+    Sub(minus_one, one_s, minus_one);  // 0 - 1 = p-1 in storage form
+    unsigned char probe[kMaxWidthBytes];
+    for (uint64_t cand = 2; cand < 4096; ++cand) {
+      SetSmall(g, cand);
+      Pow(g, half, width_bytes, probe);
+      if (std::memcmp(probe, minus_one, width_bytes) != 0) continue;
+      Pow(g, exp, width_bytes, o);
+      // Implied by the non-residue property; kept so both paths leave through
+      // the same guarantee rather than one of them by argument.
+      if (HasOrder(o, n)) return true;
+    }
+    return false;
+  }
+
+  // True when x has order exactly n: x^n == 1 and, for n > 1, x^(n/2) != 1.
+  // For n a power of two those two together are the whole condition, since any
+  // proper divisor of n divides n/2.
+  bool HasOrder(const unsigned char* x, uint64_t n) const {
+    unsigned char one_s[kMaxWidthBytes], acc[kMaxWidthBytes];
+    One(one_s);
+    Pow(x, n, acc);
+    if (std::memcmp(acc, one_s, width_bytes) != 0) return false;
+    if (n == 1) return true;
+    Pow(x, n / 2, acc);
+    return std::memcmp(acc, one_s, width_bytes) != 0;
+  }
+
+ private:
+  // Widest storage Make() accepts; sizes the scratch the helpers above use.
+  static constexpr int kMaxWidthBytes = 32;
+
+  // o = the storage-form element for the small canonical value v.
+  void SetSmall(unsigned char* o, uint64_t v) const {
+    // Reduced first: the kernels require inputs below the modulus, and a caller
+    // is free to hand over a generator that is not (p itself, say). Above 8
+    // bytes the modulus exceeds every uint64, so v is already reduced.
+    if (width_bytes == 4) {
+      v %= p32;
+    } else if (width_bytes == 8) {
+      v %= p64;
+    }
+    unsigned char c[kMaxWidthBytes];
+    std::memset(c, 0, width_bytes);
+    for (int i = 0; i < 8 && i < width_bytes; ++i) {
+      c[i] = static_cast<unsigned char>(v >> (8 * i));
+    }
+    Encode(c, o);
+  }
+
+  // In-place logical right shift of a little-endian buffer.
+  void ShiftRight(unsigned char* v, int bits) const {
+    while (bits >= 8) {
+      std::memmove(v, v + 1, width_bytes - 1);
+      v[width_bytes - 1] = 0;
+      bits -= 8;
+    }
+    if (bits == 0) return;
+    for (int i = 0; i < width_bytes; ++i) {
+      unsigned char hi =
+          (i + 1 < width_bytes)
+              ? static_cast<unsigned char>(v[i + 1] << (8 - bits))
+              : 0;
+      v[i] = static_cast<unsigned char>((v[i] >> bits) | hi);
+    }
+  }
+
+ public:
+  // Modulus, little-endian, exactly width_bytes. Kept so the exponent
+  // (p-1)/2^k and the adicity can be computed without the caller re-supplying
+  // it.
+  unsigned char p_le[kMaxWidthBytes] = {};
 };
 
 // Binary tower GF(2^(2^level)) multiply, levels 0..7 (1..128 bits). Returns

--- a/zk_dtypes/include/field/runtime_field.h
+++ b/zk_dtypes/include/field/runtime_field.h
@@ -41,12 +41,13 @@ limitations under the License.
 #include <cstring>
 
 #include "zk_dtypes/include/big_int.h"
+#include "zk_dtypes/include/bits.h"
 #include "zk_dtypes/include/field/binary_field_multiplication.h"
 #include "zk_dtypes/include/field/modular_operations.h"
 #include "zk_dtypes/include/field/mont_multiplication.h"
 
 namespace zk_dtypes {
-namespace modarith {
+namespace runtime_field {
 
 // p^-1 mod 2^64 from the low limb of p (p odd). Newton-Hensel doubles the
 // number of correct low bits each step: 3 -> 6 -> 12 -> 24 -> 48 -> 96 (>= 64).
@@ -60,9 +61,17 @@ inline uint64_t ComputeInverse(uint64_t p_low) {
 }
 
 // A prime base field of `width_bytes` (4/8/16/32) with a runtime modulus.
-// `native` is false when the (width, storage-form) combination is not handled
-// here and the caller must fall back to the generic Python-int path.
-struct PrimeField {
+//
+// `native` is false when this (width, storage-form) pair has no kernel here.
+// Add/Sub/Mul must not be called in that case — they have no default branch and
+// would leave the output untouched — so the caller has to supply its own
+// arbitrary-precision path.
+struct RuntimeField {
+  // Widest modulus a field may carry, and hence the size of every buffer these
+  // operations read or write. Public because a caller has no other way to size
+  // one, and every consumer otherwise hardcodes the same 32.
+  static constexpr int kMaxWidthBytes = 32;
+
   int width_bytes = 0;
   bool is_mont = false;
   bool native = false;      // prime add/sub/mul fully supported natively
@@ -75,10 +84,21 @@ struct PrimeField {
   uint64_t p64 = 0;
   BigInt<2> p128{};
   BigInt<4> p256{};
+  // Modulus, little-endian, exactly width_bytes. Kept so the exponent
+  // (p-1)/2^k and the adicity can be derived without the caller re-supplying
+  // it.
+  unsigned char p_le[kMaxWidthBytes] = {};
 
-  static PrimeField Make(const unsigned char* mod_le, int width_bytes,
-                         bool is_mont) {
-    PrimeField f;
+  static RuntimeField Make(const unsigned char* mod_le, int width_bytes,
+                           bool is_mont) {
+    RuntimeField f;
+    // Checked before anything reads mod_le: the widths below are the only ones
+    // with kernels, and a caller passing a user-chosen modulus can hand over
+    // any width at all.
+    if (width_bytes != 4 && width_bytes != 8 && width_bytes != 16 &&
+        width_bytes != 32) {
+      return f;  // width_bytes 0, native false — unusable, by construction
+    }
     f.width_bytes = width_bytes;
     f.is_mont = is_mont;
     std::memcpy(f.p_le, mod_le, width_bytes);
@@ -123,8 +143,6 @@ struct PrimeField {
         f.native = true;
         f.ext_native = false;
         break;
-      default:
-        f.native = false;
     }
     // Canonical (non-Montgomery) multiply is only implemented natively for the
     // single-word widths (a 128/256-bit reduce-by-division is deferred).
@@ -288,28 +306,16 @@ struct PrimeField {
 
   // Multiplicative identity in storage form: canonical 1, or R mod p when
   // Montgomery-encoded.
-  void One(unsigned char* o) const {
-    std::memset(o, 0, width_bytes);
-    o[0] = 1;
-    if (!is_mont) return;
-    // R mod p = 2^(8*width_bytes) mod p, by that many modular doublings of 1.
-    // ModAdd is the same kernel the stored values use, so no separate reduction
-    // path can disagree with it.
-    for (int i = 0; i < width_bytes * 8; ++i) Add(o, o, o);
-  }
+  void One(unsigned char* o) const { SetSmall(o, 1); }
 
   // Canonical residue -> stored. Identity for canonical storage; c*R mod p for
-  // Montgomery, via MontMul(c, R^2) = c*R^2*R^-1.
+  // Montgomery, which is c doubled 8*width_bytes times — R is 2^(8*width_bytes)
+  // and doubling is the ModAdd the stored values already use, so no separate
+  // reduction path can disagree with it.
   void Encode(const unsigned char* c, unsigned char* o) const {
-    if (!is_mont) {
-      std::memcpy(o, c, width_bytes);
-      return;
-    }
-    unsigned char r2[kMaxWidthBytes];
-    std::memset(r2, 0, width_bytes);
-    r2[0] = 1;
-    for (int i = 0; i < width_bytes * 16; ++i) Add(r2, r2, r2);  // 2^(2w) mod p
-    MontMulBytes(c, r2, o);
+    std::memcpy(o, c, width_bytes);
+    if (!is_mont) return;
+    for (int i = 0; i < width_bytes * 8; ++i) Add(o, o, o);
   }
 
   // Stored -> canonical residue. MontMul(x, 1) = x*1*R^-1 undoes the encoding
@@ -332,25 +338,17 @@ struct PrimeField {
     unsigned char acc[kMaxWidthBytes];
     unsigned char b[kMaxWidthBytes];
     One(acc);
+    // Copied because `base` may alias `o` — RootOfUnity relies on that.
     std::memcpy(b, base, width_bytes);
+    // Whole leading zero bytes are skipped; the up-to-seven leading zero bits
+    // inside the top byte only square the identity, so they cost nothing but a
+    // multiply and buy a loop without a "have we started" flag in it.
     int top = exp_bytes - 1;
     while (top >= 0 && exp_le[top] == 0) --top;
-    if (top < 0) {  // exp == 0
-      std::memcpy(o, acc, width_bytes);
-      return;
-    }
-    bool started = false;
     for (int byte = top; byte >= 0; --byte) {
       for (int bit = 7; bit >= 0; --bit) {
-        if (started) Mul(acc, acc, acc);
-        if ((exp_le[byte] >> bit) & 1) {
-          if (started) {
-            Mul(acc, b, acc);
-          } else {
-            std::memcpy(acc, b, width_bytes);
-            started = true;
-          }
-        }
+        Mul(acc, acc, acc);
+        if ((exp_le[byte] >> bit) & 1) Mul(acc, b, acc);
       }
     }
     std::memcpy(o, acc, width_bytes);
@@ -393,67 +391,71 @@ struct PrimeField {
   // the φ(n) primitive n-th roots is as valid. A caller that needs a particular
   // one must pin the generator.
   bool RootOfUnity(uint64_t n, uint64_t generator, unsigned char* o) const {
-    if (n == 0 || (n & (n - 1)) != 0) return false;  // not a power of two
-    int log_n = 0;
-    while ((uint64_t{1} << log_n) < n) ++log_n;
+    if (!IsPowerOf2(n)) return false;
+    const int log_n = static_cast<int>(Log2Ceiling(n));
     if (log_n > TwoAdicity()) return false;
 
-    unsigned char exp[kMaxWidthBytes];  // (p-1) >> log_n
-    std::memcpy(exp, p_le, width_bytes);
-    exp[0] = static_cast<unsigned char>(exp[0] - 1);  // p odd
-    ShiftRight(exp, log_n);
-
     unsigned char g[kMaxWidthBytes];
-    if (generator != 0) {
+    if (generator == 0) {
+      if (!FindNonResidue(g)) return false;
+    } else {
       SetSmall(g, generator);
-      Pow(g, exp, width_bytes, o);
-      // A pinned generator is the caller's assertion, not a fact: g = 1 raises
-      // to 1 for every n, and any g that is a square gives a root of smaller
-      // order. Both would return a plausible value that silently corrupts every
-      // butterfly downstream, so the order is checked rather than assumed.
-      return HasOrder(o, n);
     }
-    // g is a quadratic non-residue iff g^((p-1)/2) == -1; that makes
-    // g^((p-1)/2^k) have order exactly 2^k. Small candidates suffice — the
-    // non-residues have density 1/2.
-    unsigned char half[kMaxWidthBytes];
-    std::memcpy(half, p_le, width_bytes);
-    half[0] = static_cast<unsigned char>(half[0] - 1);
-    ShiftRight(half, 1);
-    unsigned char minus_one[kMaxWidthBytes];
-    unsigned char one_s[kMaxWidthBytes];
-    One(one_s);
-    std::memset(minus_one, 0, width_bytes);
-    Sub(minus_one, one_s, minus_one);  // 0 - 1 = p-1 in storage form
-    unsigned char probe[kMaxWidthBytes];
-    for (uint64_t cand = 2; cand < 4096; ++cand) {
-      SetSmall(g, cand);
-      Pow(g, half, width_bytes, probe);
-      if (std::memcmp(probe, minus_one, width_bytes) != 0) continue;
-      Pow(g, exp, width_bytes, o);
-      // Implied by the non-residue property; kept so both paths leave through
-      // the same guarantee rather than one of them by argument.
-      if (HasOrder(o, n)) return true;
-    }
-    return false;
+    unsigned char exp[kMaxWidthBytes];
+    PMinusOneShiftedRight(exp, log_n);
+    Pow(g, exp, width_bytes, o);
+    // A pinned generator is the caller's assertion, not a fact: g = 1 raises to
+    // 1 for every n, and any g that is a square gives a root of smaller order.
+    // Both would return a plausible value that silently corrupts every
+    // butterfly downstream, so the order is checked rather than assumed. For a
+    // found non-residue the check is implied, and going through it anyway is
+    // what makes "both paths carry the same guarantee" a fact about the code
+    // rather than an argument about it.
+    return HasOrder(o, n);
   }
 
-  // True when x has order exactly n: x^n == 1 and, for n > 1, x^(n/2) != 1.
-  // For n a power of two those two together are the whole condition, since any
-  // proper divisor of n divides n/2.
+  // True when x has order exactly n. For n a power of two, x^(n/2) decides it:
+  // every proper divisor of n divides n/2, so an order below n shows up there,
+  // and squaring that value is the rest of the test.
   bool HasOrder(const unsigned char* x, uint64_t n) const {
     unsigned char one_s[kMaxWidthBytes], acc[kMaxWidthBytes];
     One(one_s);
-    Pow(x, n, acc);
-    if (std::memcmp(acc, one_s, width_bytes) != 0) return false;
-    if (n == 1) return true;
+    if (n == 1) {
+      return std::memcmp(x, one_s, width_bytes) == 0;
+    }
     Pow(x, n / 2, acc);
-    return std::memcmp(acc, one_s, width_bytes) != 0;
+    if (std::memcmp(acc, one_s, width_bytes) == 0) return false;
+    Mul(acc, acc, acc);  // x^n
+    return std::memcmp(acc, one_s, width_bytes) == 0;
   }
 
  private:
-  // Widest storage Make() accepts; sizes the scratch the helpers above use.
-  static constexpr int kMaxWidthBytes = 32;
+  // (p-1) >> bits, little-endian. p is odd, so p-1 only clears the low bit.
+  void PMinusOneShiftedRight(unsigned char* o, int bits) const {
+    std::memcpy(o, p_le, width_bytes);
+    o[0] = static_cast<unsigned char>(o[0] - 1);
+    ShiftRight(o, bits);
+  }
+
+  // The smallest quadratic non-residue, in storage form. g is one iff
+  // g^((p-1)/2) == -1, and that is exactly what makes g^((p-1)/2^k) have order
+  // 2^k. Small candidates suffice — non-residues have density 1/2 — and the
+  // bound only stops a search that cannot terminate because the modulus is not
+  // prime.
+  bool FindNonResidue(unsigned char* g) const {
+    unsigned char half[kMaxWidthBytes], probe[kMaxWidthBytes];
+    unsigned char minus_one[kMaxWidthBytes], one_s[kMaxWidthBytes];
+    PMinusOneShiftedRight(half, 1);
+    One(one_s);
+    std::memset(minus_one, 0, width_bytes);
+    Sub(minus_one, one_s, minus_one);  // p-1 in storage form
+    for (uint64_t cand = 2; cand < 4096; ++cand) {
+      SetSmall(g, cand);
+      Pow(g, half, width_bytes, probe);
+      if (std::memcmp(probe, minus_one, width_bytes) == 0) return true;
+    }
+    return false;
+  }
 
   // o = the storage-form element for the small canonical value v.
   void SetSmall(unsigned char* o, uint64_t v) const {
@@ -489,12 +491,6 @@ struct PrimeField {
       v[i] = static_cast<unsigned char>((v[i] >> bits) | hi);
     }
   }
-
- public:
-  // Modulus, little-endian, exactly width_bytes. Kept so the exponent
-  // (p-1)/2^k and the adicity can be computed without the caller re-supplying
-  // it.
-  unsigned char p_le[kMaxWidthBytes] = {};
 };
 
 // Binary tower GF(2^(2^level)) multiply, levels 0..7 (1..128 bits). Returns
@@ -575,7 +571,7 @@ inline bool BinaryTowerMul(int level, const unsigned char* a,
   }
 }
 
-}  // namespace modarith
+}  // namespace runtime_field
 }  // namespace zk_dtypes
 
 #endif  // ZK_DTYPES_INCLUDE_FIELD_RUNTIME_FIELD_H_

--- a/zk_dtypes/tests/field/runtime_field_unittest.cc
+++ b/zk_dtypes/tests/field/runtime_field_unittest.cc
@@ -1,0 +1,242 @@
+/* Copyright 2026 The zk_dtypes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "zk_dtypes/include/field/runtime_field.h"
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "zk_dtypes/include/field/babybear/babybear.h"
+#include "zk_dtypes/include/field/koalabear/koalabear.h"
+
+namespace zk_dtypes {
+namespace {
+
+using modarith::PrimeField;
+
+// The runtime field is only worth having if it agrees with the compile-time
+// configs bit for bit — that is what lets a consumer serve an arbitrary modulus
+// without changing any curated result. These tests compare against the curated
+// types rather than against a reimplementation of modular arithmetic.
+template <typename F>
+PrimeField RuntimeOf() {
+  const auto modulus = F::Config::kModulus;
+  unsigned char le[32] = {};
+  constexpr int kWidth = sizeof(typename F::UnderlyingType);
+  std::memcpy(le, &modulus, kWidth <= 8 ? kWidth : 8);
+  return PrimeField::Make(le, kWidth, F::Config::kUseMontgomery);
+}
+
+// Stored bytes of a curated element, which is what the runtime path produces.
+template <typename F>
+std::vector<unsigned char> StoredBytes(const F& v) {
+  std::vector<unsigned char> out(sizeof(typename F::UnderlyingType));
+  const auto raw = v.value();
+  std::memcpy(out.data(), &raw, out.size());
+  return out;
+}
+
+TEST(RuntimeFieldTest, MulMatchesTheCuratedConfig) {
+  const PrimeField rt = RuntimeOf<BabybearMont>();
+  ASSERT_TRUE(rt.native);
+  for (uint64_t a = 1; a < 40; ++a) {
+    for (uint64_t b = 1; b < 40; ++b) {
+      const BabybearMont want = BabybearMont(a) * BabybearMont(b);
+      unsigned char ea[4], eb[4], got[4];
+      const auto ba = StoredBytes(BabybearMont(a));
+      const auto bb = StoredBytes(BabybearMont(b));
+      std::memcpy(ea, ba.data(), 4);
+      std::memcpy(eb, bb.data(), 4);
+      rt.Mul(ea, eb, got);
+      EXPECT_EQ(0, std::memcmp(got, StoredBytes(want).data(), 4))
+          << "a=" << a << " b=" << b;
+    }
+  }
+}
+
+TEST(RuntimeFieldTest, EncodeDecodeRoundTripsThroughTheStorageForm) {
+  for (const PrimeField rt :
+       {RuntimeOf<BabybearMont>(), RuntimeOf<KoalabearMont>()}) {
+    ASSERT_TRUE(rt.native);
+    for (uint64_t v = 0; v < 64; ++v) {
+      unsigned char canon[4] = {}, stored[4], back[4];
+      std::memcpy(canon, &v, 4);
+      rt.Encode(canon, stored);
+      rt.Decode(stored, back);
+      EXPECT_EQ(0, std::memcmp(canon, back, 4)) << "v=" << v;
+    }
+  }
+}
+
+// Encode has to agree with what the curated type stores, or a constant built
+// this way would be a different element than the same constant built there.
+TEST(RuntimeFieldTest, EncodeMatchesTheCuratedStorage) {
+  const PrimeField rt = RuntimeOf<BabybearMont>();
+  for (uint64_t v = 0; v < 64; ++v) {
+    unsigned char canon[4] = {}, stored[4];
+    std::memcpy(canon, &v, 4);
+    rt.Encode(canon, stored);
+    EXPECT_EQ(0, std::memcmp(stored, StoredBytes(BabybearMont(v)).data(), 4))
+        << "v=" << v;
+  }
+}
+
+TEST(RuntimeFieldTest, OneIsTheMultiplicativeIdentity) {
+  for (const PrimeField rt :
+       {RuntimeOf<BabybearMont>(), RuntimeOf<KoalabearMont>()}) {
+    unsigned char one[4], x[4], got[4];
+    rt.One(one);
+    for (uint64_t v = 1; v < 32; ++v) {
+      unsigned char canon[4] = {};
+      std::memcpy(canon, &v, 4);
+      rt.Encode(canon, x);
+      rt.Mul(x, one, got);
+      EXPECT_EQ(0, std::memcmp(got, x, 4)) << "v=" << v;
+    }
+  }
+}
+
+TEST(RuntimeFieldTest, PowMatchesTheCuratedConfig) {
+  const PrimeField rt = RuntimeOf<BabybearMont>();
+  for (uint64_t base = 2; base < 12; ++base) {
+    for (uint64_t e = 0; e < 20; ++e) {
+      unsigned char b[4], got[4];
+      std::memcpy(b, StoredBytes(BabybearMont(base)).data(), 4);
+      rt.Pow(b, e, got);
+      const BabybearMont want = BabybearMont(base).Pow(e);
+      EXPECT_EQ(0, std::memcmp(got, StoredBytes(want).data(), 4))
+          << "base=" << base << " e=" << e;
+    }
+  }
+}
+
+TEST(RuntimeFieldTest, TwoAdicityMatchesTheCuratedConfig) {
+  EXPECT_EQ(RuntimeOf<BabybearMont>().TwoAdicity(),
+            static_cast<int>(BabybearMont::Config::kTwoAdicity));
+  EXPECT_EQ(RuntimeOf<KoalabearMont>().TwoAdicity(),
+            static_cast<int>(KoalabearMont::Config::kTwoAdicity));
+}
+
+// ML-KEM's 3329 is the reason a runtime field is needed at all: 2-adicity 8
+// means it has no 512th root of unity, so a length-256 negacyclic transform is
+// arithmetically impossible over it while a length-128 one is fine. No curated
+// config covers this modulus.
+TEST(RuntimeFieldTest, MlKemTwoAdicityBoundsTheTransformLength) {
+  unsigned char le[32] = {};
+  const uint32_t q = 3329;
+  std::memcpy(le, &q, 4);
+  const PrimeField rt = PrimeField::Make(le, 4, /*is_mont=*/true);
+  ASSERT_TRUE(rt.native);
+  EXPECT_EQ(rt.TwoAdicity(), 8);
+
+  unsigned char root[4];
+  EXPECT_TRUE(rt.RootOfUnity(256, /*generator=*/0, root));   // length-128 nega
+  EXPECT_FALSE(rt.RootOfUnity(512, /*generator=*/0, root));  // length-256 nega
+}
+
+// ML-DSA's 8380417 is the other modulus driving this work, and unlike ML-KEM's
+// it has room to spare: 2-adicity 13 covers a length-256 negacyclic transform
+// (which needs a 512th root) with seven layers left over. No curated config
+// covers it either.
+TEST(RuntimeFieldTest, MlDsaSupportsTheFullTransformLength) {
+  unsigned char le[32] = {};
+  const uint32_t q = 8380417;
+  std::memcpy(le, &q, 4);
+  const PrimeField rt = PrimeField::Make(le, 4, /*is_mont=*/true);
+  ASSERT_TRUE(rt.native);
+  EXPECT_EQ(rt.TwoAdicity(), 13);
+
+  unsigned char root[4];
+  EXPECT_TRUE(rt.RootOfUnity(512, /*generator=*/0, root));  // length-256 nega
+  EXPECT_TRUE(rt.RootOfUnity(8192, /*generator=*/0, root));
+  EXPECT_FALSE(rt.RootOfUnity(16384, /*generator=*/0, root));
+
+  // The round trip the two motivating moduli have to survive.
+  for (uint64_t v : {1, 2, 1234, 8380416}) {
+    unsigned char canon[4] = {}, stored[4], back[4], sq[4];
+    const uint32_t v32 = static_cast<uint32_t>(v);
+    std::memcpy(canon, &v32, 4);
+    rt.Encode(canon, stored);
+    rt.Mul(stored, stored, sq);
+    rt.Decode(sq, back);
+    uint32_t got = 0;
+    std::memcpy(&got, back, 4);
+    EXPECT_EQ(got, static_cast<uint32_t>((v * v) % q)) << "v=" << v;
+  }
+}
+
+// A pinned generator is the caller's claim, not a checked fact, so RootOfUnity
+// has to reject the ones that produce a plausible but non-primitive value —
+// they would silently corrupt every butterfly built on the result.
+TEST(RuntimeFieldTest, PinnedGeneratorThatIsNotPrimitiveIsRejected) {
+  const PrimeField rt = RuntimeOf<BabybearMont>();
+  unsigned char root[4];
+  // 1^k == 1 for every k, so it "succeeds" at producing a value of order 1.
+  EXPECT_FALSE(rt.RootOfUnity(1024, /*generator=*/1, root));
+  // A square has no odd part left to reach order 2^k: 3 is a residue here.
+  EXPECT_FALSE(rt.RootOfUnity(1024, /*generator=*/3, root));
+  // Congruent to zero mod p, which reduces to 0 rather than running out of
+  // range through the kernels.
+  EXPECT_FALSE(rt.RootOfUnity(1024, /*generator=*/2013265921, root));
+  // n == 1 is the one case where the identity is the right answer.
+  EXPECT_TRUE(rt.RootOfUnity(1, /*generator=*/1, root));
+}
+
+// A root found by search is a *valid* primitive n-th root, not the specific one
+// a curated config stores — any of the phi(n) primitive roots is as correct.
+// What must hold is the defining property.
+TEST(RuntimeFieldTest, SearchedRootHasExactlyOrderN) {
+  for (const PrimeField rt :
+       {RuntimeOf<BabybearMont>(), RuntimeOf<KoalabearMont>()}) {
+    for (uint64_t n : {2, 4, 8, 256, 1024}) {
+      unsigned char root[4], acc[4], one[4];
+      ASSERT_TRUE(rt.RootOfUnity(n, /*generator=*/0, root)) << "n=" << n;
+      rt.One(one);
+      rt.Pow(root, n, acc);
+      EXPECT_EQ(0, std::memcmp(acc, one, 4)) << "root^n != 1, n=" << n;
+      if (n > 1) {
+        rt.Pow(root, n / 2, acc);
+        EXPECT_NE(0, std::memcmp(acc, one, 4))
+            << "root^(n/2) == 1, so order < n, n=" << n;
+      }
+    }
+  }
+}
+
+// Pinning the generator is the reproducible form: the same g and n must give
+// the same root every time, which is what a caller needing a *particular* root
+// uses instead of the search.
+TEST(RuntimeFieldTest, PinnedGeneratorIsDeterministic) {
+  const PrimeField rt = RuntimeOf<BabybearMont>();
+  unsigned char a[4], b[4];
+  ASSERT_TRUE(rt.RootOfUnity(1024, /*generator=*/31, a));
+  ASSERT_TRUE(rt.RootOfUnity(1024, /*generator=*/31, b));
+  EXPECT_EQ(0, std::memcmp(a, b, 4));
+
+  unsigned char one[4], acc[4];
+  rt.One(one);
+  rt.Pow(a, uint64_t{1024}, acc);
+  EXPECT_EQ(0, std::memcmp(acc, one, 4));
+  // a^1024 == 1 alone would also hold for the identity, so the order has to be
+  // pinned from below as well.
+  rt.Pow(a, uint64_t{512}, acc);
+  EXPECT_NE(0, std::memcmp(acc, one, 4));
+}
+
+}  // namespace
+}  // namespace zk_dtypes

--- a/zk_dtypes/tests/field/runtime_field_unittest.cc
+++ b/zk_dtypes/tests/field/runtime_field_unittest.cc
@@ -27,32 +27,39 @@ limitations under the License.
 namespace zk_dtypes {
 namespace {
 
-using modarith::PrimeField;
+using runtime_field::RuntimeField;
 
 // The runtime field is only worth having if it agrees with the compile-time
 // configs bit for bit — that is what lets a consumer serve an arbitrary modulus
 // without changing any curated result. These tests compare against the curated
 // types rather than against a reimplementation of modular arithmetic.
 template <typename F>
-PrimeField RuntimeOf() {
+RuntimeField RuntimeOf() {
   const auto modulus = F::Config::kModulus;
-  unsigned char le[32] = {};
-  constexpr int kWidth = sizeof(typename F::UnderlyingType);
-  std::memcpy(le, &modulus, kWidth <= 8 ? kWidth : 8);
-  return PrimeField::Make(le, kWidth, F::Config::kUseMontgomery);
+  unsigned char le[RuntimeField::kMaxWidthBytes] = {};
+  std::memcpy(le, &modulus, sizeof(modulus));
+  return RuntimeField::Make(le, F::kByteWidth, F::Config::kUseMontgomery);
+}
+
+// A runtime field for an arbitrary 4-byte modulus — the case no curated config
+// covers, and the reason this type exists.
+RuntimeField RuntimeOfModulus(uint32_t q) {
+  unsigned char le[RuntimeField::kMaxWidthBytes] = {};
+  std::memcpy(le, &q, sizeof(q));
+  return RuntimeField::Make(le, sizeof(q), /*is_mont=*/true);
 }
 
 // Stored bytes of a curated element, which is what the runtime path produces.
 template <typename F>
 std::vector<unsigned char> StoredBytes(const F& v) {
-  std::vector<unsigned char> out(sizeof(typename F::UnderlyingType));
+  std::vector<unsigned char> out(F::kByteWidth);
   const auto raw = v.value();
   std::memcpy(out.data(), &raw, out.size());
   return out;
 }
 
 TEST(RuntimeFieldTest, MulMatchesTheCuratedConfig) {
-  const PrimeField rt = RuntimeOf<BabybearMont>();
+  const RuntimeField rt = RuntimeOf<BabybearMont>();
   ASSERT_TRUE(rt.native);
   for (uint64_t a = 1; a < 40; ++a) {
     for (uint64_t b = 1; b < 40; ++b) {
@@ -70,7 +77,7 @@ TEST(RuntimeFieldTest, MulMatchesTheCuratedConfig) {
 }
 
 TEST(RuntimeFieldTest, EncodeDecodeRoundTripsThroughTheStorageForm) {
-  for (const PrimeField rt :
+  for (const RuntimeField rt :
        {RuntimeOf<BabybearMont>(), RuntimeOf<KoalabearMont>()}) {
     ASSERT_TRUE(rt.native);
     for (uint64_t v = 0; v < 64; ++v) {
@@ -86,7 +93,7 @@ TEST(RuntimeFieldTest, EncodeDecodeRoundTripsThroughTheStorageForm) {
 // Encode has to agree with what the curated type stores, or a constant built
 // this way would be a different element than the same constant built there.
 TEST(RuntimeFieldTest, EncodeMatchesTheCuratedStorage) {
-  const PrimeField rt = RuntimeOf<BabybearMont>();
+  const RuntimeField rt = RuntimeOf<BabybearMont>();
   for (uint64_t v = 0; v < 64; ++v) {
     unsigned char canon[4] = {}, stored[4];
     std::memcpy(canon, &v, 4);
@@ -97,7 +104,7 @@ TEST(RuntimeFieldTest, EncodeMatchesTheCuratedStorage) {
 }
 
 TEST(RuntimeFieldTest, OneIsTheMultiplicativeIdentity) {
-  for (const PrimeField rt :
+  for (const RuntimeField rt :
        {RuntimeOf<BabybearMont>(), RuntimeOf<KoalabearMont>()}) {
     unsigned char one[4], x[4], got[4];
     rt.One(one);
@@ -112,7 +119,7 @@ TEST(RuntimeFieldTest, OneIsTheMultiplicativeIdentity) {
 }
 
 TEST(RuntimeFieldTest, PowMatchesTheCuratedConfig) {
-  const PrimeField rt = RuntimeOf<BabybearMont>();
+  const RuntimeField rt = RuntimeOf<BabybearMont>();
   for (uint64_t base = 2; base < 12; ++base) {
     for (uint64_t e = 0; e < 20; ++e) {
       unsigned char b[4], got[4];
@@ -132,15 +139,11 @@ TEST(RuntimeFieldTest, TwoAdicityMatchesTheCuratedConfig) {
             static_cast<int>(KoalabearMont::Config::kTwoAdicity));
 }
 
-// ML-KEM's 3329 is the reason a runtime field is needed at all: 2-adicity 8
-// means it has no 512th root of unity, so a length-256 negacyclic transform is
-// arithmetically impossible over it while a length-128 one is fine. No curated
-// config covers this modulus.
+// 3329 has 2-adicity 8, so it has no 512th root of unity and a length-256
+// negacyclic transform is arithmetically impossible over it while a length-128
+// one is fine. That bound is why ML-KEM's transform is two length-128 NTTs.
 TEST(RuntimeFieldTest, MlKemTwoAdicityBoundsTheTransformLength) {
-  unsigned char le[32] = {};
-  const uint32_t q = 3329;
-  std::memcpy(le, &q, 4);
-  const PrimeField rt = PrimeField::Make(le, 4, /*is_mont=*/true);
+  const RuntimeField rt = RuntimeOfModulus(3329);
   ASSERT_TRUE(rt.native);
   EXPECT_EQ(rt.TwoAdicity(), 8);
 
@@ -149,15 +152,11 @@ TEST(RuntimeFieldTest, MlKemTwoAdicityBoundsTheTransformLength) {
   EXPECT_FALSE(rt.RootOfUnity(512, /*generator=*/0, root));  // length-256 nega
 }
 
-// ML-DSA's 8380417 is the other modulus driving this work, and unlike ML-KEM's
-// it has room to spare: 2-adicity 13 covers a length-256 negacyclic transform
-// (which needs a 512th root) with seven layers left over. No curated config
-// covers it either.
+// 8380417 has 2-adicity 13, which covers a length-256 negacyclic transform
+// (needing a 512th root) with seven layers to spare — the opposite end of the
+// range from 3329, and the reason ML-DSA transforms in one pass.
 TEST(RuntimeFieldTest, MlDsaSupportsTheFullTransformLength) {
-  unsigned char le[32] = {};
-  const uint32_t q = 8380417;
-  std::memcpy(le, &q, 4);
-  const PrimeField rt = PrimeField::Make(le, 4, /*is_mont=*/true);
+  const RuntimeField rt = RuntimeOfModulus(8380417);
   ASSERT_TRUE(rt.native);
   EXPECT_EQ(rt.TwoAdicity(), 13);
 
@@ -166,8 +165,11 @@ TEST(RuntimeFieldTest, MlDsaSupportsTheFullTransformLength) {
   EXPECT_TRUE(rt.RootOfUnity(8192, /*generator=*/0, root));
   EXPECT_FALSE(rt.RootOfUnity(16384, /*generator=*/0, root));
 
-  // The round trip the two motivating moduli have to survive.
-  for (uint64_t v : {1, 2, 1234, 8380416}) {
+  // encode -> mul -> decode against exact integer arithmetic, which is the
+  // round trip an uncurated modulus has to survive for a constant built through
+  // this path to mean anything.
+  constexpr uint64_t kQ = 8380417;
+  for (uint64_t v : {uint64_t{1}, uint64_t{2}, uint64_t{1234}, kQ - 1}) {
     unsigned char canon[4] = {}, stored[4], back[4], sq[4];
     const uint32_t v32 = static_cast<uint32_t>(v);
     std::memcpy(canon, &v32, 4);
@@ -176,7 +178,7 @@ TEST(RuntimeFieldTest, MlDsaSupportsTheFullTransformLength) {
     rt.Decode(sq, back);
     uint32_t got = 0;
     std::memcpy(&got, back, 4);
-    EXPECT_EQ(got, static_cast<uint32_t>((v * v) % q)) << "v=" << v;
+    EXPECT_EQ(got, static_cast<uint32_t>((v * v) % kQ)) << "v=" << v;
   }
 }
 
@@ -184,7 +186,7 @@ TEST(RuntimeFieldTest, MlDsaSupportsTheFullTransformLength) {
 // has to reject the ones that produce a plausible but non-primitive value —
 // they would silently corrupt every butterfly built on the result.
 TEST(RuntimeFieldTest, PinnedGeneratorThatIsNotPrimitiveIsRejected) {
-  const PrimeField rt = RuntimeOf<BabybearMont>();
+  const RuntimeField rt = RuntimeOf<BabybearMont>();
   unsigned char root[4];
   // 1^k == 1 for every k, so it "succeeds" at producing a value of order 1.
   EXPECT_FALSE(rt.RootOfUnity(1024, /*generator=*/1, root));
@@ -201,7 +203,7 @@ TEST(RuntimeFieldTest, PinnedGeneratorThatIsNotPrimitiveIsRejected) {
 // a curated config stores — any of the phi(n) primitive roots is as correct.
 // What must hold is the defining property.
 TEST(RuntimeFieldTest, SearchedRootHasExactlyOrderN) {
-  for (const PrimeField rt :
+  for (const RuntimeField rt :
        {RuntimeOf<BabybearMont>(), RuntimeOf<KoalabearMont>()}) {
     for (uint64_t n : {2, 4, 8, 256, 1024}) {
       unsigned char root[4], acc[4], one[4];
@@ -222,7 +224,7 @@ TEST(RuntimeFieldTest, SearchedRootHasExactlyOrderN) {
 // the same root every time, which is what a caller needing a *particular* root
 // uses instead of the search.
 TEST(RuntimeFieldTest, PinnedGeneratorIsDeterministic) {
-  const PrimeField rt = RuntimeOf<BabybearMont>();
+  const RuntimeField rt = RuntimeOf<BabybearMont>();
   unsigned char a[4], b[4];
   ASSERT_TRUE(rt.RootOfUnity(1024, /*generator=*/31, a));
   ASSERT_TRUE(rt.RootOfUnity(1024, /*generator=*/31, b));
@@ -236,6 +238,19 @@ TEST(RuntimeFieldTest, PinnedGeneratorIsDeterministic) {
   // pinned from below as well.
   rt.Pow(a, uint64_t{512}, acc);
   EXPECT_NE(0, std::memcmp(acc, one, 4));
+}
+
+// A width with no kernel has to be refused at construction rather than
+// half-initialized: Make copies the modulus into a fixed buffer, and a caller
+// serving a user-chosen field can pass any width at all.
+TEST(RuntimeFieldTest, UnsupportedWidthYieldsAnUnusableField) {
+  unsigned char le[RuntimeField::kMaxWidthBytes] = {};
+  le[0] = 7;
+  for (int width : {0, 1, 3, 12, 64, 1024}) {
+    const RuntimeField rt = RuntimeField::Make(le, width, /*is_mont=*/true);
+    EXPECT_FALSE(rt.native) << "width=" << width;
+    EXPECT_EQ(rt.width_bytes, 0) << "width=" << width;
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
Closes #170.

`fractalyze/xla#441` needs to build NTT twiddle tables for a field minted from a
modulus rather than curated — a host-side computation in the compiler. XLA has
no way to do it: every host-side field operation there binds a compile-time
class, and a parametric field has none by construction.

The arithmetic to do it already existed here. `_src/field_modarith.h`, added for
the NEP-42 parametric descriptor (#163), carries the modulus as a value and
reuses this repo's own Montgomery and modular-add/sub kernels — which is what
makes a runtime result byte-identical to the corresponding curated type by
construction rather than by testing. That property is what lets a consumer serve
an arbitrary modulus without any curated result moving.

## What was in the way

Packaging, not capability. The header was already free of numpy and the Python C
API, but it sat in `_src/` as a `src` of `_zk_dtypes_ext_cc`, whose deps carry
both — so depending on the arithmetic meant linking both.

It moves to `include/field/runtime_field.h` behind its own `cc_library`, and the
extension target depends on that instead of carrying the header. One
implementation, two consumers. Verified closure: 615 targets, none numpy or
Python.

Named for the field rather than for modular arithmetic because it also carries
the binary-tower multiply, which is a field operation and not a modular one.

## What was added

The four shipped operations map stored representatives to stored
representatives, which is all a ufunc loop needs. A constant needs more:

- **`One` / `Encode` / `Decode`** — the storage encoding, in and out. `R mod p`
  comes from `w` modular doublings of 1 rather than a separate reduction path,
  so it cannot disagree with the stored values; `Decode` is `MontMul(x, 1)`,
  which undoes the encoding without `R^-1` existing as a value.
- **`Pow`** — square-and-multiply over `Mul`, exponent as little-endian bytes
  (the exponent `(p-1)/2^k` does not fit a `uint64` for a 256-bit modulus).
- **`TwoAdicity` / `RootOfUnity`** — the transform's actual question.

## The one place equality does not hold, deliberately

`GetRootOfUnity<F>` squares down `Config::kTwoAdicRootOfUnity`, a constant each
family stores. A runtime modulus has no such constant, and any of the φ(n)
primitive n-th roots is equally valid — so a search finds *a* root, not *that*
root.

`RootOfUnity` therefore has two modes: pinning the generator gives
`g^((p-1)/n)`, reproducible and the form a caller needing a specific root uses;
passing `0` selects the smallest quadratic non-residue, deterministic but not
curated-equal. The tests assert the **defining property** (order exactly n) for
the searched root and assert equality only where equality is guaranteed.

This means one acceptance criterion as I originally wrote it on #170 —
"root-of-unity results byte-identical to the compile-time path" — is not
achievable by search and is not what the consumer needs. `xla#441` keeps the
templated path for curated families, so their results are unchanged by not
touching them; the runtime path only serves fields that have no curated path at
all.

## Verification

`//zk_dtypes:field_unittests` — 799 pass, 9 of them new. Byte-identity against
Babybear and Koalabear for `Mul`, `Pow`, and `Encode`; `Encode`/`Decode` round
trip; `One` is the identity; `TwoAdicity` matches each config.

ML-KEM's 3329 has a test of its own: 2-adicity 8, so a 256th root exists and a
512th does not — which is precisely why its transform is two length-128
negacyclic NTTs rather than one length-256.

`prime_field_factory_test`, `ec_point_test`, `extension_field_test`,
`binary_field_test` all green, confirming the descriptor is unaffected by the
move.

**Pre-existing failures, not from this change:** `GoldilocksX3Test.SquareMatchesPil2`
and `InverseMatchesPil2` fail on `main` too (verified by stashing this branch).

A release is needed before `xla#441` can pin it.
