### PR TITLE
chore: release 0.0.14

### DIFF
--- a/zk_dtypes/__init__.py
+++ b/zk_dtypes/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==============================================================================
 
-__version__ = "0.0.13"
+__version__ = "0.0.14"
 __all__ = [
     "__version__",
     "binary_field",


### PR DESCRIPTION
## Description

Bumps `zk_dtypes.__version__`, which `pyproject.toml` derives the distribution
version from (`version = { attr = "zk_dtypes.__version__" }`) and which the
release gate compares the tag against.

**Why a new number rather than re-cutting 0.0.13.** `v0.0.13` is tagged and its
literal already sits on `main`, and `main` has since moved past it — #171 landed
on top of the release commit. Publishing `main` as 0.0.13 would ship that under a
number whose notes do not mention it.

## Contents since 0.0.13

The runtime-modulus prime field, exposed as its own `cc_library` free of numpy
and the Python C API (#171). That is what lets a compiler build NTT twiddle
tables for a field minted from a modulus rather than a curated family — the
capability `fractalyze/xla#441` is blocked on.

## Consumers waiting on this reaching the index

PyPI currently serves 0.0.12; 0.0.13 never published. The parametric
`prime_field(p)` factory from #163 is in both, and consumers cannot pin it until
a release lands:

- `fractalyze/sig-frx` — ML-DSA over `q = 8380417` hand-writes its `Z_q`
  arithmetic in 16-bit limbs. Verified against a local build that the parametric
  field replaces all of it: `add`/`sub`/`mul` byte-match Python big integers
  under `jit`, and `.astype(np.uint32)` inside a traced function returns
  canonical values, which is what the FIPS 204 rounding functions need.
- `fractalyze/enc-frx` — ML-KEM over `q = 3329`, the same shape.

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline